### PR TITLE
security: enable npm provenance attestation on all published packages

### DIFF
--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -54,7 +54,8 @@
     "llms.txt"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "node build-css.mjs && tsdown",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -88,7 +88,8 @@
     "llms.txt"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "sideEffects": false,
   "scripts": {

--- a/packages/neon-js/package.json
+++ b/packages/neon-js/package.json
@@ -100,7 +100,8 @@
     "llms.txt"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/postgrest-js/package.json
+++ b/packages/postgrest-js/package.json
@@ -40,7 +40,8 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
 ## Summary

  Add `"provenance": true` to `publishConfig` in all 4 published packages
  (`auth`, `auth-ui`, `postgrest-js`, `neon-js`). This tells npm to require
  a signed OIDC provenance statement on every publish, linking each release
  to its source commit and CI run.

  Companion to the CI release workflow in `ci/oidc-release` — that workflow
  sets `NPM_CONFIG_PROVENANCE=true` at publish time, which is what actually
  generates the attestation. This change declares the requirement on the
  package side.

  ## Dependencies

  - Depends on `ci/oidc-release` being merged and `NPM_TOKEN` configured
    before provenance can be generated in practice
  - Local publishes via `scripts/release.ts` will fail once npmjs.com is
    configured to require provenance, which is the intended enforcement

  ## Test plan

  - [ ] After `ci/oidc-release` is merged and a release is triggered, verify
    the provenance badge appears on the package page on npmjs.com


Co-authored-by: Isaac