### PR TITLE
security: harden CI workflows and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every PR requires review from @shridhad
+* @shridhad

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,10 +45,6 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Restrict tools to read-only operations + gh CLI + bun scripts only.
+          # Blocks curl/wget/arbitrary bash to prevent exfiltration via prompt injection.
+          claude_args: '--allowed-tools "Read,Glob,Grep,Bash(gh:*),Bash(bun run:*),Bash(git diff:*),Bash(git log:*),Bash(git status)"'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,18 +6,9 @@ on:
   pull_request:
     branches: [main]
 
-  # Cross-repo trigger: Allow external repos to run E2E tests
-  # Used by Neon Auth service to validate changes don't break the SDK
-  repository_dispatch:
-    types: [run-e2e]
-
-  # Manual trigger with optional ref, environment, and app override
+  # Manual trigger with optional environment and app override
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Git ref to test (branch, tag, or SHA)'
-        required: false
-        default: 'main'
       environment:
         description: 'Neon environment to test against'
         required: false
@@ -42,53 +33,7 @@ permissions:
   contents: read
 
 jobs:
-  # Validation job: Validates and sanitizes inputs for dispatch events
-  validate:
-    runs-on:
-      group: neondatabase-protected-runner-group
-      labels: linux-ubuntu-latest
-    # Skip validation for push/PR events (they don't have dispatch payloads)
-    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
-    outputs:
-      environment: ${{ steps.validate.outputs.environment }}
-    steps:
-      - name: Audit log entry
-        run: |
-          echo "## E2E Dispatch Audit" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Timestamp:** $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Event:** ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Run ID:** ${{ github.run_id }}" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Validate and extract inputs
-        id: validate
-        env:
-          INPUT_ENV: ${{ github.event.client_payload.environment || github.event.inputs.environment || 'production' }}
-          INPUT_SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
-        run: |
-          # Log source repo for audit trail
-          if [[ -n "$INPUT_SOURCE_REPO" ]]; then
-            echo "- **Source repo:** $INPUT_SOURCE_REPO" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          # Validate environment against allowed values (only needed for repository_dispatch)
-          if [[ ! "$INPUT_ENV" =~ ^(production|staging|preview)$ ]]; then
-            echo "::error::Invalid environment: $INPUT_ENV. Must be production, staging, or preview"
-            exit 1
-          fi
-          echo "environment=$INPUT_ENV" >> "$GITHUB_OUTPUT"
-          echo "- **Environment:** $INPUT_ENV" >> "$GITHUB_STEP_SUMMARY"
-
   e2e:
-    needs: [validate]
-    # Run if:
-    # - Push/PR events (no validate job ran, needs.validate is skipped)
-    # - Dispatch events where validation passed
-    if: |
-      always() && (
-        github.event_name == 'push' ||
-        github.event_name == 'pull_request' ||
-        needs.validate.result == 'success'
-      )
     timeout-minutes: 20
     runs-on:
       group: neondatabase-protected-runner-group
@@ -110,24 +55,18 @@ jobs:
     # - production: Default, uses production Neon API
     # - staging: Uses staging Neon API (console.stage.neon.tech)
     # - preview: Uses preview Neon API
-    environment: ${{ needs.validate.outputs.environment || 'production' }}
+    environment: ${{ github.event.inputs.environment || 'production' }}
 
-    # Concurrency: prevent duplicate runs per app, but don't cancel external triggers
+    # Concurrency: cancel duplicate runs per app on the same branch
     concurrency:
-      group: e2e-${{ matrix.app }}-${{ github.event_name == 'repository_dispatch' && github.run_id || github.head_ref || github.ref }}
-      cancel-in-progress: ${{ github.event_name != 'repository_dispatch' }}
+      group: e2e-${{ matrix.app }}-${{ github.head_ref || github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          # Use ref from dispatch events, otherwise default behavior
-          ref: ${{ github.event.client_payload.ref || inputs.ref || '' }}
-          # Security: don't persist git creds for normal triggers.
-          # For repository_dispatch (cross-repo), we must persist credentials because
-          # the cleanup phase fails with the cross-repo token context.
-          # This is safe: no subsequent step uses git, and the runner is ephemeral.
-          persist-credentials: ${{ github.event_name == 'repository_dispatch' }}
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2


### PR DESCRIPTION
 ## Summary

  - Remove `id-token: write` from `claude-code-review.yml` — confirmed unused; only needed for Bedrock/Vertex/Foundry OIDC, not direct API key
  - Remove `repository_dispatch` from `e2e.yml` — dead code, no active sender; also removes validate job, unvalidated ref/source_repo inputs, and persist-credentials
   conditional
  - Add `claude_args` tool restriction to `claude.yml` — blocks curl/wget/arbitrary bash, prevents exfiltration via prompt injection
  - Add `.github/CODEOWNERS` 

  ## Test plan
  - [ ] ci.yml and unit-tests.yml pass (no changes to those workflows)
  - [ ] e2e.yml still triggers on push/PR and workflow_dispatch
  - [ ] claude-code-review.yml runs without error (no OIDC steps needed id-token)
  - [ ] claude.yml responds to @claude with restricted tool set


Co-authored-by: Isaac