### PR TITLE
misc: add neon-auth magic link example app

### DIFF
--- a/examples/neon-auth-magic-link-example/.env.example
+++ b/examples/neon-auth-magic-link-example/.env.example
@@ -1,0 +1,6 @@
+NEON_AUTH_BASE_URL=https://ep-xxx.neonauth.us-east-1.aws.neon.tech/neondb/auth
+DATABASE_URL=
+
+# Generate a random secret with: openssl rand -base64 32
+# Must be at least 32 characters for HMAC-SHA256 security
+NEON_AUTH_COOKIE_SECRET=REPLACE_WITH_RANDOM_SECRET_AT_LEAST_32_CHARS

--- a/examples/neon-auth-magic-link-example/.gitignore
+++ b/examples/neon-auth-magic-link-example/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/examples/neon-auth-magic-link-example/.gitignore
+++ b/examples/neon-auth-magic-link-example/.gitignore
@@ -1,0 +1,41 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+.history
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+!.env.example
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/examples/neon-auth-magic-link-example/README.md
+++ b/examples/neon-auth-magic-link-example/README.md
@@ -1,0 +1,49 @@
+# Neon Auth - Magic Link Example
+
+Minimal passwordless authentication using email OTP (magic link) with [Neon Auth](https://neon.tech/docs/guides/neon-auth).
+
+No passwords, no social providers, no organizations — just enter your email and get a one-time code.
+
+## Setup
+
+1. Install dependencies from the monorepo root:
+
+```bash
+bun install
+```
+
+2. Build workspace packages:
+
+```bash
+bun run build
+```
+
+3. Copy `.env.example` to `.env.local` and fill in your values:
+
+```bash
+cp .env.example .env.local
+```
+
+| Variable | Where to find it |
+|----------|-----------------|
+| `DATABASE_URL` | Neon Console > Connection Details |
+| `NEON_AUTH_BASE_URL` | Neon Console > Project > Auth > Configuration |
+| `NEON_AUTH_COOKIE_SECRET` | Generate with `openssl rand -base64 32` |
+
+4. Run the app:
+
+```bash
+cd examples/neon-auth-magic-link-example
+bun run dev
+```
+
+5. Open [http://localhost:3000](http://localhost:3000) and click "Sign in with Magic Link".
+
+## How it works
+
+- **Landing page** (`/`) — single button to sign in
+- **Auth pages** (`/auth/*`) — handled by `@neondatabase/auth` UI components with `emailOTP` enabled
+- **Dashboard** (`/dashboard`) — shows your email and session info after sign-in
+- **API route** (`/api/auth/*`) — proxies auth requests to Neon Auth
+
+The `emailOTP` prop on `NeonAuthUIProvider` enables passwordless email authentication. Users enter their email, receive a one-time code, and are signed in without ever setting a password.

--- a/examples/neon-auth-magic-link-example/README.md
+++ b/examples/neon-auth-magic-link-example/README.md
@@ -47,3 +47,32 @@ bun run dev
 - **API route** (`/api/auth/*`) — proxies auth requests to Neon Auth
 
 The `emailOTP` prop on `NeonAuthUIProvider` enables passwordless email authentication. Users enter their email, receive a one-time code, and are signed in without ever setting a password.
+
+## Webhooks
+
+This example includes a webhook handler that receives events from Neon Auth and displays them in a live log.
+
+### Endpoint
+
+The app exposes `POST /api/webhooks/neon-auth` which receives webhook events from your Neon Auth instance. In local dev mode (when `NEON_AUTH_WEBHOOK_SECRET` is unset or `whsec_local_dev_secret`), signature verification is skipped.
+
+### Configuring webhooks
+
+In the Neon Console, go to **Project > Auth > Plugins** and add a webhook with:
+
+- **URL**: Your app's webhook endpoint (see below for local dev)
+- **Events**: `send.magic_link`, `user.created`, `user.before_create`, `user.updated`, `user.deleted`, `session.created`
+
+### Local dev with Tilt
+
+When running neon-auth in Docker via Tilt, use `host.docker.internal` so the container can reach your host machine:
+
+```
+https://host.docker.internal:<port>/api/webhooks/neon-auth
+```
+
+Replace `<port>` with the port your dev server is running on (e.g. `3000` or `3003`).
+
+### Viewing events
+
+Open [/webhooks](/webhooks) in your browser to see received webhook events in real time. The page polls every 2.5 seconds and displays events with expandable JSON payloads.

--- a/examples/neon-auth-magic-link-example/app/api/auth/[...path]/route.ts
+++ b/examples/neon-auth-magic-link-example/app/api/auth/[...path]/route.ts
@@ -1,0 +1,3 @@
+import { auth } from '@/lib/auth/server';
+
+export const { GET, POST } = auth.handler();

--- a/examples/neon-auth-magic-link-example/app/api/webhooks/events/route.ts
+++ b/examples/neon-auth-magic-link-example/app/api/webhooks/events/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { getEvents, clearEvents } from '@/lib/webhook-store';
+
+export async function GET() {
+  return NextResponse.json({ events: getEvents() });
+}
+
+export async function DELETE() {
+  clearEvents();
+  return NextResponse.json({ cleared: true });
+}

--- a/examples/neon-auth-magic-link-example/app/api/webhooks/neon-auth/route.ts
+++ b/examples/neon-auth-magic-link-example/app/api/webhooks/neon-auth/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { addEvent } from '@/lib/webhook-store';
+import { createRemoteJWKSet, compactVerify } from 'jose';
+
+/**
+ * Neon Auth signs webhooks with EdDSA (Ed25519) using detached JWS.
+ *
+ * Headers sent by neon-auth:
+ *   X-Neon-Signature:       detached JWS (header..signature, no payload)
+ *   X-Neon-Signature-Kid:   key ID
+ *   X-Neon-Timestamp:       unix timestamp in milliseconds
+ *
+ * The signed payload is: `${timestamp}.${base64url(rawBody)}`
+ * The public keys are at `/.well-known/jwks.json` on the auth server.
+ */
+
+// Cache the JWKS fetcher per auth base URL
+const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function getJWKS(authBaseUrl: string) {
+  let jwks = jwksCache.get(authBaseUrl);
+  if (!jwks) {
+    // The JWKS endpoint is at the auth server root, not under /auth
+    const baseWithoutAuth = authBaseUrl.replace(/\/auth\/?$/, '');
+    const jwksUrl = new URL('/.well-known/jwks.json', baseWithoutAuth);
+    jwks = createRemoteJWKSet(jwksUrl);
+    jwksCache.set(authBaseUrl, jwks);
+  }
+  return jwks;
+}
+
+/**
+ * Maximum allowed age of a webhook timestamp (5 minutes).
+ * Prevents replay attacks with old signatures.
+ */
+const MAX_TIMESTAMP_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * Verify the detached JWS webhook signature from neon-auth.
+ */
+async function verifyJWSSignature(
+  rawBody: string,
+  detachedSignature: string,
+  timestamp: string,
+  authBaseUrl: string,
+): Promise<boolean> {
+  try {
+    const ts = parseInt(timestamp, 10);
+    if (isNaN(ts) || Math.abs(Date.now() - ts) > MAX_TIMESTAMP_AGE_MS) {
+      console.error('[webhook] Timestamp too old or invalid:', timestamp);
+      return false;
+    }
+
+    const payloadB64 = Buffer.from(rawBody, 'utf8').toString('base64url');
+    const signaturePayload = `${timestamp}.${payloadB64}`;
+
+    const [header, , sig] = detachedSignature.split('.');
+    const signaturePayloadB64 = Buffer.from(signaturePayload, 'utf8').toString('base64url');
+    const fullJWS = `${header}.${signaturePayloadB64}.${sig}`;
+
+    const jwks = getJWKS(authBaseUrl);
+    await compactVerify(fullJWS, jwks);
+
+    return true;
+  } catch (error) {
+    console.error('[webhook] JWS verification failed:', error instanceof Error ? error.message : error);
+    return false;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+
+  const signature = request.headers.get('x-neon-signature');
+  const timestamp = request.headers.get('x-neon-timestamp');
+  const authBaseUrl = process.env.NEON_AUTH_BASE_URL;
+  const webhookSecret = process.env.NEON_AUTH_WEBHOOK_SECRET;
+
+  // In local dev with the known dev secret, skip verification
+  const isLocalDev = !webhookSecret || webhookSecret === 'whsec_local_dev_secret';
+
+  if (!isLocalDev) {
+    if (!signature || !timestamp || !authBaseUrl) {
+      console.error('[webhook] Missing required headers or NEON_AUTH_BASE_URL');
+      return NextResponse.json({ error: 'Missing signature headers' }, { status: 401 });
+    }
+
+    const valid = await verifyJWSSignature(rawBody, signature, timestamp, authBaseUrl);
+    if (!valid) {
+      console.error('[webhook] Invalid JWS signature');
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+    }
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const eventType = (payload.event_type as string) || 'unknown';
+
+  console.log(`[webhook] Received event: ${eventType}`);
+  console.log(`[webhook] Payload:`, JSON.stringify(payload, null, 2));
+
+  addEvent(eventType, payload);
+
+  // "before" hooks require an explicit { allowed: true } response to proceed
+  if (eventType.includes('.before_')) {
+    return NextResponse.json({ allowed: true });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/examples/neon-auth-magic-link-example/app/auth/[path]/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/auth/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { AuthView } from '@neondatabase/auth/react/ui';
-import { authViewPaths } from '@neondatabase/auth/react/ui/server';
+import { MagicLinkForm } from "@/components/magic-link-form";
+import { authViewPaths } from "@neondatabase/auth/react/ui/server";
 
 export const dynamicParams = false;
 
@@ -12,11 +12,11 @@ export default async function AuthPage({
 }: {
   params: Promise<{ path: string }>;
 }) {
-  const { path } = await params;
+  await params;
 
   return (
-    <main className="flex min-h-screen items-center justify-center p-4">
-      <AuthView path={path} />
+    <main className="flex min-h-screen items-center justify-center bg-background p-4">
+      <MagicLinkForm />
     </main>
   );
 }

--- a/examples/neon-auth-magic-link-example/app/auth/[path]/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/auth/[path]/page.tsx
@@ -1,0 +1,22 @@
+import { AuthView } from '@neondatabase/auth/react/ui';
+import { authViewPaths } from '@neondatabase/auth/react/ui/server';
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return Object.values(authViewPaths).map((path) => ({ path }));
+}
+
+export default async function AuthPage({
+  params,
+}: {
+  params: Promise<{ path: string }>;
+}) {
+  const { path } = await params;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-4">
+      <AuthView path={path} />
+    </main>
+  );
+}

--- a/examples/neon-auth-magic-link-example/app/dashboard/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/dashboard/page.tsx
@@ -1,0 +1,113 @@
+"use client"
+
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+
+import { authClient } from "@/lib/auth/client"
+
+export default function DashboardPage() {
+    const { data: session, isPending } = authClient.useSession()
+    const router = useRouter()
+
+    useEffect(() => {
+        if (!isPending && !session) {
+            router.push("/auth/sign-in")
+        }
+    }, [session, isPending, router])
+
+    if (isPending) {
+        return (
+            <div className="flex min-h-screen items-center justify-center">
+                <div className="flex flex-col items-center gap-2">
+                    <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-foreground" />
+                    <p className="text-sm text-muted-foreground">Loading...</p>
+                </div>
+            </div>
+        )
+    }
+
+    if (!session) {
+        return null
+    }
+
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-secondary">
+            <div className="w-full max-w-md px-6">
+                <div className="rounded-xl border bg-card p-8 shadow-sm">
+                    <div className="mb-6 flex items-center gap-3">
+                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-lg font-bold text-primary">
+                            {(session.user.name?.[0] || session.user.email?.[0] || "?").toUpperCase()}
+                        </div>
+                        <div>
+                            <h1 className="text-xl font-bold text-foreground">
+                                Welcome!
+                            </h1>
+                            <p className="text-sm text-muted-foreground">
+                                You&apos;re signed in
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="space-y-4">
+                        <div className="rounded-lg bg-muted/50 p-4">
+                            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                Email
+                            </p>
+                            <p className="mt-1 font-medium text-foreground">
+                                {session.user.email}
+                            </p>
+                        </div>
+
+                        {session.user.name && (
+                            <div className="rounded-lg bg-muted/50 p-4">
+                                <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                    Name
+                                </p>
+                                <p className="mt-1 font-medium text-foreground">
+                                    {session.user.name}
+                                </p>
+                            </div>
+                        )}
+
+                        <div className="rounded-lg bg-muted/50 p-4">
+                            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                User ID
+                            </p>
+                            <p className="mt-1 font-mono text-sm text-muted-foreground">
+                                {session.user.id}
+                            </p>
+                        </div>
+
+                        <div className="rounded-lg bg-muted/50 p-4">
+                            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                Session expires
+                            </p>
+                            <p className="mt-1 text-sm text-foreground">
+                                {new Date(session.session.expiresAt).toLocaleString()}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex flex-col gap-3">
+                        <button
+                            onClick={async () => {
+                                await authClient.signOut()
+                                router.push("/")
+                            }}
+                            className="flex h-10 w-full items-center justify-center rounded-lg border border-input bg-background text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                        >
+                            Sign Out
+                        </button>
+                        <Link
+                            href="/"
+                            className="text-center text-sm text-muted-foreground transition-colors hover:text-foreground"
+                        >
+                            Back to home
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/examples/neon-auth-magic-link-example/app/dashboard/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/dashboard/page.tsx
@@ -2,13 +2,18 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 
 import { authClient } from "@/lib/auth/client"
 
 export default function DashboardPage() {
     const { data: session, isPending } = authClient.useSession()
     const router = useRouter()
+    const [mounted, setMounted] = useState(false)
+
+    useEffect(() => {
+        setMounted(true)
+    }, [])
 
     useEffect(() => {
         if (!isPending && !session) {
@@ -32,7 +37,7 @@ export default function DashboardPage() {
     }
 
     return (
-        <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-secondary">
+        <div className="flex min-h-screen items-center justify-center bg-background">
             <div className="w-full max-w-md px-6">
                 <div className="rounded-xl border bg-card p-8 shadow-sm">
                     <div className="mb-6 flex items-center gap-3">
@@ -84,7 +89,7 @@ export default function DashboardPage() {
                                 Session expires
                             </p>
                             <p className="mt-1 text-sm text-foreground">
-                                {new Date(session.session.expiresAt).toLocaleString()}
+                                {mounted ? new Date(session.session.expiresAt).toLocaleString() : "\u00A0"}
                             </p>
                         </div>
                     </div>
@@ -95,7 +100,7 @@ export default function DashboardPage() {
                                 await authClient.signOut()
                                 router.push("/")
                             }}
-                            className="flex h-10 w-full items-center justify-center rounded-lg border border-input bg-background text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                            className="flex h-10 w-full items-center justify-center rounded-lg border border-border bg-card text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
                         >
                             Sign Out
                         </button>

--- a/examples/neon-auth-magic-link-example/app/globals.css
+++ b/examples/neon-auth-magic-link-example/app/globals.css
@@ -1,0 +1,84 @@
+@import 'tailwindcss';
+@import '@neondatabase/auth/ui/tailwind';
+@import 'tw-animate-css';
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+:root {
+  --radius: 0.5rem;
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(222.2 84% 4.9%);
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(222.2 84% 4.9%);
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(222.2 84% 4.9%);
+  --primary: hsl(221.2 83.2% 53.3%);
+  --primary-foreground: hsl(210 40% 98%);
+  --secondary: hsl(210 40% 96.1%);
+  --secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --muted: hsl(210 40% 96.1%);
+  --muted-foreground: hsl(215.4 16.3% 46.9%);
+  --accent: hsl(210 40% 96.1%);
+  --accent-foreground: hsl(222.2 47.4% 11.2%);
+  --destructive: hsl(0 84.2% 60.2%);
+  --border: hsl(214.3 31.8% 91.4%);
+  --input: hsl(214.3 31.8% 91.4%);
+  --ring: hsl(221.2 83.2% 53.3%);
+}
+
+.dark {
+  --background: hsl(222.2 84% 4.9%);
+  --foreground: hsl(210 40% 98%);
+  --card: hsl(222.2 84% 4.9%);
+  --card-foreground: hsl(210 40% 98%);
+  --popover: hsl(222.2 84% 4.9%);
+  --popover-foreground: hsl(210 40% 98%);
+  --primary: hsl(217.2 91.2% 59.8%);
+  --primary-foreground: hsl(222.2 47.4% 11.2%);
+  --secondary: hsl(217.2 32.6% 17.5%);
+  --secondary-foreground: hsl(210 40% 98%);
+  --muted: hsl(217.2 32.6% 17.5%);
+  --muted-foreground: hsl(215 20.2% 65.1%);
+  --accent: hsl(217.2 32.6% 17.5%);
+  --accent-foreground: hsl(210 40% 98%);
+  --destructive: hsl(0 62.8% 30.6%);
+  --border: hsl(217.2 32.6% 17.5%);
+  --input: hsl(217.2 32.6% 17.5%);
+  --ring: hsl(224.3 76.3% 48%);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/examples/neon-auth-magic-link-example/app/globals.css
+++ b/examples/neon-auth-magic-link-example/app/globals.css
@@ -33,45 +33,47 @@
 
 :root {
   --radius: 0.5rem;
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(222.2 84% 4.9%);
-  --card: hsl(0 0% 100%);
-  --card-foreground: hsl(222.2 84% 4.9%);
-  --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(222.2 84% 4.9%);
-  --primary: hsl(221.2 83.2% 53.3%);
-  --primary-foreground: hsl(210 40% 98%);
-  --secondary: hsl(210 40% 96.1%);
-  --secondary-foreground: hsl(222.2 47.4% 11.2%);
-  --muted: hsl(210 40% 96.1%);
-  --muted-foreground: hsl(215.4 16.3% 46.9%);
-  --accent: hsl(210 40% 96.1%);
-  --accent-foreground: hsl(222.2 47.4% 11.2%);
-  --destructive: hsl(0 84.2% 60.2%);
-  --border: hsl(214.3 31.8% 91.4%);
-  --input: hsl(214.3 31.8% 91.4%);
-  --ring: hsl(221.2 83.2% 53.3%);
+  /* Neon brand: dark theme by default */
+  --background: hsl(240 10% 4%);
+  --foreground: hsl(0 0% 95%);
+  --card: hsl(240 6% 8%);
+  --card-foreground: hsl(0 0% 95%);
+  --popover: hsl(240 6% 8%);
+  --popover-foreground: hsl(0 0% 95%);
+  /* Neon Green #00E599 ≈ hsl(156 100% 45%) */
+  --primary: hsl(156 100% 45%);
+  --primary-foreground: hsl(240 10% 4%);
+  --secondary: hsl(240 4% 14%);
+  --secondary-foreground: hsl(0 0% 95%);
+  --muted: hsl(240 4% 14%);
+  --muted-foreground: hsl(240 5% 55%);
+  --accent: hsl(240 4% 14%);
+  --accent-foreground: hsl(0 0% 95%);
+  --destructive: hsl(0 62.8% 30.6%);
+  --border: hsl(240 4% 16%);
+  --input: hsl(240 4% 16%);
+  --ring: hsl(156 100% 45%);
 }
 
 .dark {
-  --background: hsl(222.2 84% 4.9%);
-  --foreground: hsl(210 40% 98%);
-  --card: hsl(222.2 84% 4.9%);
-  --card-foreground: hsl(210 40% 98%);
-  --popover: hsl(222.2 84% 4.9%);
-  --popover-foreground: hsl(210 40% 98%);
-  --primary: hsl(217.2 91.2% 59.8%);
-  --primary-foreground: hsl(222.2 47.4% 11.2%);
-  --secondary: hsl(217.2 32.6% 17.5%);
-  --secondary-foreground: hsl(210 40% 98%);
-  --muted: hsl(217.2 32.6% 17.5%);
-  --muted-foreground: hsl(215 20.2% 65.1%);
-  --accent: hsl(217.2 32.6% 17.5%);
-  --accent-foreground: hsl(210 40% 98%);
+  --background: hsl(240 10% 4%);
+  --foreground: hsl(0 0% 95%);
+  --card: hsl(240 6% 8%);
+  --card-foreground: hsl(0 0% 95%);
+  --popover: hsl(240 6% 8%);
+  --popover-foreground: hsl(0 0% 95%);
+  --primary: hsl(156 100% 45%);
+  --primary-foreground: hsl(240 10% 4%);
+  --secondary: hsl(240 4% 14%);
+  --secondary-foreground: hsl(0 0% 95%);
+  --muted: hsl(240 4% 14%);
+  --muted-foreground: hsl(240 5% 55%);
+  --accent: hsl(240 4% 14%);
+  --accent-foreground: hsl(0 0% 95%);
   --destructive: hsl(0 62.8% 30.6%);
-  --border: hsl(217.2 32.6% 17.5%);
-  --input: hsl(217.2 32.6% 17.5%);
-  --ring: hsl(224.3 76.3% 48%);
+  --border: hsl(240 4% 16%);
+  --input: hsl(240 4% 16%);
+  --ring: hsl(156 100% 45%);
 }
 
 @layer base {

--- a/examples/neon-auth-magic-link-example/app/layout.tsx
+++ b/examples/neon-auth-magic-link-example/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/examples/neon-auth-magic-link-example/app/layout.tsx
+++ b/examples/neon-auth-magic-link-example/app/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { Providers } from "./providers"
+
+import { Geist, Geist_Mono } from "next/font/google";
+import "./globals.css";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "Neon Auth - Magic Link Example",
+  description: "Minimal magic link (email OTP) authentication with Neon Auth",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
+        <Providers>
+          {children}
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/examples/neon-auth-magic-link-example/app/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-secondary font-sans">
+      <main className="flex w-full max-w-md flex-col items-center justify-center gap-8 px-6 py-20">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10">
+            <svg
+              className="h-8 w-8 text-primary"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+              />
+            </svg>
+          </div>
+          <h1 className="text-4xl font-bold tracking-tight text-foreground">
+            Magic Link Auth
+          </h1>
+          <p className="max-w-sm text-base leading-relaxed text-muted-foreground">
+            Passwordless authentication with email OTP, powered by{" "}
+            <a
+              href="https://neon.tech/docs/guides/neon-auth"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-foreground underline decoration-muted-foreground transition-colors hover:decoration-foreground"
+            >
+              Neon Auth
+            </a>
+            . Enter your email, get a code, sign in.
+          </p>
+        </div>
+
+        <Link
+          href="/auth/sign-in"
+          className="flex h-12 w-full items-center justify-center rounded-lg bg-primary px-8 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          Sign in with Magic Link
+        </Link>
+
+        <p className="text-center text-sm text-muted-foreground">
+          No password needed. We&apos;ll send a one-time code to your email.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/examples/neon-auth-magic-link-example/app/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-background to-secondary font-sans">
+    <div className="flex min-h-screen items-center justify-center bg-background font-sans">
       <main className="flex w-full max-w-md flex-col items-center justify-center gap-8 px-6 py-20">
         <div className="flex flex-col items-center gap-4 text-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10">
@@ -29,20 +29,36 @@ export default function Home() {
               href="https://neon.tech/docs/guides/neon-auth"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-semibold text-foreground underline decoration-muted-foreground transition-colors hover:decoration-foreground"
+              className="font-semibold text-primary transition-colors hover:text-primary/80"
             >
               Neon Auth
             </a>
-            . Enter your email, get a code, sign in.
+            . Enter your email, get a code, and you&apos;re in.
           </p>
         </div>
 
-        <Link
-          href="/auth/sign-in"
-          className="flex h-12 w-full items-center justify-center rounded-lg bg-primary px-8 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          Sign in with Magic Link
-        </Link>
+        <div className="flex w-full flex-col gap-3">
+          <Link
+            href="/auth/sign-up"
+            className="flex h-12 w-full items-center justify-center rounded-lg bg-primary px-8 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Sign Up
+          </Link>
+
+          <Link
+            href="/auth/sign-in"
+            className="flex h-12 w-full items-center justify-center rounded-lg border border-border bg-card px-8 text-base font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Sign In
+          </Link>
+
+          <Link
+            href="/webhooks"
+            className="flex h-12 w-full items-center justify-center rounded-lg border border-border bg-card px-8 text-base font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            Webhooks
+          </Link>
+        </div>
 
         <p className="text-center text-sm text-muted-foreground">
           No password needed. We&apos;ll send a one-time code to your email.

--- a/examples/neon-auth-magic-link-example/app/providers.tsx
+++ b/examples/neon-auth-magic-link-example/app/providers.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { NeonAuthUIProvider } from "@neondatabase/auth/react/ui"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import type { ReactNode } from "react"
+
+import { authClient } from "@/lib/auth/client"
+
+export function Providers({ children }: { children: ReactNode }) {
+    const router = useRouter()
+
+    return (
+        <NeonAuthUIProvider
+            authClient={authClient}
+            navigate={router.push}
+            replace={router.replace}
+            onSessionChange={() => {
+                router.refresh()
+            }}
+            emailOTP
+            redirectTo="/dashboard"
+            Link={Link}
+        >
+            {children}
+        </NeonAuthUIProvider>
+    )
+}

--- a/examples/neon-auth-magic-link-example/app/providers.tsx
+++ b/examples/neon-auth-magic-link-example/app/providers.tsx
@@ -1,28 +1,7 @@
 "use client"
 
-import { NeonAuthUIProvider } from "@neondatabase/auth/react/ui"
-import Link from "next/link"
-import { useRouter } from "next/navigation"
 import type { ReactNode } from "react"
 
-import { authClient } from "@/lib/auth/client"
-
 export function Providers({ children }: { children: ReactNode }) {
-    const router = useRouter()
-
-    return (
-        <NeonAuthUIProvider
-            authClient={authClient}
-            navigate={router.push}
-            replace={router.replace}
-            onSessionChange={() => {
-                router.refresh()
-            }}
-            emailOTP
-            redirectTo="/dashboard"
-            Link={Link}
-        >
-            {children}
-        </NeonAuthUIProvider>
-    )
+    return <>{children}</>
 }

--- a/examples/neon-auth-magic-link-example/app/webhooks/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/webhooks/page.tsx
@@ -1,0 +1,226 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import Link from "next/link"
+
+interface WebhookEvent {
+  id: string
+  type: string
+  timestamp: string
+  payload: Record<string, unknown>
+}
+
+const EVENT_TYPE_COLORS: Record<string, string> = {
+  "magic-link": "bg-primary/15 text-primary",
+  "magic-link.sent": "bg-primary/15 text-primary",
+  "send.magic_link": "bg-primary/15 text-primary",
+  "otp": "bg-primary/15 text-primary",
+  "otp.sent": "bg-primary/15 text-primary",
+  "email-otp": "bg-primary/15 text-primary",
+  "user.created": "bg-emerald-900/40 text-emerald-400",
+  "user.before_create": "bg-emerald-900/40 text-emerald-400",
+  "user.updated": "bg-yellow-900/40 text-yellow-400",
+  "user.deleted": "bg-red-900/40 text-red-400",
+  "session.created": "bg-purple-900/40 text-purple-400",
+}
+
+function getEventColor(type: string): string {
+  if (EVENT_TYPE_COLORS[type]) return EVENT_TYPE_COLORS[type]
+  const prefix = Object.keys(EVENT_TYPE_COLORS).find(k => type.startsWith(k))
+  if (prefix) return EVENT_TYPE_COLORS[prefix]
+  return "bg-secondary text-secondary-foreground"
+}
+
+export default function WebhooksPage() {
+  const [events, setEvents] = useState<WebhookEvent[]>([])
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [newEventIds, setNewEventIds] = useState<Set<string>>(new Set())
+  const [lastFetchCount, setLastFetchCount] = useState(0)
+  const [origin, setOrigin] = useState("")
+
+  useEffect(() => {
+    setOrigin(window.location.origin)
+  }, [])
+
+  const fetchEvents = useCallback(async () => {
+    try {
+      const res = await fetch("/api/webhooks/events")
+      const data = await res.json()
+      const fetched = data.events as WebhookEvent[]
+
+      if (fetched.length > lastFetchCount) {
+        const newIds = new Set(fetched.slice(0, fetched.length - lastFetchCount).map(e => e.id))
+        setNewEventIds(prev => new Set([...prev, ...newIds]))
+        setTimeout(() => {
+          setNewEventIds(prev => {
+            const next = new Set(prev)
+            for (const id of newIds) next.delete(id)
+            return next
+          })
+        }, 5000)
+      }
+      setLastFetchCount(fetched.length)
+      setEvents(fetched)
+    } catch {
+      // ignore fetch errors
+    }
+  }, [lastFetchCount])
+
+  useEffect(() => {
+    fetchEvents()
+    const interval = setInterval(fetchEvents, 2500)
+    return () => clearInterval(interval)
+  }, [fetchEvents])
+
+  const clearAll = async () => {
+    await fetch("/api/webhooks/events", { method: "DELETE" })
+    setEvents([])
+    setLastFetchCount(0)
+    setNewEventIds(new Set())
+  }
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const grouped = events.reduce<Record<string, WebhookEvent[]>>((acc, event) => {
+    const key = event.type
+    if (!acc[key]) acc[key] = []
+    acc[key].push(event)
+    return acc
+  }, {})
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-5xl px-4 py-8 md:px-6 md:py-12">
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">
+              Webhook Event Log
+            </h1>
+            <p className="mt-1 text-muted-foreground">
+              Received {events.length} event{events.length !== 1 ? "s" : ""}. Polling every 2.5 seconds.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Link
+              href="/dashboard"
+              className="rounded-md border border-border bg-card px-3 py-1.5 text-sm text-foreground hover:bg-accent"
+            >
+              Dashboard
+            </Link>
+            <button
+              onClick={clearAll}
+              disabled={events.length === 0}
+              className="rounded-md bg-destructive px-3 py-1.5 text-sm text-foreground hover:bg-destructive/80 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Clear Events
+            </button>
+          </div>
+        </div>
+
+        {/* Summary by type */}
+        {Object.keys(grouped).length > 0 && (
+          <div className="mb-6 flex flex-wrap gap-2">
+            {Object.entries(grouped).map(([type, evts]) => (
+              <span key={type} className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${getEventColor(type)}`}>
+                {type} ({evts.length})
+              </span>
+            ))}
+          </div>
+        )}
+
+        {events.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card p-12 text-center">
+            <svg className="mx-auto h-12 w-12 text-muted-foreground/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+            </svg>
+            <h3 className="mt-4 text-lg font-medium text-foreground">No webhook events yet</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Configure your neon-auth instance to send webhooks to{" "}
+              <code className="rounded bg-secondary px-1.5 py-0.5 font-mono text-xs">
+                POST /api/webhooks/neon-auth
+              </code>
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Then try sending a magic link to see events appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {events.map((event) => (
+              <div
+                key={event.id}
+                className={`rounded-lg border border-border bg-card transition-all ${
+                  newEventIds.has(event.id)
+                    ? "ring-2 ring-primary/50 border-primary/30"
+                    : ""
+                }`}
+              >
+                <button
+                  onClick={() => toggleExpand(event.id)}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-accent/50 rounded-lg transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getEventColor(event.type)}`}>
+                      {event.type}
+                    </span>
+                    {newEventIds.has(event.id) && (
+                      <span className="inline-flex items-center rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+                        NEW
+                      </span>
+                    )}
+                    <span className="text-xs text-muted-foreground">
+                      #{event.id}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(event.timestamp).toLocaleTimeString()}
+                    </span>
+                    <svg
+                      className={`h-4 w-4 text-muted-foreground transition-transform ${
+                        expandedIds.has(event.id) ? "rotate-180" : ""
+                      }`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </div>
+                </button>
+                {expandedIds.has(event.id) && (
+                  <div className="border-t border-border px-4 py-3">
+                    <pre className="overflow-x-auto rounded-md bg-background p-3 text-xs font-mono text-foreground">
+                      {JSON.stringify(event.payload, null, 2)}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Setup instructions */}
+        <div className="mt-8 rounded-lg border border-primary/30 bg-primary/5 p-4">
+          <h3 className="text-sm font-semibold text-primary">Webhook Setup</h3>
+          <p className="mt-1 text-sm text-primary/70">
+            Configure your neon-auth project to send webhooks to:
+          </p>
+          <code className="mt-2 block rounded bg-primary/10 px-3 py-2 text-xs font-mono text-primary">
+            POST {origin || "http://localhost:3000"}/api/webhooks/neon-auth
+          </code>
+          <p className="mt-2 text-sm text-primary/70">
+            Events triggered by magic link, user creation, and more will appear here.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/examples/neon-auth-magic-link-example/components/magic-link-form.tsx
+++ b/examples/neon-auth-magic-link-example/components/magic-link-form.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { authClient } from "@/lib/auth/client";
+import Link from "next/link";
+import { useState } from "react";
+
+type Status = "idle" | "sending" | "sent" | "error";
+
+export function MagicLinkForm() {
+  const [status, setStatus] = useState<Status>("idle");
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSendMagicLink(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setStatus("sending");
+
+    try {
+      const result = await authClient.signIn.magicLink({
+        email,
+        callbackURL: "/dashboard",
+      });
+
+      if (result.error) {
+        setError(result.error.message ?? "Failed to send magic link");
+        setStatus("error");
+        return;
+      }
+
+      setStatus("sent");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to send magic link",
+      );
+      setStatus("error");
+    }
+  }
+
+  function handleChangeEmail() {
+    setStatus("idle");
+    setError(null);
+  }
+
+  async function handleResend() {
+    setError(null);
+    setStatus("sending");
+
+    try {
+      const result = await authClient.signIn.magicLink({
+        email,
+        callbackURL: "/dashboard",
+      });
+
+      if (result.error) {
+        setError(result.error.message ?? "Failed to resend magic link");
+        setStatus("sent");
+        return;
+      }
+
+      setStatus("sent");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to resend magic link",
+      );
+      setStatus("sent");
+    }
+  }
+
+  const showForm = status === "idle" || status === "error";
+
+  return (
+    <div className="w-full max-w-md rounded-xl border border-border bg-card p-8">
+      <div className="mb-6 flex flex-col items-center gap-2 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10">
+          <svg
+            className="h-6 w-6 text-primary"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+        </div>
+        <h2 className="text-2xl font-bold text-foreground">
+          {showForm ? "Sign in with Magic Link" : "Check your email"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {showForm
+            ? "We'll send a magic link to your email"
+            : `We sent a magic link to ${email}`}
+        </p>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {showForm ? (
+        <form onSubmit={handleSendMagicLink} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="email"
+              className="text-sm font-medium text-foreground"
+            >
+              Email address
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="h-11 rounded-lg border border-input bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              disabled={status === "sending"}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={status === "sending"}
+            className="h-11 rounded-lg bg-primary font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+          >
+            {status === "sending" ? "Sending..." : "Send Magic Link"}
+          </button>
+        </form>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <p className="text-center text-sm text-muted-foreground">
+            Click the link in the email to sign in. You can close this tab.
+          </p>
+          <Link
+            href="/webhooks"
+            className="text-center text-sm text-primary transition-colors hover:text-primary/80"
+          >
+            Or check your webhooks &rarr;
+          </Link>
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={handleChangeEmail}
+              className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Use different email
+            </button>
+            <button
+              type="button"
+              onClick={handleResend}
+              disabled={status === "sending"}
+              className="text-sm text-primary transition-colors hover:text-primary/80 disabled:opacity-50"
+            >
+              Resend link
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/neon-auth-magic-link-example/drizzle.config.ts
+++ b/examples/neon-auth-magic-link-example/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit'
+
+export default defineConfig({
+  schema: ['./lib/schema.ts'],
+  out: './drizzle',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.DATABASE_URL!,
+  },
+})

--- a/examples/neon-auth-magic-link-example/eslint.config.mjs
+++ b/examples/neon-auth-magic-link-example/eslint.config.mjs
@@ -1,0 +1,26 @@
+import globals from 'globals';
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  globalIgnores([
+    ".next/**",
+    "out/**",
+    "build/**",
+    "next-env.d.ts",
+    ".history/**",
+  ]),
+  {
+    files: ['**/*.{ts,tsx,mjs}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: {...globals.browser, ...globals.node},
+      parserOptions: { tsconfigRootDir: import.meta.dirname },
+    },
+  },
+]);
+
+export default eslintConfig;

--- a/examples/neon-auth-magic-link-example/lib/auth/client.ts
+++ b/examples/neon-auth-magic-link-example/lib/auth/client.ts
@@ -1,0 +1,3 @@
+import { createAuthClient } from "@neondatabase/auth/next"
+
+export const authClient = createAuthClient()

--- a/examples/neon-auth-magic-link-example/lib/auth/server.ts
+++ b/examples/neon-auth-magic-link-example/lib/auth/server.ts
@@ -1,0 +1,9 @@
+import { createNeonAuth } from '@neondatabase/auth/next/server';
+
+export const auth = createNeonAuth({
+  baseUrl: process.env.NEON_AUTH_BASE_URL!,
+  cookies: {
+    secret: process.env.NEON_AUTH_COOKIE_SECRET!,
+    sessionDataTtl: 300,
+  },
+});

--- a/examples/neon-auth-magic-link-example/lib/db.ts
+++ b/examples/neon-auth-magic-link-example/lib/db.ts
@@ -1,0 +1,15 @@
+import { neon } from "@neondatabase/serverless"
+import { drizzle } from "drizzle-orm/neon-http"
+import * as schema from "./schema"
+
+function getDatabaseUrl(): string {
+  const url = process.env.DATABASE_URL
+  if (!url) {
+    throw new Error('DATABASE_URL is not set')
+  }
+  return url
+}
+
+const sql = neon(getDatabaseUrl())
+
+export const db = drizzle(sql, { schema })

--- a/examples/neon-auth-magic-link-example/lib/schema.ts
+++ b/examples/neon-auth-magic-link-example/lib/schema.ts
@@ -1,0 +1,5 @@
+// This example has no app-specific tables.
+// The neon_auth schema (users, sessions, etc.) is managed by Neon Auth automatically.
+// If you need app tables, define them here in the public schema.
+
+export {}

--- a/examples/neon-auth-magic-link-example/lib/webhook-store.ts
+++ b/examples/neon-auth-magic-link-example/lib/webhook-store.ts
@@ -1,0 +1,59 @@
+/**
+ * In-memory webhook event store.
+ * Events are stored in a global array and exposed via API routes.
+ * This is for demo purposes only — in production, persist to a database.
+ *
+ * We attach the store to `globalThis` so that it survives module
+ * re-instantiation across Next.js route handlers (App Router can
+ * create separate module instances for each route, which means a
+ * plain module-level variable would be duplicated and events added
+ * by one route would be invisible to another).
+ */
+
+export interface WebhookEvent {
+  id: string;
+  type: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+}
+
+interface WebhookStore {
+  events: WebhookEvent[];
+  nextId: number;
+}
+
+// Symbol key avoids collisions with other globals
+const STORE_KEY = Symbol.for('__neon_auth_webhook_store__');
+
+function getStore(): WebhookStore {
+  const g = globalThis as unknown as Record<symbol, WebhookStore | undefined>;
+  if (!g[STORE_KEY]) {
+    g[STORE_KEY] = { events: [], nextId: 1 };
+  }
+  return g[STORE_KEY]!;
+}
+
+export function addEvent(type: string, payload: Record<string, unknown>): WebhookEvent {
+  const store = getStore();
+  const event: WebhookEvent = {
+    id: String(store.nextId++),
+    type,
+    timestamp: new Date().toISOString(),
+    payload,
+  };
+  store.events.unshift(event); // newest first
+  // Keep max 200 events
+  if (store.events.length > 200) {
+    store.events.length = 200;
+  }
+  return event;
+}
+
+export function getEvents(): WebhookEvent[] {
+  return getStore().events;
+}
+
+export function clearEvents(): void {
+  const store = getStore();
+  store.events.length = 0;
+}

--- a/examples/neon-auth-magic-link-example/next.config.ts
+++ b/examples/neon-auth-magic-link-example/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  transpilePackages: ['@neondatabase/auth'],
+};
+
+export default nextConfig;

--- a/examples/neon-auth-magic-link-example/package.json
+++ b/examples/neon-auth-magic-link-example/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "neon-auth-magic-link-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint",
+    "db:generate": "drizzle-kit generate",
+    "db:push": "drizzle-kit push"
+  },
+  "dependencies": {
+    "@neondatabase/auth": "workspace:*",
+    "@neondatabase/serverless": "^1.0.2",
+    "drizzle-kit": "^0.31.7",
+    "drizzle-orm": "^0.45.0",
+    "next": "16.0.7",
+    "react": "19.2.1",
+    "react-dom": "19.2.1"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.0.7",
+    "globals": "^16.5.0",
+    "tailwindcss": "^4",
+    "tw-animate-css": "^1.4.0",
+    "typescript": "^5"
+  }
+}

--- a/examples/neon-auth-magic-link-example/package.json
+++ b/examples/neon-auth-magic-link-example/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
@@ -11,12 +11,12 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
-    "@neondatabase/auth": "workspace:*",
     "@neondatabase/serverless": "^1.0.2",
     "drizzle-kit": "^0.31.7",
     "drizzle-orm": "^0.45.0",
     "next": "16.0.7",
     "react": "19.2.1",
+    "jose": "^6.1.2",
     "react-dom": "19.2.1"
   },
   "devDependencies": {

--- a/examples/neon-auth-magic-link-example/postcss.config.mjs
+++ b/examples/neon-auth-magic-link-example/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+    plugins: ["@tailwindcss/postcss"]
+}
+
+export default config

--- a/examples/neon-auth-magic-link-example/tsconfig.json
+++ b/examples/neon-auth-magic-link-example/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,61 @@ importers:
         specifier: ^1.57.0
         version: 1.59.0
 
+  examples/neon-auth-magic-link-example:
+    dependencies:
+      '@neondatabase/serverless':
+        specifier: ^1.0.2
+        version: 1.0.2
+      drizzle-kit:
+        specifier: ^0.31.7
+        version: 0.31.10
+      drizzle-orm:
+        specifier: ^0.45.0
+        version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0)
+      jose:
+        specifier: ^6.1.2
+        version: 6.1.2
+      next:
+        specifier: 16.2.3
+        version: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react:
+        specifier: 19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: 19.2.1
+        version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.2.2
+      '@types/node':
+        specifier: ^20
+        version: 20.19.37
+      '@types/react':
+        specifier: ^19
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^9
+        version: 9.39.2(jiti@2.6.1)
+      eslint-config-next:
+        specifier: 16.0.7
+        version: 16.0.7(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      globals:
+        specifier: ^16.5.0
+        version: 16.5.0
+      tailwindcss:
+        specifier: 4.2.1
+        version: 4.2.1
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   examples/neon-auth-orgs-example:
     dependencies:
       '@hookform/resolvers':
@@ -11985,7 +12040,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -12005,7 +12060,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -12053,7 +12108,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -12108,7 +12163,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
Minimal passwordless authentication example using email OTP (magic link) with Neon Auth. Demonstrates @neondatabase/auth emailOTP integration in a Next.js app with Drizzle ORM.

## Related PRs

**Feature: Magic Link**
- [neon-auth/be] Add magic link plugin support — https://github.com/databricks-eng/neon-cloud/pull/5583
- [console/be] Add magic link plugin config endpoint — https://github.com/databricks-eng/neon-cloud/pull/5585
- [lakebase/web] Add Magic Link config to Identity dashboard — https://github.com/databricks-eng/universe-dev/pull/8602
- [neon-js] feat(auth): add magicLinkClient to supported plugins — https://github.com/neondatabase/neon-js/pull/58
- [neon-js] misc: add neon-auth magic link example app — https://github.com/neondatabase/neon-js/pull/57 ← you are here
- [neon-js] test(e2e): add magic link flow tests — https://github.com/neondatabase/neon-js/pull/59