### PR TITLE
fix: pin delete-branch-action to v3.2.1 for e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -177,7 +177,7 @@ jobs:
       # Clean up: Delete Neon branch (runs even if tests fail)
       - name: Delete Neon branch
         if: always()
-        uses: neondatabase/delete-branch-action@c2005bb7d7caeba12ba3ec63857e9c9f9a4d695a # v3
+        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3.2.1
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch: test-${{ matrix.app }}-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary
- Update `neondatabase/delete-branch-action` from old SHA (v3) to `4468d825` (v3.2.1)
- v3.2.1 pins `actions/setup-node` internally to a full commit SHA
- Fixes e2e workflow failures caused by the runner group's SHA-pinning policy

Replaces closed #69 (auto-closed during branch cleanup).

## Test plan
- [ ] e2e (nextjs-neon-auth) passes
- [ ] e2e (react-neon-js) passes

Note: ci and unit-tests checks will still fail due to a pre-existing bun install
hang on the protected runner group (affects all PRs, not specific to this change).

This pull request was AI-assisted by Isaac.