### PR TITLE
fix: send session_verifier token on oauth flow

### DIFF
--- a/packages/neon-auth/src/core/adapter-core.ts
+++ b/packages/neon-auth/src/core/adapter-core.ts
@@ -67,7 +67,7 @@ export abstract class NeonAuthAdapterCore {
           const url = request.url;
           const method = deriveBetterAuthMethodFromUrl(url.toString());
           if (method) {
-            BETTER_AUTH_METHODS_HOOKS[method].onRequest();
+            BETTER_AUTH_METHODS_HOOKS[method].onRequest(request);
           }
 
           userOnRequest?.(request);

--- a/packages/neon-auth/src/core/constants.ts
+++ b/packages/neon-auth/src/core/constants.ts
@@ -15,3 +15,7 @@ export const CLOCK_SKEW_BUFFER_MS = 10_000;
 
 /** Default session expiry duration in milliseconds (1 hour) */
 export const DEFAULT_SESSION_EXPIRY_MS = 3_600_000;
+
+/** Name of the session verifier parameter in the URL, used for the OAUTH flow */
+export const NEON_AUTH_SESSION_VERIFIER_PARAM_NAME =
+  'neon_auth_session_verifier';


### PR DESCRIPTION
### Summary

Fixes OAuth authentication flow by forwarding the `session_verifier` token to the server during session retrieval.

### Problem

When completing an OAuth login, the callback redirects back to the application with a `neon_auth_session_verifier` parameter in the URL. This token was not being sent with the `getSession` request, causing OAuth session verification to fail.

### Solution

- Forward the `neon_auth_session_verifier` URL parameter to the `getSession` API call
- Clean up the parameter from the browser URL after successful authentication using `history.replaceState`

### Changes

- `better-auth-methods.ts`: Added logic to read and forward the session verifier param, plus cleanup on success
- `adapter-core.ts`: Pass request context to `onRequest` hooks
- `constants.ts`: Added `NEON_AUTH_SESSION_VERIFIER_PARAM_NAME` constant