### PR TITLE
ci: fix prepare-release $GITHUB_OUTPUT multi-line JSON

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -146,8 +146,8 @@ jobs:
             echo "::endgroup::"
           done
 
-          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "versions=$(echo "$VERSIONS" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "tags=$(echo "$TAGS" | jq -c .)" >> "$GITHUB_OUTPUT"
           echo "### Versions" >> "$GITHUB_STEP_SUMMARY"
           echo "$VERSIONS" | jq -r 'to_entries[] | "- **\(.key)** v\(.value)"' >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## Problem

The `Prepare Release` workflow fails in the `Bump versions` step whenever the cascade includes 2+ packages. Example from [run 24723704186](https://github.com/neondatabase/neon-js/actions/runs/24723704186):

```
Invalid format '  "auth": "0.3.0",'
```

The step exits non-zero and no versions are committed.

## Root cause

In `.github/workflows/prepare-release.yml`, the `Bump versions` step builds the `VERSIONS` object and `TAGS` array incrementally with `jq`:

```bash
VERSIONS=$(echo "$VERSIONS" | jq --arg k "$pkg" --arg v "$new" '. + {($k): $v}')
TAGS=$(echo "$TAGS" | jq --arg t "${pkg}@v${new}" '. + [$t]')
```

Neither call passes `-c`, so `jq` emits **pretty-printed, multi-line** JSON once there is more than one entry, e.g.:

```
{
  "auth": "0.3.0",
  "neon-js": "0.5.0"
}
```

Those values were then written directly to `$GITHUB_OUTPUT`:

```bash
echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
```

GitHub Actions parses `$GITHUB_OUTPUT` **line-by-line** against a strict `key=value` (or heredoc) contract. A raw newline in the value ends the `versions=` line prematurely and every subsequent JSON line is treated as a malformed key=value pair — hence `Invalid format '  "auth": "0.3.0",'`.

This only bites when the cascade has 2+ packages (i.e., everything except the `neon-js`-only trigger), which is why the workflow appeared to work initially.

## Fix

Pipe both values through `jq -c` when writing the step outputs so `$GITHUB_OUTPUT` sees single-line compact JSON. Two-line diff:

```diff
-          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "versions=$(echo "$VERSIONS" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "tags=$(echo "$TAGS" | jq -c .)" >> "$GITHUB_OUTPUT"
```

Downstream consumers (`Commit version bumps`, `Create tags`, `Release failure guidance`) already re-parse these outputs via `jq`, so switching from pretty-printed to compact JSON is transparent to them. The `$GITHUB_STEP_SUMMARY` block keeps using the unpipped `$VERSIONS` — that file tolerates multi-line input, so no change needed there.

## Verification

- [ ] Merge this PR.
- [ ] Re-run the **Prepare Release** workflow (same inputs as the failing run: trigger package with a cascade of 2+ packages, e.g. `auth` or `auth-ui`).
- [ ] Confirm the `Bump versions` step succeeds and writes `versions` / `tags` outputs that downstream steps consume cleanly.

Failing run for reference: https://github.com/neondatabase/neon-js/actions/runs/24723704186