### PR TITLE
ci: fix backtick body bug + add prerelease/custom-version inputs to prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,14 +36,20 @@ on:
           - postgrest-js
           - neon-js
       bump:
-        description: 'Version bump type'
-        required: true
+        description: 'Semver bump kind (ignored if `version` is set)'
+        required: false
         type: choice
-        default: patch
+        default: prerelease
         options:
+          - prerelease
           - patch
           - minor
           - major
+      version:
+        description: 'Full custom version string (overrides `bump` if set, e.g. 0.3.0-beta.1). Applies to the TRIGGER package only; cascade packages still use `bump`.'
+        required: false
+        type: string
+        default: ''
       ref:
         description: 'Branch or SHA to release from (default: main)'
         required: false
@@ -126,11 +132,28 @@ jobs:
 
       - name: Bump versions
         id: versions
+        env:
+          BUMP: ${{ inputs.bump }}
+          VERSION_INPUT: ${{ inputs.version }}
+          TRIGGER: ${{ inputs.package }}
         run: |
-          BUMP="${{ inputs.bump }}"
           PACKAGES='${{ steps.cascade.outputs.packages }}'
           VERSIONS='{}'
           TAGS='[]'
+
+          # Version resolution preamble.
+          echo "### Version resolution" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -n "$VERSION_INPUT" ]]; then
+            MODE="CUSTOM_VERSION"
+            echo "- Mode: **CUSTOM_VERSION**" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Trigger package ($TRIGGER) uses explicit version: \`$VERSION_INPUT\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Cascade packages still follow bump kind: \`$BUMP\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            MODE="BUMP"
+            echo "- Mode: **BUMP**" >> "$GITHUB_STEP_SUMMARY"
+            echo "- All packages use bump kind: \`$BUMP\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
 
           for pkg in $(echo "$PACKAGES" | jq -r '.[]'); do
             echo "::group::Bump $pkg ($BUMP)"
@@ -139,15 +162,42 @@ jobs:
             current=$(jq -r '.version' package.json)
             echo "Current version: $current"
 
-            # Strip any prerelease suffix (e.g. 0.2.1-beta.1 -> 0.2.1)
-            base="${current%%-*}"
-            IFS='.' read -r major minor patch <<< "$base"
+            if [[ "$MODE" == "CUSTOM_VERSION" && "$pkg" == "$TRIGGER" ]]; then
+              # Trigger package gets the exact version the user typed.
+              new="$VERSION_INPUT"
+            else
+              # Parse semver: major.minor.patch(-preid.prenum)?
+              if [[ "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-zA-Z][a-zA-Z0-9]*)(\.([0-9]+))?)?$ ]]; then
+                cur_major="${BASH_REMATCH[1]}"
+                cur_minor="${BASH_REMATCH[2]}"
+                cur_patch="${BASH_REMATCH[3]}"
+                pre_id="${BASH_REMATCH[5]:-}"
+                pre_num="${BASH_REMATCH[7]:-}"
+              else
+                echo "::error::Could not parse current version '$current' for package $pkg (expected semver)"
+                exit 1
+              fi
 
-            case "$BUMP" in
-              major) new="$((major+1)).0.0" ;;
-              minor) new="${major}.$((minor+1)).0" ;;
-              patch) new="${major}.${minor}.$((patch+1))" ;;
-            esac
+              case "$BUMP" in
+                major) new="$((cur_major+1)).0.0" ;;
+                minor) new="${cur_major}.$((cur_minor+1)).0" ;;
+                patch) new="${cur_major}.${cur_minor}.$((cur_patch+1))" ;;
+                prerelease)
+                  if [[ -n "$pre_id" ]]; then
+                    # Already on a prerelease track — increment counter (default to 0 if missing).
+                    next_num=$(( ${pre_num:-0} + 1 ))
+                    new="${cur_major}.${cur_minor}.${cur_patch}-${pre_id}.${next_num}"
+                  else
+                    # Stable version — start a new -beta.1 chain.
+                    new="${cur_major}.${cur_minor}.${cur_patch}-beta.1"
+                  fi
+                  ;;
+                *)
+                  echo "::error::Unknown bump kind '$BUMP'"
+                  exit 1
+                  ;;
+              esac
+            fi
 
             echo "New version: $new"
             jq --arg v "$new" '.version = $v' package.json > tmp.json && mv tmp.json package.json
@@ -238,12 +288,18 @@ jobs:
         id: open-pr
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pass these via env rather than inline ${{ }} interpolation so that
+          # backticks / shell metacharacters in the body stay literal when
+          # bash parses the rendered script.
+          PR_BRANCH: ${{ steps.meta.outputs.branch }}
+          PR_TITLE: ${{ steps.meta.outputs.pr_title }}
+          PR_BODY: ${{ steps.meta.outputs.body }}
         run: |
           PR_URL=$(gh pr create \
             --base main \
-            --head "${{ steps.meta.outputs.branch }}" \
-            --title "${{ steps.meta.outputs.pr_title }}" \
-            --body "${{ steps.meta.outputs.body }}" \
+            --head "$PR_BRANCH" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
             --label release)
 
           echo "Opened: $PR_URL"


### PR DESCRIPTION
## Summary

Two fixes for `prepare-release.yml` that surfaced right after PR #80 merged.

### 1. Fix backtick-interpolation bug

The "Open PR + enable auto-merge" step passed the PR body via `--body "${{ steps.meta.outputs.body }}"`. GitHub Actions expands `${{ ... }}` at YAML preprocess time, so backticks baked into the body (e.g. `` `prepare-release.yml` ``, `` `auth` ``, `` `git push origin :refs/tags/<pkg>@v<ver>` ``) arrived raw in a bash double-quoted string and got evaluated as command substitution. Mangled the PR body and spammed "command not found" into the runner log.

**Reproduced on** [run 24782919760](https://github.com/neondatabase/neon-js/actions/runs/24782919760) → opened #83 with a mangled body (now closed).

**Fix:** pass `PR_BRANCH`, `PR_TITLE`, `PR_BODY` via the step's `env:` block. Bash then references them as `$PR_BODY` etc. — pure variable expansion, no re-interpretation.

### 2. Prerelease-aware version handling

Before: workflow accepted `bump: patch | minor | major` and **always stripped** the `-beta.N` suffix. Bumping `0.2.0-beta.1` any way produced a stable version by accident — not what any @neondatabase/* package wants right now.

After:
- `bump` default changed to **`prerelease`** (matches current reality).
- New `prerelease` bump: `0.2.0-beta.1 → 0.2.0-beta.2`. If current is stable, starts a new `-beta.1` chain.
- `patch`/`minor`/`major` still strip the suffix (intentional — graduates from prereleases to stable).
- New optional **`version`** input: type a full custom version (e.g. `0.3.0-beta.1`). Overrides `bump` for the **trigger package only**; cascade packages still follow `bump`.
- Workflow summary logs the resolution mode (`CUSTOM_VERSION` vs `BUMP`) for audit.

### UI mockup of the new dispatch form

```
Package:  [auth             ▾]
Bump:     [prerelease       ▾]   ← default, used unless `version` is set
Version:  [                  ]   ← leave empty for bump math; or type e.g. 0.3.0-beta.1
Ref:      [main              ]
```

## Test plan

- [ ] Dispatch `prepare-release.yml` with `package=postgrest-js`, `bump=prerelease`, `version=''`, `ref=main`. Confirm versions go `0.1.0-alpha.2 → 0.1.0-alpha.3` (and cascade) — no stripped suffix, no `stable` accident.
- [ ] Confirm the opened PR body renders cleanly with literal backticks around filenames + commands — not mangled, no "command not found" in the runner log.
- [ ] Dispatch again with `package=postgrest-js`, `version=0.3.0-beta.1`. Confirm postgrest-js jumps to the exact string typed; cascade packages (e.g. neon-js) follow `bump=prerelease`.
- [ ] Workflow summary shows "Mode: CUSTOM_VERSION" vs "Mode: BUMP" accordingly.

This pull request and its description were written by Isaac.