### PR TITLE
feat: add phoneNumber client plugin for phone OTP sign-in (LKB-11605)

### DIFF
--- a/packages/auth/src/core/adapter-core.ts
+++ b/packages/auth/src/core/adapter-core.ts
@@ -6,6 +6,7 @@ import {
   emailOTPClient,
   magicLinkClient,
   organizationClient,
+  phoneNumberClient,
 } from 'better-auth/client/plugins';
 import {
   BETTER_AUTH_METHODS_HOOKS,
@@ -31,6 +32,7 @@ const supportedBetterAuthClientPlugins = [
   organizationClient(),
   emailOTPClient(),
   magicLinkClient(),
+  phoneNumberClient(),
   anonymousTokenClient(),
 ] satisfies BetterAuthClientOptions['plugins'];
 

--- a/packages/auth/src/types/index.ts
+++ b/packages/auth/src/types/index.ts
@@ -78,6 +78,9 @@ export type { EmailOTPOptions } from 'better-auth/plugins/email-otp';
 // Magic Link plugin
 export type { MagicLinkOptions } from 'better-auth/plugins/magic-link';
 
+// Phone Number plugin
+export type { PhoneNumberOptions } from 'better-auth/plugins/phone-number';
+
 // Anonymous plugin - no additional types to export
 
 // ============================================


### PR DESCRIPTION
## Summary

Adds `phoneNumberClient()` to the supported Better Auth client plugins, enabling:
- `signIn.phoneNumber()` for phone+password sign-in
- Phone number verification and update methods
- Proper session invalidation for phone-related routes

No dependency bump needed — `better-auth@1.4.6` (already installed) includes `phoneNumberClient`.

## Related

- neon-cloud PR: databricks-eng/neon-cloud#5599 (Go backend + neon-auth)

## Test plan

- [ ] Verify build passes
- [ ] Verify `signIn.phoneNumber` is available on typed client