### PR TITLE
[auth] fix: refresh session_data cookie cache on mutation responses

### DIFF
--- a/packages/auth/src/server/client-factory.ts
+++ b/packages/auth/src/server/client-factory.ts
@@ -13,6 +13,7 @@ import { parseSetCookies, parseCookieValue } from '@/server/utils/cookies';
 import { validateSessionData } from '@/server/session/validator';
 import { NEON_AUTH_SESSION_COOKIE_NAME, NEON_AUTH_SESSION_DATA_COOKIE_NAME } from './constants';
 import { mintSessionDataFromResponse } from './session/minting';
+import { maybeRefreshSessionDataAfterResponse } from './session/post-response-refresh';
 import { normalizeBetterAuthError } from '@/core/better-auth-helpers';
 import type { ResolvedNeonAuthLogging } from './logger';
 import { classifyFetchFailure } from './network-error';
@@ -133,8 +134,9 @@ export function createAuthServerInternal(
       });
     }
 
-    // Handle response cookies 
+    // Handle response cookies
     const setCookieHeaders = response.headers.getSetCookie();
+    let sessionDataCookie: string | null = null;
     if (setCookieHeaders.length > 0) {
       for (const setCookieHeader of setCookieHeaders) {
         const parsedCookies = parseSetCookies(setCookieHeader);
@@ -155,7 +157,7 @@ export function createAuthServerInternal(
 
       // Mint session data cookie if session_token was set
       try {
-        const sessionDataCookie = await mintSessionDataFromResponse(
+        sessionDataCookie = await mintSessionDataFromResponse(
           response.headers,
           baseUrl,
           {
@@ -184,6 +186,36 @@ export function createAuthServerInternal(
           err: error,
         });
       }
+    }
+
+    // Post-response refresh fallback: covers mutation routes (update-user,
+    // phone-number/verify, update-email) where upstream returns fresh
+    // user/session in the body but doesn't rotate session_token — so no
+    // Set-Cookie header is present at all.
+    try {
+      const fallback = await maybeRefreshSessionDataAfterResponse({
+        requestCookieHeader: cookies,
+        response,
+        baseUrl,
+        cookieConfig: { secret: cookieSecret, sessionDataTtl, domain, sameSite },
+        alreadyMintedFromHeader: sessionDataCookie !== null,
+      });
+      if (fallback) {
+        const [parsedFallback] = parseSetCookies(fallback);
+        if (parsedFallback) {
+          await ctx.setCookie(
+            parsedFallback.name,
+            parsedFallback.value,
+            parsedFallback
+          );
+        }
+      }
+    } catch (error) {
+      log?.warn('[neon-auth] Post-response refresh failed', {
+        component: 'server-api',
+        detail: error instanceof Error ? error.message : String(error),
+        err: error,
+      });
     }
 
     const responseData = await response.json().catch(() => null);

--- a/packages/auth/src/server/proxy/handler.test.ts
+++ b/packages/auth/src/server/proxy/handler.test.ts
@@ -164,12 +164,17 @@ describe('handleAuthProxyRequest', () => {
 
       await handleAuthProxyRequest(config);
 
-      expect(handleAuthResponseSpy).toHaveBeenCalledWith(upstreamResponse, BASE_URL, {
-        secret: TEST_SECRET,
-        sessionDataTtl: 600,
-        domain: '.example.com',
-        sameSite: undefined,
-      });
+      expect(handleAuthResponseSpy).toHaveBeenCalledWith(
+        upstreamResponse,
+        BASE_URL,
+        {
+          secret: TEST_SECRET,
+          sessionDataTtl: 600,
+          domain: '.example.com',
+          sameSite: undefined,
+        },
+        expect.objectContaining({})
+      );
     });
 
     test('returns processed response from handleAuthResponse', async () => {
@@ -212,7 +217,8 @@ describe('handleAuthProxyRequest', () => {
         BASE_URL,
         expect.objectContaining({
           sessionDataTtl: 900,
-        })
+        }),
+        expect.objectContaining({})
       );
     });
 
@@ -239,7 +245,8 @@ describe('handleAuthProxyRequest', () => {
         BASE_URL,
         expect.objectContaining({
           domain: '.custom-domain.com',
-        })
+        }),
+        expect.objectContaining({})
       );
     });
 
