### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  # npm dependencies (root + all packages)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      # Group minor/patch updates to reduce PR noise
+      production:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    open-pull-requests-limit: 10
+
+  # GitHub Actions versions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,12 @@
 version: 2
 updates:
-  # bun dependencies (root + all packages)
+  # Bun dependencies (root + all packages)
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
-      # Group minor/patch updates to reduce PR noise
       production:
         patterns: ["*"]
         update-types: ["minor", "patch"]
@@ -17,4 +16,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  # npm dependencies (root + all packages)
-  - package-ecosystem: "npm"
+  # bun dependencies (root + all packages)
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for automated dependency and GitHub Actions updates
- npm dependencies: weekly, minor+patch grouped into single PR
- GitHub Actions: weekly, keeps SHA pins current
- Addresses security checklist item: "How do you periodically rescan artifacts?"

## Test plan
- [ ] Verify Dependabot creates PRs on next scheduled run
- [ ] Verify grouped updates produce a single PR for minor+patch bumps

This pull request was AI-assisted by Isaac.

## Related PRs

**Feature: neon-js OIDC + CI**
- [neon-js] ci: add OIDC release workflow with cascade version bumping — https://github.com/neondatabase/neon-js/pull/62 *(superseded by #71)*
- [neon-js] chore: migrate from bun to pnpm + OIDC release workflow — https://github.com/neondatabase/neon-js/pull/71
- [neon-js] ci: add Dependabot configuration — https://github.com/neondatabase/neon-js/pull/68 ← you are here