### PR TITLE
feat: verify session token and refresh if needed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
       "name": "@neondatabase/auth",
       "version": "0.1.0-beta.2",
       "dependencies": {
-        "@neondatabase/auth-ui": "workspace:*",
+        "@neondatabase/auth-ui": "file:../auth-ui",
         "@supabase/auth-js": "2.79.0",
         "better-auth": "1.4.6-beta.3",
         "jose": "6.1.2",
@@ -83,7 +83,7 @@
         "zod": "^4.1.12",
       },
       "devDependencies": {
-        "@neondatabase/auth": "workspace:*",
+        "@neondatabase/auth": "file:../auth",
         "@tailwindcss/cli": "^4.1.17",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -69,7 +69,7 @@
     "clean": "rm -rf node_modules dist"
   },
   "devDependencies": {
-    "@neondatabase/auth": "workspace:*",
+    "@neondatabase/auth": "file:../auth",
     "@tailwindcss/cli": "^4.1.17",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/packages/auth/NEXT-JS.md
+++ b/packages/auth/NEXT-JS.md
@@ -8,6 +8,11 @@
 npm install @neondatabase/auth
 ```
 
+### Set environment variables
+
+```properties
+NEON_AUTH_BASE_URL='https://endpoint-id.neonauth.aws.neon.tech/neondb/auth'
+```
 
 ### Create an Auth Handler 
 
@@ -15,13 +20,22 @@ To integrate Neon Auth with Next.js, we need to mount the auth handler to an API
 
 ```ts
 // api/auth/[...path]/route.ts
-import { toNextJsHandler } from "@neondatabase/auth/next"
+import { authApiHandler } from "@neondatabase/auth/next"
 
-export const { GET, POST } = toNextJsHandler(
-  process.env.NEON_AUTH_BASE_URL
-)
+export const { GET, POST } = authApiHandler()
 ```
 
+### Create a auth middleware
+
+Add a `neonAuthMiddleware()` to protect routes from unauthenticated users. In your `proxy.ts` (`middleware.ts` for Next.js <= 15) file, export the middleware
+
+```ts
+import { neonAuthMiddleware } from "@neondatabase/auth/next"
+
+export default neonAuthMiddleware({
+  loginUrl: "/auth/sign-in",
+})
+```
 
 ### Create a Client
 
@@ -156,6 +170,18 @@ If your project already uses Tailwind CSS v4, import the Tailwind-ready CSS to a
 This imports only the theme variables and component scanning directive. Your Tailwind build will generate the necessary utility classes, avoiding duplication with your existing Tailwind setup.
 
 
-### Server Actions
+### React Server Components
 
-TBD
+The `@neondatabse/auth/next` provides with api function `neonAuth()` to retrieve the session and user details on protected routes. 
+
+```ts
+import { neonAuth } from '@neondatabase/auth/next`;
+
+export async function Profile() {
+  const { user } = await neonAuth()
+
+  if (user == null) return null;
+  
+  return (<span>{user.name}</span>);
+}
+```

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -102,7 +102,7 @@
     "better-auth": "1.4.6-beta.3",
     "zod": "4.1.12",
     "jose": "6.1.2",
-    "@neondatabase/auth-ui": "workspace:*"
+    "@neondatabase/auth-ui": "file:../auth-ui"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/auth/src/next/auth/cookies.ts
+++ b/packages/auth/src/next/auth/cookies.ts
@@ -1,0 +1,82 @@
+import { parseCookies, parseSetCookieHeader } from "better-auth/cookies";
+import { NEON_AUTH_COOKIE_PREFIX } from "../constants";
+
+type RequestCookie = {
+  name: string;
+  value: string;
+}
+
+type ResponseCookie = {
+  name: string;
+  value: string,
+  maxAge?: number | undefined;
+	expires?: Date | undefined;
+	domain?: string | undefined;
+	path?: string | undefined;
+	secure?: boolean | undefined;
+	httpOnly?: boolean | undefined;
+  partitioned?: boolean | undefined;
+	sameSite?: ("strict" | "lax" | "none") | undefined;
+}
+
+/**
+ * Extract the Neon Auth cookies from the request headers that starts with the NEON_AUTH_COOKIE_PREFIX.
+ * 
+ * @param headers - The request headers.
+ * @returns The cookie string with all Neon Auth cookies.
+ */
+export function extractRequestCookies(headers: Headers): string {
+  const cookieHeader = headers.get('cookie');
+  if (!cookieHeader) return '';
+
+  const parsedCookies = parseCookies(cookieHeader)
+  const result: RequestCookie[] = [];
+  for (const [name, value] of parsedCookies.entries()) {
+    if (name.startsWith(NEON_AUTH_COOKIE_PREFIX)) {
+      result.push({name, value});
+    }
+  }
+  return result.map(cookie => cookie.name + '=' + cookie.value).join('; ');
+}
+
+
+/**
+ * Extract the Neon Auth cookies from the response headers that starts with the NEON_AUTH_COOKIE_PREFIX.
+ * 
+ * @param headers - The response headers.
+ * @returns The cookies that starts with the NEON_AUTH_COOKIE_PREFIX.
+ */
+export const extractResponseCookies = (headers: Headers) => {
+  const cookieHeader = headers.get('set-cookie');
+  if (!cookieHeader) return [];
+
+  const cookies = cookieHeader.split(', ').map(c => c.trim());
+  return cookies;
+}
+
+/**
+ * 
+ * Parses the `set-cookie` header from Neon Auth response into the list of ResponseCookies,
+ *  compatible with NextCookies.
+ * 
+ * @param cookies - The `set-cookie` header from Neon Auth response.
+ * @returns The list of ResponseCookies.
+ */
+export const parseSetCookies = (cookies: string) => {
+  const parsedCookies = parseSetCookieHeader(cookies)
+  const responseCookies: ResponseCookie[] = [];
+  for (const entry of parsedCookies.entries()) {
+    const [name, parsedCookie] = entry
+    responseCookies.push({
+      name,
+      value: decodeURIComponent(parsedCookie.value),
+      path: parsedCookie.path,
+      maxAge: parsedCookie['max-age'] ?? parsedCookie.maxAge,
+      httpOnly: parsedCookie.httponly ?? true,
+      secure: parsedCookie.secure ?? true, 
+      sameSite: parsedCookie.samesite ?? 'none',
+      partitioned: parsedCookie.partitioned
+    })
+  }
+  return responseCookies;
+}

--- a/packages/auth/src/next/auth/index.ts
+++ b/packages/auth/src/next/auth/index.ts
@@ -1,0 +1,2 @@
+export { neonAuth } from './session';
+

--- a/packages/auth/src/next/auth/session.ts
+++ b/packages/auth/src/next/auth/session.ts
@@ -1,0 +1,71 @@
+import { cookies, headers } from "next/headers";
+import type { BetterAuthSession as Session, BetterAuthUser as User } from "../../core/better-auth-types";
+import { getUpstreamURL } from "../handler/request";
+import { NEON_AUTH_BASE_URL } from "../env-variables";
+import { ERRORS } from "../errors";
+
+import { extractRequestCookies, parseSetCookies } from "./cookies";
+import { NEON_AUTH_HEADER_MIDDLEWARE_NAME } from "../constants";
+
+export type SessionData = {
+  session: Session;
+  user: User;
+} | {
+  session: null
+  user: null
+}
+
+/**
+ * A utility function to be used in react server components fetch the session details from the Neon Auth API, if session token is available in cookie. 
+ * 
+ * @returns - `{ session: Session, user: User }` | `{ session: null, user: null}`.
+ * 
+ * @example
+ * ```ts
+ * import { neonAuth } from "@neondatabase/auth/next"
+ * 
+ * const { session, user } = await neonAuth()
+ * ```
+ */
+export const neonAuth = async (): Promise<SessionData> => {
+  const reqHeaders = await headers()
+  if (!reqHeaders.has(NEON_AUTH_HEADER_MIDDLEWARE_NAME)) {
+    throw new Error(ERRORS.NEON_AUTH_MIDDLEWARE_NOT_FOUND);
+  }
+  return await fetchSession();
+}
+
+/**
+ * A utility function to fetch the session details from the Neon Auth API, if session token is available in cookie. 
+ * 
+ * @returns - `{ session: Session, user: User }` | `{ session: null, user: null}`.
+ */
+export const fetchSession = async (): Promise<SessionData> => {
+  const baseUrl = NEON_AUTH_BASE_URL!
+  const requestHeaders = await headers()
+  const upstreamURL = getUpstreamURL(baseUrl, 'get-session', { 
+    originalUrl: new URL('get-session', baseUrl)
+  });
+  
+  const response =  await fetch(upstreamURL.toString(), {
+    method: 'GET',
+    headers: {
+      Cookie: extractRequestCookies(requestHeaders),
+    },
+  })
+
+  const body = await response.json();
+  const cookieHeader = response.headers.get('set-cookie');
+  if (cookieHeader) {
+    const cookieStore = await cookies()
+    parseSetCookies(cookieHeader).map(cookie => {
+      cookieStore.set(cookie.name, cookie.value, cookie)
+    })
+  }
+  
+  if (!response.ok || body === null) {
+    return { session: null, user: null};
+  }
+  return { session: body.session, user: body.user }
+};
+  

--- a/packages/auth/src/next/constants.ts
+++ b/packages/auth/src/next/constants.ts
@@ -5,3 +5,5 @@ export const NEON_AUTH_SESSION_CHALLENGE_COOKIE_NAME = `${NEON_AUTH_COOKIE_PREFI
 /** Name of the session verifier parameter in the URL, used for the OAUTH flow */
 export const NEON_AUTH_SESSION_VERIFIER_PARAM_NAME =
   'neon_auth_session_verifier';
+
+export const NEON_AUTH_HEADER_MIDDLEWARE_NAME = 'X-Neon-Auth-Next-Middleware';

--- a/packages/auth/src/next/env-variables.ts
+++ b/packages/auth/src/next/env-variables.ts
@@ -1,0 +1,1 @@
+export const NEON_AUTH_BASE_URL = process.env.NEON_AUTH_BASE_URL;

--- a/packages/auth/src/next/errors.ts
+++ b/packages/auth/src/next/errors.ts
@@ -1,0 +1,4 @@
+export const ERRORS = {
+  MISSING_AUTH_BASE_URL: 'Missing environment variable: NEON_AUTH_BASE_URL. \n You must provide the auth url of your Neon Auth instance in environment variables',
+  NEON_AUTH_MIDDLEWARE_NOT_FOUND: 'You are calling `neonAuth` on a route that is not covered by `neonAuthMiddleware`. Make sure it is running on all paths you are calling `neonAuth` from by updating your middleware config in `(middleware|proxy).(js|ts)`.',
+}

--- a/packages/auth/src/next/handler/index.ts
+++ b/packages/auth/src/next/handler/index.ts
@@ -1,14 +1,32 @@
+import { ERRORS } from '../errors';
 import { handleAuthRequest } from './request';
 import { handleAuthResponse } from './response';
 
 type Params = { path: string[] };
 
-export const toNextJsHandler = (baseUrl: string) => {
-  const baseURL = baseUrl || process.env.NEON_AUTH_BASE_URL;
+/**
+ * 
+ * An API route handler to handle the auth requests from the client and proxy them to the Neon Auth.
+ * 
+ * @returns A Next.js API handler functions those can be used in a Next.js route.
+ *
+ * @example
+ * 
+ * Mount the `authApiHandler` to an API route. Create a route file inside `/api/auth/[...all]/route.ts` directory. 
+ *  And add the following code:
+ * 
+ * ```ts 
+ * 
+ * import { authApiHandler } from '@neondatabase/auth/next';
+ * 
+ * export const { GET, POST } = authApiHandler();
+ * ```
+ * 
+ */
+export function authApiHandler() {
+  const baseURL = process.env.NEON_AUTH_BASE_URL;
   if (!baseURL) {
-    throw new Error(
-      'You must provide a Neon Auth base URL in the handler options or in the environment variables'
-    );
+    throw new Error(ERRORS.MISSING_AUTH_BASE_URL);
   }
 
   const handler = async (

--- a/packages/auth/src/next/handler/response.ts
+++ b/packages/auth/src/next/handler/response.ts
@@ -1,5 +1,4 @@
-// This is allowlist of headers that we want to proxy to the client
-// We can proxy all headers, but its safer to only proxy the headers we need
+// Allowlist of response headers that we want to proxy to the client from Neon Auth.
 const RESPONSE_HEADERS_ALLOWLIST = ['content-type', 'content-length', 'content-encoding', 'transfer-encoding',
     'connection', 'date',
    'set-cookie', 'set-auth-jwt', 'set-auth-token', 'x-neon-ret-request-id'];
@@ -21,12 +20,4 @@ const prepareResponseHeaders = (response: Response) => {
     }
   }
   return headers;
-}
-
-export const extractResponseCookies = (headers: Headers) => {
-  const cookieHeader = headers.get('set-cookie');
-  if (!cookieHeader) return [];
-
-  const cookies = cookieHeader.split(', ').map(c => c.trim());
-  return cookies;
 }

--- a/packages/auth/src/next/index.ts
+++ b/packages/auth/src/next/index.ts
@@ -1,9 +1,10 @@
 import { BetterAuthReactAdapter } from '../adapters/better-auth-react/better-auth-react-adapter';
 import { createAuthClient as createNeonAuthClient } from '../neon-auth';
-export { toNextJsHandler } from './handler';
+export { authApiHandler } from './handler';
 export { neonAuthMiddleware } from './middleware';
+export { neonAuth } from './auth';
 
-export const createAuthClient = () => {
+export function createAuthClient()  {
   // @ts-expect-error - for nextjs proxy we do not need the baseUrl
   return createNeonAuthClient(undefined, {
     adapter: BetterAuthReactAdapter(),


### PR DESCRIPTION

- [x] Verify `session_token` from cookie is valid and refresh if not freshly issued in `neonAuthMiddleware`
- [x] Directly read `authUrl` from environments variables in both middleware and api handler
- [x] Rename `toNextJsHandler` to `authApiHandler`, read authUrl from environments
- [x] `neonAuth()` function to retrieve session & user details. Utilize Next.js's `fetch` function cache