@@ -261,12 +268,17 @@ describe('handleAuthProxyRequest', () => {
 
       await handleAuthProxyRequest(config);
 
-      expect(handleAuthResponseSpy).toHaveBeenCalledWith(upstreamResponse, BASE_URL, {
-        secret: TEST_SECRET,
-        sessionDataTtl: undefined,
-        domain: undefined,
-        sameSite: undefined,
-      });
+      expect(handleAuthResponseSpy).toHaveBeenCalledWith(
+        upstreamResponse,
+        BASE_URL,
+        {
+          secret: TEST_SECRET,
+          sessionDataTtl: undefined,
+          domain: undefined,
+          sameSite: undefined,
+        },
+        expect.objectContaining({})
+      );
     });
   });
 

--- a/packages/auth/src/server/proxy/handler.ts
+++ b/packages/auth/src/server/proxy/handler.ts
@@ -61,10 +61,15 @@ export async function handleAuthProxyRequest(config: AuthProxyConfig): Promise<R
 
 	// Fallback: Call upstream API
 	const response = await handleAuthRequest(baseUrl, request, path, log);
-	return await handleAuthResponse(response, baseUrl, {
-		secret: cookieSecret,
-		sessionDataTtl,
-		domain,
-		sameSite,
-	});
+	return await handleAuthResponse(
+		response,
+		baseUrl,
+		{
+			secret: cookieSecret,
+			sessionDataTtl,
+			domain,
+			sameSite,
+		},
+		{ cookieHeader: request.headers.get('cookie') },
+	);
 }

--- a/packages/auth/src/server/proxy/response.ts
+++ b/packages/auth/src/server/proxy/response.ts
@@ -1,4 +1,5 @@
 import { mintSessionDataFromResponse } from '../session/minting';
+import { maybeRefreshSessionDataAfterResponse } from '../session/post-response-refresh';
 import { parseSetCookies, serializeSetCookie } from '@/server/utils/cookies';
 import type { SessionCookieConfig } from '../config';
 
@@ -7,20 +8,28 @@ const RESPONSE_HEADERS_ALLOWLIST = ['content-type', 'content-length', 'content-e
     'connection', 'date',
    'set-cookie', 'set-auth-jwt', 'set-auth-token', 'x-neon-ret-request-id'];
 
