### PR TITLE
feat: token exchange for oauth flow

### DIFF
--- a/packages/neon-auth-next/src/constants.ts
+++ b/packages/neon-auth-next/src/constants.ts
@@ -1,2 +1,8 @@
-export const NEXT_AUTH_COOKIE_PREFIX = '__Secure-neon-auth';
-export const NEXT_AUTH_SESION_COOKIE_NAME = `${NEXT_AUTH_COOKIE_PREFIX}.session_token`;
+export const NEON_AUTH_COOKIE_PREFIX = '__Secure-neon-auth';
+export const NEON_AUTH_SESION_COOKIE_NAME = `${NEON_AUTH_COOKIE_PREFIX}.session_token`;
+
+
+export const NEON_AUTH_SESSION_CHALLENGE_COOKIE_NAME = `${NEON_AUTH_COOKIE_PREFIX}.session_challange`;
+/** Name of the session verifier parameter in the URL, used for the OAUTH flow */
+export const NEON_AUTH_SESSION_VERIFIER_PARAM_NAME =
+  'neon_auth_session_verifier';

--- a/packages/neon-auth-next/src/handler/index.ts
+++ b/packages/neon-auth-next/src/handler/index.ts
@@ -2,7 +2,13 @@ import { handleAuthRequest } from "./request";
 import { handleAuthResponse } from "./response";
 
 type Params = { path: string[] }
