### PR TITLE
chore: add missing BetterAuth types with additional properties for session and user

### DIFF
--- a/packages/auth/src/core/better-auth-types.ts
+++ b/packages/auth/src/core/better-auth-types.ts
@@ -1,6 +1,16 @@
 import type { BetterFetchError } from '@better-fetch/fetch';
 import type { Session, User } from 'better-auth/types';
 
-export type BetterAuthSession = Session;
-export type BetterAuthUser = User;
+export type BetterAuthSession = Session & {
+  impersonatedBy?: string | null;
+  activeOrganizationId?: string | null;
+};
+
+export type BetterAuthUser = User & {
+  role?: string | null;
+  banned?: boolean | null;
+  banReason?: string | null;
+  banExpires?: Date | null;
+};
+
 export type BetterAuthErrorResponse = BetterFetchError;


### PR DESCRIPTION
Currently, the `neon_auth.user` database schema, and the object returned by `/get-session` api have more fields than the type we defined in `packages/auth/src/core/better-auth-types.ts`