+export interface AuthResponseRequestContext {
+  /** Raw Cookie header from the inbound request, used to locate session_token for post-response refresh. */
+  cookieHeader: string | null;
+}
+
 /**
  * Handles responses from upstream Neon Auth server
  * - Proxies allowed headers to client
  * - Mints session data cookie if session token is present
+ * - Optionally refreshes session data cookie if mutation response body carries fresh user/session
  *
  * @param response - Response from upstream Neon Auth server
  * @param baseUrl - Base URL of Neon Auth server
  * @param cookieConfig - Session cookie configuration
+ * @param requestContext - Optional inbound request context for post-response refresh
  * @returns New Response with proxied headers and session data cookie
  */
 export const handleAuthResponse = async (
   response: Response,
   baseUrl: string,
-  cookieConfig: SessionCookieConfig
+  cookieConfig: SessionCookieConfig,
+  requestContext?: AuthResponseRequestContext
 ) => {
   const responseHeaders = prepareResponseHeaders(response, cookieConfig);
 
@@ -28,6 +37,21 @@ export const handleAuthResponse = async (
   const sessionDataCookie = await mintSessionDataFromResponse(response.headers, baseUrl, cookieConfig);
   if (sessionDataCookie) {
     responseHeaders.append('Set-Cookie', sessionDataCookie);
+  }
+
+  // Fallback refresh: covers mutation routes (update-user, phone-number/verify, etc.)
+  // where upstream returns fresh user/session in the body without rotating session_token.
+  if (requestContext) {
+    const fallback = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: requestContext.cookieHeader,
+      response,
+      baseUrl,
+      cookieConfig,
+      alreadyMintedFromHeader: sessionDataCookie !== null,
+    });
+    if (fallback) {
+      responseHeaders.append('Set-Cookie', fallback);
+    }
   }
 
   return new Response(response.body, {

--- a/packages/auth/src/server/session/minting.ts
+++ b/packages/auth/src/server/session/minting.ts
@@ -59,6 +59,26 @@ async function mintSessionDataCookie(
 }
 
 /**
+ * Serialize a Set-Cookie header that deletes the session_data cookie.
+ *
+ * Used both by the token-rotation path (sign-out) and the post-response
+ * refresh fallback path (when re-minting fails, we clear the cache so the
+ * next read fetches fresh state from upstream).
+ */
+export function serializeSessionDataDeletion(cookieConfig: SessionCookieConfig): string {
+  return serializeSetCookie({
+    name: NEON_AUTH_SESSION_DATA_COOKIE_NAME,
+    value: '',
+    path: '/',
+    domain: cookieConfig.domain,
+    httpOnly: true,
+    secure: true,
+    sameSite: cookieConfig.sameSite ?? 'strict',
+    maxAge: 0,
+  });
+}
+
+/**
  * Utility A: Mint session_data cookie when session_token is updated by upstream
  *
  * Checks response headers for session_token in Set-Cookie, then mints session_data.
@@ -89,17 +109,7 @@ export async function mintSessionDataFromResponse(
   // Check if session_token is being deleted (sign-out scenario)
   const sessionCookieLower = sessionTokenCookie.toLowerCase();
   if (sessionCookieLower.includes('max-age=0')) {
-    // Return deletion cookie for session_data
-    return serializeSetCookie({
-      name: NEON_AUTH_SESSION_DATA_COOKIE_NAME,
-      value: '',
-      path: '/',
-      domain: cookieConfig.domain,
-      httpOnly: true,
-      secure: true,
-      sameSite: cookieConfig.sameSite ?? 'strict',
-      maxAge: 0,
-    });
+    return serializeSessionDataDeletion(cookieConfig);
   }
 
   // Session token was set/updated - mint new session_data cookie

--- a/packages/auth/src/server/session/post-response-refresh.test.ts
+++ b/packages/auth/src/server/session/post-response-refresh.test.ts
@@ -1,0 +1,279 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { maybeRefreshSessionDataAfterResponse } from './post-response-refresh';
+import { handleAuthResponse } from '../proxy/response';
+import { NEON_AUTH_SESSION_COOKIE_NAME, NEON_AUTH_SESSION_DATA_COOKIE_NAME } from '../constants';
+import type { RequireSessionData } from '@/server/types';
+import type { BetterAuthSession, BetterAuthUser } from '@/core/better-auth-types';
+
+const TEST_SECRET = 'test-secret-at-least-32-characters-long!';
+const TEST_BASE_URL = 'https://auth.example.com';
+const TEST_COOKIE_CONFIG = {
+  secret: TEST_SECRET,
+  sessionDataTtl: 300,
+};
+const SESSION_TOKEN_COOKIE_HEADER = `${NEON_AUTH_SESSION_COOKIE_NAME}=valid-token`;
+
+const createTestSessionData = (): RequireSessionData => ({
+  session: {
+    id: 'session-123',
+    userId: 'user-123',
+    token: 'opaque-token-abc',
+    expiresAt: new Date(Date.now() + 3_600_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: '127.0.0.1',
+    userAgent: 'test-agent',
+  } as BetterAuthSession,
+  user: {
+    id: 'user-123',
+    email: 'test@example.com',
+    emailVerified: true,
+    name: 'Test User',
+    image: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as BetterAuthUser,
+});
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('maybeRefreshSessionDataAfterResponse', () => {
+  test('case 1: 2xx JSON with top-level user → returns remint Set-Cookie string', async () => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/get-session`, () => HttpResponse.json(createTestSessionData()))
+    );
+
+    const response = Response.json(
+      { user: { id: 'user-123', email: 'new@example.com' } },
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).not.toBe(null);
+    expect(result).toContain(`${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=`);
+    expect(result).toContain('HttpOnly');
+  });
+
+  test('case 2: /update-user response with {user, session} → returns remint cookie', async () => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/get-session`, () => HttpResponse.json(createTestSessionData()))
+    );
+
+    const response = Response.json(
+      {
+        user: { id: 'user-123', name: 'Updated' },
+        session: { id: 'session-123', token: 'opaque-token-abc' },
+      },
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).not.toBe(null);
+    expect(result).toContain(`${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=`);
+  });
+
+  test('case 3: 2xx JSON without user/session → returns null', async () => {
+    const response = Response.json({ ok: true, message: 'done' }, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).toBe(null);
+  });
+
+  test('case 4: 2xx but non-JSON (text/html) → returns null', async () => {
+    const response = new Response('<html><body>ok</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).toBe(null);
+  });
+
+  test('case 5: missing session_token in request cookies → returns null even for qualifying body', async () => {
+    const response = Response.json({ user: { id: 'user-123' } }, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: 'other-cookie=value',
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).toBe(null);
+  });
+
+  test('case 6: mintSessionDataFromToken fails → returns deletion cookie (Max-Age=0)', async () => {
+    // Upstream returns 401 so minting fails — we should emit a deletion cookie.
+    server.use(
+      http.get(`${TEST_BASE_URL}/get-session`, () =>
+        HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+      )
+    );
+
+    const response = Response.json({ user: { id: 'user-123' } }, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).not.toBe(null);
+    expect(result).toContain(`${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=`);
+    expect(result).toContain('Max-Age=0');
+  });
+
+  test('alreadyMintedFromHeader=true short-circuits before touching body', async () => {
+    const response = Response.json({ user: { id: 'user-123' } }, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: true,
+    });
+
+    expect(result).toBe(null);
+  });
+
+  test('non-2xx response is skipped', async () => {
+    const response = Response.json({ user: { id: 'user-123' } }, {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).toBe(null);
+  });
+
+  test('wrapped body shape { data: { user } } is matched', async () => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/get-session`, () => HttpResponse.json(createTestSessionData()))
+    );
+
+    const response = Response.json(
+      { data: { user: { id: 'user-123' } } },
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+
+    const result = await maybeRefreshSessionDataAfterResponse({
+      requestCookieHeader: SESSION_TOKEN_COOKIE_HEADER,
+      response,
+      baseUrl: TEST_BASE_URL,
+      cookieConfig: TEST_COOKIE_CONFIG,
+      alreadyMintedFromHeader: false,
+    });
+
+    expect(result).not.toBe(null);
+    expect(result).toContain(`${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=`);
+  });
+});
+
+describe('handleAuthResponse integration', () => {
+  test('simulated mutation response → Response has Set-Cookie: session_data=', async () => {
+    server.use(
+      http.get(`${TEST_BASE_URL}/get-session`, () => HttpResponse.json(createTestSessionData()))
+    );
+
+    // Upstream response: 2xx JSON with user body, no Set-Cookie headers
+    // (mirrors Better Auth's /update-user return shape).
+    const upstream = Response.json(
+      { user: { id: 'user-123', name: 'Updated' } },
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+
+    const processed = await handleAuthResponse(
+      upstream,
+      TEST_BASE_URL,
+      TEST_COOKIE_CONFIG,
+      { cookieHeader: SESSION_TOKEN_COOKIE_HEADER }
+    );
+
+    const setCookies = processed.headers.getSetCookie();
+    const sessionDataCookie = setCookies.find((c) =>
+      c.startsWith(`${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=`)
+    );
+
+    expect(sessionDataCookie).toBeDefined();
+    expect(sessionDataCookie).toContain('HttpOnly');
+  });
+
+  test('no requestContext → no session_data Set-Cookie on plain mutation', async () => {
+    // Without requestContext the fallback is disabled — preserves prior behavior
+    // for callers that haven't opted in.
+    const upstream = Response.json(
+      { user: { id: 'user-123' } },
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+
+    const processed = await handleAuthResponse(
+      upstream,
+      TEST_BASE_URL,
+      TEST_COOKIE_CONFIG
+    );
+
+    const setCookies = processed.headers.getSetCookie();
+    const sessionDataCookie = setCookies.find((c) =>
+      c.startsWith(`${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=`)
+    );
+
+    expect(sessionDataCookie).toBeUndefined();
+  });
+});

--- a/packages/auth/src/server/session/post-response-refresh.ts
+++ b/packages/auth/src/server/session/post-response-refresh.ts
@@ -1,0 +1,129 @@
+import { mintSessionDataFromToken, serializeSessionDataDeletion } from './minting';
+import { NEON_AUTH_SESSION_COOKIE_NAME } from '../constants';
+import type { SessionCookieConfig } from '../config';
+
+interface RefreshArgs {
+  requestCookieHeader: string | null;
+  response: Response;
+  baseUrl: string;
+  cookieConfig: SessionCookieConfig;
+  alreadyMintedFromHeader: boolean;
+}
+
+/**
+ * After a proxy/server-client response, optionally refresh the session_data
+ * cookie cache based on whether the response body carries fresh user/session
+ * state.
+ *
+ * Why this exists:
+ *   Better Auth solves cache staleness by calling `setSessionCookie`
+ *   (which internally calls `setCookieCache`) inside every mutation route
+ *   — so the cookie re-mints naturally on mutations like `/update-user`,
+ *   `/phone-number/verify`, `/update-email` which do NOT rotate the
+ *   opaque session_token. Our wrapper previously keyed re-mint on
+ *   session_token rotation and therefore missed those mutations, serving
+ *   pre-mutation state for up to the cache TTL.
+ *
+ * Ordering: call AFTER `mintSessionDataFromResponse`.
+ *   - If that already minted (token rotation, sign-out), skip.
+ *   - Otherwise, if the response body carries fresh `user`/`session`,
+ *     re-mint from the existing session_token in the request.
+ *   - If re-mint fails (upstream error, invalid token), delete
+ *     session_data so the next read falls through to a fresh fetch.
+ *
+ * @returns A Set-Cookie string to append, or null when no action is needed.
+ */
+export async function maybeRefreshSessionDataAfterResponse(
+  args: RefreshArgs
+): Promise<string | null> {
+  const {
+    requestCookieHeader,
+    response,
+    baseUrl,
+    cookieConfig,
+    alreadyMintedFromHeader,
+  } = args;
+
+  if (alreadyMintedFromHeader) return null;
+  if (!response.ok) return null;
+
+  // Cheap content-type guard: avoid cloning + JSON-parsing HTML / SSE / etc.
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) return null;
+
+  let body: unknown;
+  try {
+    body = await response.clone().json();
+  } catch {
+    return null;
+  }
+
+  if (!carriesUserOrSession(body)) return null;
+
+  const sessionToken = parseSessionTokenFromCookieHeader(requestCookieHeader);
+  if (!sessionToken) return null; // Unauthenticated request — no cache to refresh.
+
+  try {
+    const refreshed = await mintSessionDataFromToken(
+      sessionToken,
+      baseUrl,
+      cookieConfig
+    );
+    if (refreshed) return refreshed;
+  } catch {
+    // Fall through to deletion: clearing the stale cache is safer than
+    // leaving it — next read will fetch fresh state from upstream.
+  }
+
+  return serializeSessionDataDeletion(cookieConfig);
+}
+
+/**
+ * Does this JSON body carry fresh user/session state that should invalidate
+ * the session_data cache?
+ *
+ * Matches both flat (`{user,...}` / `{session,...}`) and wrapped
+ * (`{data:{user,...}}`) shapes — Better Auth uses both depending on route.
+ */
+function carriesUserOrSession(body: unknown): boolean {
+  if (body == null || typeof body !== 'object') return false;
+  const obj = body as Record<string, unknown>;
+
+  if (isNonNullObject(obj.user)) return true;
+  if (isNonNullObject(obj.session)) return true;
+
+  const data = obj.data;
+  if (isNonNullObject(data)) {
+    const d = data as Record<string, unknown>;
+    if (isNonNullObject(d.user)) return true;
+    if (isNonNullObject(d.session)) return true;
+  }
+
+  return false;
+}
+
+function isNonNullObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+/**
+ * Extract a session_token cookie pair (name=value) from a request Cookie
+ * header for passing to `mintSessionDataFromToken`. Returns null when no
+ * session_token is present (unauthenticated request).
+ */
+function parseSessionTokenFromCookieHeader(
+  header: string | null
+): string | null {
+  if (!header) return null;
+  for (const pair of header.split(/;\s*/)) {
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    const name = pair.slice(0, eq).trim();
+    if (name === NEON_AUTH_SESSION_COOKIE_NAME) {
+      // Return as "name=value" — mintSessionDataFromToken expects a
+      // cookie-header fragment, not a bare value.
+      return pair.trim();
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

The `session_data` cookie cache goes stale after user mutations. `mintSessionDataFromResponse` only re-mints when the upstream sets a new `session_token` — but Better Auth doesn't rotate `session_token` on routes like `/update-user`, `/phone-number/verify`, `/update-email`. Result: after a mutation, the 300s cache serves pre-mutation user state until TTL expires.

This was observed in the phone-plugin example app: user verifies phone, UI correctly shows verified, refresh shows the phone-entry input again.

## Fix

Mirror Better Auth's upstream pattern. In Better Auth, every mutation route explicitly calls `setSessionCookie` (which internally re-mints via `setCookieCache`). neon-js's wrapper lost that contract by keying re-mint on `session_token` rotation. This PR adds a post-response refresh step that mints `session_data` whenever a 2xx JSON response carries `user` or `session` in its body — matching Better Auth's own per-mutation contract.

Ordering in the response chain:
1. Existing `mintSessionDataFromResponse` runs first (handles token rotation, sign-out — unchanged)
2. New `maybeRefreshSessionDataAfterResponse` runs as fallback if step 1 didn't already mint
3. On refresh failure, delete `session_data` (forces next read to fetch fresh)

Called from both the proxy path (`handleAuthResponse`) and the server-client path (`createAuthServerInternal`), so both consumer paths are covered.

## Tests

New `post-response-refresh.test.ts` with 6 unit cases plus the `handleAuthResponse` integration flow:
- case 1: 2xx JSON with top-level `user` plus valid session_token returns a remint cookie
- case 2: `/update-user`-shaped `{user, session}` response returns a remint cookie
- case 3: 2xx JSON without `user`/`session` returns null
- case 4: 2xx but non-JSON (text/html) returns null
- case 5: missing session_token in request returns null even for qualifying body
- case 6: minting failure returns a deletion cookie (Max-Age=0)
- plus: `alreadyMintedFromHeader` short-circuit, non-2xx skip, wrapped `{ data: { user } }` body shape, integration flow through `handleAuthResponse`

All 122 tests in `packages/auth` pass. Build + lint are green.

## Refs

- Bug surfaced testing phone-plugin example app
- Better Auth reference: every mutation route calls `setSessionCookie` (see `packages/better-auth/src/api/routes/update-user.ts` and `plugins/phone-number/routes.ts`)