+
 export const toNextJsHandler = (baseUrl: string) => {
+  const baseURL = baseUrl || process.env.NEON_AUTH_BASE_URL;
+  if (!baseURL) {
+    throw new Error('You must provider a Neon Auth base URL in the handler options or in the environment variables');
+  }
+
   const handler = async (request: Request, {params}: {params: Promise<Params>}) => {
     const resolvedParams = await params;
     const path = resolvedParams.path.join('/');

--- a/packages/neon-auth-next/src/handler/request.ts
+++ b/packages/neon-auth-next/src/handler/request.ts
@@ -1,4 +1,4 @@
-import { NEXT_AUTH_COOKIE_PREFIX } from "../constants";
+import { NEON_AUTH_COOKIE_PREFIX } from "../constants";
 
 const PROXY_HEADERS = ['user-agent', 'authorization', 'referer'];
 export const handleAuthRequest = async (baseUrl: string, request: Request, path: string) => {
@@ -32,7 +32,7 @@ const prepareRequestHeaders = (request: Request) => {
   }
   
   headers.set('Origin', getOrigin(request));
-  headers.set('Cookie', extractRequestCookies(request));
+  headers.set('Cookie', extractRequestCookies(request.headers));
   headers.set('X-Neon-Auth-Next', 'true');     // Add for observability purpose
   return headers;
 }
@@ -45,8 +45,8 @@ const getOrigin = (request: Request) => {
                    new URL(request.url).origin;
 }
 
-const extractRequestCookies = (request: Request) => {
-  const cookieHeader = request.headers.get('cookie');
+const extractRequestCookies = (headers: Headers) => {
+  const cookieHeader = headers.get('cookie');
   if (!cookieHeader) return '';
 
   const cookies = cookieHeader.split(';').map(c => c.trim());
@@ -54,7 +54,7 @@ const extractRequestCookies = (request: Request) => {
 
   for (const cookie of cookies) {
     const [name] = cookie.split('=');
-    if (name.startsWith(NEXT_AUTH_COOKIE_PREFIX)) {
+    if (name.startsWith(NEON_AUTH_COOKIE_PREFIX)) {
       result.push(cookie);
     }
   }

--- a/packages/neon-auth-next/src/handler/response.ts
+++ b/packages/neon-auth-next/src/handler/response.ts
@@ -22,3 +22,11 @@ const prepareResponseHeaders = (response: Response) => {
   }
   return headers;
 }
+
+export const extractResponseCookies = (headers: Headers) => {
+  const cookieHeader = headers.get('set-cookie');
+  if (!cookieHeader) return [];
+
+  const cookies = cookieHeader.split(', ').map(c => c.trim());
+  return cookies;
+}

--- a/packages/neon-auth-next/src/middleware/index.ts
+++ b/packages/neon-auth-next/src/middleware/index.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { NEXT_AUTH_SESION_COOKIE_NAME } from "../constants";
+import { NEON_AUTH_SESION_COOKIE_NAME } from "../constants";
+import { needsSessionVerification, verifySession } from "./oauth";
+
 
 const AUTH_API_ROUTES = '/api/auth';
 const SKIP_ROUTES = [
@@ -14,23 +16,52 @@ const SKIP_ROUTES = [
 ];
 
 type NeonAuthMiddlewareOptions = {
+  /*
+  *  The URL to redirect to when the user is not authenticated.
+  *  Defaults to `/auth/sign-in`
+  */
   loginUrl?: string;
+
+  /** 
+   * The Neon Auth base URL
+   *  Defaults to `process.env.NEON_AUTH_BASE_URL`
+   * 
+   * If not provided, and if not in the environment, the middleware will throw an error.
+   * 
+   * @throws {Error} If the authURL is not provided and not in the environment.
+  */
+  authBaseUrl?: string;
 }
 
-export const neonAuthMiddleware = ({ loginUrl = '/auth/sign-in' }: NeonAuthMiddlewareOptions = {}) => {
-
+export const neonAuthMiddleware = ({ loginUrl = '/auth/sign-in', authBaseUrl }: NeonAuthMiddlewareOptions) => {
+  const baseURL = authBaseUrl || process.env.NEON_AUTH_BASE_URL;
+  if (!baseURL) {
+    throw new Error('You must provider a Neon Auth base URL in the middleware options or in the environment variables');
+  }
+  
   return async (request: NextRequest) => {
     const { pathname } = request.nextUrl;
 
-    // Always skip session check for login URL
+    // Always skip session check for login URL to prevent infinite redirect loop
     if (pathname.startsWith(loginUrl)) {
       return NextResponse.next();
+    }
+
+    // For OAuth flow, the callback from Neon Auth will include a session verifier token in the query params.
+    // We need to exchange the verifier token and session challenge for the session cookie
+    const verification = needsSessionVerification(request);
+    if (verification) {
+      const response = await verifySession(request, baseURL);
+      // 
+      if (response !== null) {
+        return response;
+      }
     }
 
     if (SKIP_ROUTES.some(route => pathname.startsWith(route))) {
       return NextResponse.next();
     }
-    const token = request.cookies.get(NEXT_AUTH_SESION_COOKIE_NAME);
+    const token = request.cookies.get(NEON_AUTH_SESION_COOKIE_NAME);
     if (!token) {
       return NextResponse.redirect(new URL(loginUrl, request.url));
     }

--- a/packages/neon-auth-next/src/middleware/oauth.ts
+++ b/packages/neon-auth-next/src/middleware/oauth.ts
@@ -1,0 +1,56 @@
+import { NextResponse, type NextRequest } from "next/server"
+import { NEON_AUTH_SESION_COOKIE_NAME, NEON_AUTH_SESSION_CHALLENGE_COOKIE_NAME, NEON_AUTH_SESSION_VERIFIER_PARAM_NAME } from "../constants"
+import { handleAuthRequest } from "../handler/request";
+import { handleAuthResponse } from "../handler/response";
+
+export const needsSessionVerification = (request: NextRequest) => {
+  const url = request.nextUrl;
+  const hasVerifier = url.searchParams.has(NEON_AUTH_SESSION_VERIFIER_PARAM_NAME)
+  const hasChallenge = request.cookies.get(NEON_AUTH_SESSION_CHALLENGE_COOKIE_NAME)
+  const hasSession = request.cookies.get(NEON_AUTH_SESION_COOKIE_NAME)
+
+  return hasVerifier && hasChallenge && !hasSession;
+}
+
+export const verifySession = async (request: NextRequest, baseUrl: string) => {
+  const url = request.nextUrl;
+  const verifier = url.searchParams.get(NEON_AUTH_SESSION_VERIFIER_PARAM_NAME)
+  const challenge = request.cookies.get(NEON_AUTH_SESSION_CHALLENGE_COOKIE_NAME)
+
+  if (!verifier || !challenge) {
+    return null;
+  }
+
+  const response = await getSession(request, baseUrl);
+  if (response.ok) {
+    const headers = new Headers()
+    const cookies = extractResponseCookies(response.headers);
+    for (const cookie of cookies) {
+      headers.append('Set-Cookie', cookie);
+    }
+    
+    url.searchParams.delete(NEON_AUTH_SESSION_VERIFIER_PARAM_NAME);
+    return NextResponse.redirect(url, {
+      headers,
+    });
+  }
+  return null;
+}
+
+
+const getSession  = async (request: NextRequest, baseUrl: string) => {
+  const upstreamRequest = new Request(request.url, {
+    method: 'GET',
+    headers: request.headers,
+    body: null,
+  })
+  const response = await handleAuthRequest(baseUrl, upstreamRequest, 'get-session');
+  return handleAuthResponse(response);
+}
+
+const extractResponseCookies = (headers: Headers) => {
+  const cookieHeader = headers.get('set-cookie');
+  if (!cookieHeader) return [];
+
+  return cookieHeader.split(', ').map(c => c.trim());
+}


### PR DESCRIPTION
The oauth flow expects the token exchange to happen in the final callbackUrl redirect. However, with next middleware, we reject the request with missing session cookies and user is never logged in. 

This change exchanges the session verifier and session challenge cookie with neon auth server for session token. 