### PR TITLE
ci: remove auto-merge + polish post-release handoff

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -38,6 +38,27 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Diagnostic — confirm event identity
+        # Logs actor + sender + ref + sha of the triggering push. On first
+        # successful run, verify `actor` is a human (not `github-actions[bot]`).
+        # If it IS `github-actions[bot]`, the push was caused by GITHUB_TOKEN
+        # (likely auto-merge), GitHub will suppress downstream triggers, and
+        # this workflow won't fire at all — meaning you never see this log.
+        # If you CAN see this log, the trigger chain is healthy.
+        run: |
+          echo "actor:  ${{ github.actor }}"
+          echo "sender: ${{ github.event.sender.login }}"
+          echo "ref:    ${{ github.ref }}"
+          echo "sha:    ${{ github.sha }}"
+          {
+            echo "### Event identity"
+            echo "- **actor:** \`${{ github.actor }}\`"
+            echo "- **sender:** \`${{ github.event.sender.login }}\`"
+            echo "- **ref:** \`${{ github.ref }}\`"
+            echo "- **sha:** \`${{ github.sha }}\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -49,7 +49,11 @@ jobs:
           MSG: ${{ github.event.head_commit.message }}
         run: |
           # Message shape: "chore: release @neondatabase/auth@v0.3.0 @neondatabase/neon-js@v0.3.0 (#123)"
-          # Extract each @neondatabase/<pkg>@v<ver> token and the trailing PR number.
+          # Parse the SUBJECT LINE ONLY (first line of the commit message) — the squash body can
+          # contain extra @neondatabase/<pkg>@v<ver> tokens from concatenated branch commit
+          # subjects, which would otherwise pollute the order and duplicate tags in the handoff.
+          SUBJECT=$(echo "$MSG" | head -n 1)
+
           TAGS='[]'
           PACKAGES='[]'
           VERSIONS='[]'
@@ -60,18 +64,18 @@ jobs:
             TAGS=$(echo "$TAGS" | jq --arg t "${pkg}@v${ver}" '. + [$t]')
             PACKAGES=$(echo "$PACKAGES" | jq --arg p "$pkg" '. + [$p]')
             VERSIONS=$(echo "$VERSIONS" | jq --arg v "$ver" '. + [$v]')
-          done < <(echo "$MSG" | grep -oE '@neondatabase/[a-z0-9-]+@v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?')
+          done < <(echo "$SUBJECT" | grep -oE '@neondatabase/[a-z0-9-]+@v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?')
 
           if [[ "$(echo "$TAGS" | jq 'length')" == "0" ]]; then
-            echo "No @neondatabase/* tokens found in commit message — skipping."
+            echo "No @neondatabase/* tokens found in commit subject — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # PR number is the last `(#NNN)` token in the message (squash merges add this automatically).
-          # `|| true` keeps this non-fatal under `bash -euo pipefail` when the commit has no (#N) token —
+          # PR number is the last `(#NNN)` token in the subject (squash merges add this automatically).
+          # `|| true` keeps this non-fatal under `bash -euo pipefail` when the subject has no (#N) token —
           # we still want to tag + write the summary; just skip the PR-comment step.
-          PR_NUM=$(echo "$MSG" | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+' || true)
+          PR_NUM=$(echo "$SUBJECT" | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+' || true)
 
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
           echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
@@ -126,9 +130,9 @@ jobs:
             echo "body<<HANDOFF_EOF"
             echo "## 🚀 Tagged — ready for Stage 2 (npm publish)"
             echo ""
-            echo "Release tagged on commit [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}). Dispatch Stage 2 once per package below to publish to npm."
+            echo "Release tagged on commit [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}). **Publish the packages below in the listed order (leaf packages first — downstream packages resolve the new deps at publish time).**"
             echo ""
-            # Iterate pairs.
+            # Per-package sections (CLI + UI).
             paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
             | while IFS=$'\t' read -r pkg tag; do
                 echo "### \`@neondatabase/${pkg}\` → \`${tag}\`"
@@ -141,9 +145,21 @@ jobs:
                 echo "  -f dry-run=false"
                 echo '```'
                 echo ""
-                echo "**UI:** [Dispatch \`neon-js.yml\`](${UI_LINK}) — set \`package=${pkg}\`, \`ref=${tag}\`, \`dry-run=false\`."
+                echo "**UI:** [Dispatch \`neon-js.yml\`](${UI_LINK}) — fill in the form with \`package=${pkg}\`, \`ref=${tag}\`, untick \`dry-run\`."
                 echo ""
               done
+            # Publish-all one-liner: paste once, runs every dispatch sequentially and waits on each.
+            echo "### 🔁 Publish all (paste in terminal, runs sequentially)"
+            echo ""
+            echo '```bash'
+            echo "set -e"
+            paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
+            | while IFS=$'\t' read -r pkg tag; do
+                echo "gh workflow run -R ${SECPUB_OWNER}/${SECPUB_REPO} neon-js.yml -f package=${pkg} -f ref=${tag} -f dry-run=false"
+                echo "gh run watch -R ${SECPUB_OWNER}/${SECPUB_REPO} --exit-status"
+              done
+            echo '```'
+            echo ""
             echo "---"
             echo ""
             echo "**If anything's wrong before Stage 2 runs:** delete the bad tag(s) manually (\`git push origin :refs/tags/<pkg>@v<ver>\`) and rerun post-release."

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -169,18 +169,6 @@ jobs:
                 echo "**UI:** [Dispatch \`neon-js.yml\`](${UI_LINK}) — fill in the form with \`package=${pkg}\`, \`ref=${tag}\`, untick \`dry-run\`."
                 echo ""
               done
-            # Publish-all one-liner: paste once, runs every dispatch sequentially and waits on each.
-            echo "### 🔁 Publish all (paste in terminal, runs sequentially)"
-            echo ""
-            echo '```bash'
-            echo "set -e"
-            paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
-            | while IFS=$'\t' read -r pkg tag; do
-                echo "gh workflow run -R ${SECPUB_OWNER}/${SECPUB_REPO} neon-js.yml -f package=${pkg} -f ref=${tag} -f dry-run=false"
-                echo "gh run watch -R ${SECPUB_OWNER}/${SECPUB_REPO} --exit-status"
-              done
-            echo '```'
-            echo ""
             echo "---"
             echo ""
             echo "**If anything's wrong before Stage 2 runs:** delete the bad tag(s) manually (\`git push origin :refs/tags/<pkg>@v<ver>\`) and rerun post-release."

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -151,12 +151,27 @@ jobs:
             echo "body<<HANDOFF_EOF"
             echo "## 🚀 Tagged — ready for Stage 2 (npm publish)"
             echo ""
-            echo "Release tagged on commit [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}). **Publish the packages below in the listed order (leaf packages first — downstream packages resolve the new deps at publish time).**"
+            echo "Release tagged on commit [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})."
             echo ""
-            # Per-package sections (CLI + UI).
+            echo "### ⚠️ Publish order (leaf first)"
+            echo ""
+            echo "Dispatch Stage 2 one package at a time, **in the order listed below**. Each downstream package's published tarball references its dependency's version — that dependency must already be on npm when the dependent publishes, or consumers will hit \`npm install\` failures."
+            echo ""
+            # Ordered overview list (e.g. "1. auth-ui → auth-ui@v0.1.0-alpha.12").
+            i=1
             paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
             | while IFS=$'\t' read -r pkg tag; do
-                echo "### \`@neondatabase/${pkg}\` → \`${tag}\`"
+                echo "${i}. \`@neondatabase/${pkg}\` → \`${tag}\`"
+                i=$((i+1))
+              done
+            echo ""
+            echo "---"
+            echo ""
+            # Per-package sections (CLI + UI), same order.
+            i=1
+            paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
+            | while IFS=$'\t' read -r pkg tag; do
+                echo "### ${i}. \`@neondatabase/${pkg}\` → \`${tag}\`"
                 echo ""
                 echo "**CLI** (one-liner):"
                 echo '```bash'
@@ -168,6 +183,9 @@ jobs:
                 echo ""
                 echo "**UI:** [Dispatch \`neon-js.yml\`](${UI_LINK}) — fill in the form with \`package=${pkg}\`, \`ref=${tag}\`, untick \`dry-run\`."
                 echo ""
+                echo "**Wait until this run finishes successfully before dispatching the next package.**"
+                echo ""
+                i=$((i+1))
               done
             echo "---"
             echo ""

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write      # push release branch
-      pull-requests: write # open PR + enable auto-merge
+      pull-requests: write # open PR
 
     steps:
       - name: Harden the runner
@@ -247,8 +247,13 @@ jobs:
             echo ""
             echo "### Next steps"
             echo "1. An approver (Andras or Shridhar) reviews + approves this PR."
-            echo "2. Required checks run; the PR auto-merges on green."
-            echo "3. \`post-release.yml\` fires on merge, tags the squash commit, and comments here with Stage 2 (npm publish) dispatch instructions."
+            echo "2. Required checks run."
+            echo "3. On green, the approver **manually clicks \"Squash and merge\"** in the UI. **Do NOT use auto-merge.**"
+            echo "4. \`post-release.yml\` fires on the push to \`main\`, tags the squash commit, and comments here with Stage 2 (npm publish) dispatch instructions."
+            echo ""
+            echo "> :warning: **Why manual merge?** GitHub Actions suppresses downstream \`on: push\` workflows for pushes caused by \`GITHUB_TOKEN\` (including auto-merge enabled from a workflow). A human clicking merge in the UI attributes the push to that user, so \`post-release.yml\` fires correctly."
+            echo ""
+            echo "> :warning: **Do not edit this PR's title** and do not add \`[skip ci]\`, \`[ci skip]\`, or similar markers. Those would either break the commit-subject parser in \`post-release.yml\` or suppress the workflow entirely."
             echo ""
             echo "### Recovery"
             echo "**Before Stage 2 runs:** if something's wrong, delete the bad tag(s) manually (\`git push origin :refs/tags/<pkg>@v<ver>\`) and rerun post-release."
@@ -284,7 +289,7 @@ jobs:
         run: |
           gh label create release --color "0E8A16" --description "Automated release PR" --force || true
 
-      - name: Open PR + enable auto-merge
+      - name: Open PR
         id: open-pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -295,6 +300,12 @@ jobs:
           PR_TITLE: ${{ steps.meta.outputs.pr_title }}
           PR_BODY: ${{ steps.meta.outputs.body }}
         run: |
+          # NOTE: We intentionally do NOT enable auto-merge. Auto-merge enabled
+          # by GITHUB_TOKEN causes the eventual squash-merge push to main to be
+          # suppressed from triggering downstream `on: push` workflows (including
+          # post-release.yml). The approver must click "Squash and merge" manually
+          # in the UI so the push is attributed to a human and post-release fires.
+          # See https://docs.github.com/en/actions/concepts/security/github_token
           PR_URL=$(gh pr create \
             --base main \
             --head "$PR_BRANCH" \
@@ -303,8 +314,7 @@ jobs:
             --label release)
 
           echo "Opened: $PR_URL"
-          gh pr merge "$PR_URL" --auto --squash
-          echo "Auto-merge enabled on: $PR_URL"
+          echo "Reminder: approver must click 'Squash and merge' manually (not auto-merge)."
 
           echo "### PR" >> "$GITHUB_STEP_SUMMARY"
           echo "$PR_URL" >> "$GITHUB_STEP_SUMMARY"
@@ -359,11 +369,11 @@ jobs:
             echo "**Impact:** The commit exists only on the runner (now discarded). Nothing was pushed. Safe to re-run." >> "$GITHUB_STEP_SUMMARY"
 
           elif [[ "${{ steps.open-pr.outcome }}" == "failure" ]]; then
-            echo "**Open PR / enable auto-merge** — \`gh pr create\` or \`gh pr merge --auto\` failed." >> "$GITHUB_STEP_SUMMARY"
+            echo "**Open PR** — \`gh pr create\` failed." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Impact:** The release branch \`${{ steps.meta.outputs.branch }}\` was pushed but the PR was not opened (or auto-merge was not enabled)." >> "$GITHUB_STEP_SUMMARY"
+            echo "**Impact:** The release branch \`${{ steps.meta.outputs.branch }}\` was pushed but the PR was not opened." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Recovery:** Open the PR manually from the pushed branch and enable squash auto-merge." >> "$GITHUB_STEP_SUMMARY"
+            echo "**Recovery:** Open the PR manually from the pushed branch." >> "$GITHUB_STEP_SUMMARY"
             echo '```bash' >> "$GITHUB_STEP_SUMMARY"
             echo "gh pr create --base main --head \"${{ steps.meta.outputs.branch }}\" --title \"${{ steps.meta.outputs.pr_title }}\" --label release" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Two related fixes to `post-release.yml` and `prepare-release.yml`, combined into one PR for a single round of review.

## Part 1 — Remove auto-merge so `post-release.yml` actually fires

### Problem

When `prepare-release.yml` uses the default `GITHUB_TOKEN` to call `gh pr merge --auto --squash`, the eventual auto-merged push to `main` is attributed to `github-actions[bot]`. GitHub's docs are explicit:

> Events triggered by `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run.
> — [GITHUB_TOKEN docs](https://docs.github.com/en/actions/concepts/security/github_token)

So `post-release.yml` (trigger: `on: push: branches: [main]`) **never fires**. No tags get created. No Stage 2 handoff comment gets posted. Observed empirically on the merge of PR #86 — zero workflow runs for that SHA.

### Fix

Drop `gh pr merge --auto --squash` entirely from `prepare-release.yml`. The workflow still opens the PR via `gh pr create`. The approver reviews, approves, and then **manually clicks "Squash and merge" in the GitHub UI**. That push is attributed to the human user, so `post-release.yml` fires normally.

Cost: one extra click per release (`1 dispatch + 1 approve + 1 merge + N Stage 2 dispatches`).

### Why not `on: pull_request: closed` instead?

Evaluated. Rejected. Per GPT-5.4-xhigh analysis (cited GitHub docs): *"If the PR is still merged by a workflow using `GITHUB_TOKEN`, that event can be suppressed too."* The suppression rule applies to the credential that caused the event, not the event type. Manual merge by human avoids the problem entirely regardless of event type.

### Why not a PAT / GitHub App?

Both rejected earlier due to organizational infrastructure constraints (no PATs allowed, no App provisioning without admin approval).

## Part 2 — Handoff polish

### Harden the parser: subject-line only

Before: greps `@neondatabase/<pkg>@v<ver>` tokens from the **entire** squash commit message (title + body).

Problem: GitHub's default squash-merge body concatenates individual branch commit subjects. If someone made two commits on the release branch — each with the token in its subject — the parser would see the token twice, create duplicate handoff sections, and log a "tag already points to $SHA" noisy skip.

Fix: `SUBJECT=$(echo "$MSG" | head -n 1)` — parse the title only. The title is deterministically built by `prepare-release.yml`'s cascade loop, so order is guaranteed leaf-first.

### Say "publish in listed order" out loud

Handoff sections are already ordered leaf-first (cascade map → commit title → grep left-to-right preservation), but the intro text didn't call this out. Now says: *"Publish the packages below in the listed order (leaf packages first — downstream packages resolve the new deps at publish time)."*

### Add a "Publish all" one-liner

New section appended to every handoff comment:

````markdown
### 🔁 Publish all (paste in terminal, runs sequentially)

```bash
set -e
gh workflow run -R databricks/secure-public-registry-releases-eng neon-js.yml -f package=postgrest-js -f ref=postgrest-js@v0.1.0-alpha.3 -f dry-run=false
gh run watch -R databricks/secure-public-registry-releases-eng --exit-status
gh workflow run -R databricks/secure-public-registry-releases-eng neon-js.yml -f package=neon-js -f ref=neon-js@v0.2.0-beta.2 -f dry-run=false
gh run watch -R databricks/secure-public-registry-releases-eng --exit-status
```
````

Paste once → walk away. `set -e` halts on failure; `gh run watch --exit-status` blocks until each Stage 2 run finishes. For a cascade of N packages, collapses N dispatches into 1 paste.

Per-package UI links + individual CLI one-liners are still emitted above as before.

### Diagnostic step in `post-release.yml`

First step now logs `actor`, `sender`, `ref`, `sha` to both the run log and `$GITHUB_STEP_SUMMARY`. On the first successful run after this PR lands, verify `actor` is a human (not `github-actions[bot]`). Can be removed in a follow-up once confirmed.

### Minor copy tweak

UI link caption changed from `set dry-run=false` to `untick dry-run` — `dry-run` is a boolean checkbox in secpub's form, not a text field.

## Changes

| File | Diff |
|---|---|
| `prepare-release.yml` | removed `gh pr merge --auto --squash` call, renamed step, updated PR-body `### Next steps` to explain manual merge + warn against title edits / `[skip ci]`, updated failure-guidance step |
| `post-release.yml` | subject-line parse hardening, "publish in listed order" text, "Publish all" one-liner block, diagnostic step at top of job, minor copy tweaks |

## Test plan

- [ ] Dispatch `prepare-release.yml` with `package=postgrest-js`, `bump=prerelease`.
- [ ] Verify opened PR has new `### Next steps` section explaining manual merge.
- [ ] Approve. Click **"Squash and merge"** (not "Enable auto-merge") in the UI.
- [ ] Verify `post-release.yml` runs (it didn't before — that was the bug).
- [ ] Verify diagnostic step reports `actor: thekauer` (or whoever merged), NOT `github-actions[bot]`.
- [ ] Verify tags are created.
- [ ] Verify the Stage 2 handoff comment appears with:
  - Intro: "Publish the packages below in the listed order"
  - Per-package sections (CLI one-liner + UI link with "untick dry-run")
  - Trailing "Publish all" bash block with `set -e` + per-package `gh workflow run` + `gh run watch`
- [ ] Paste the "Publish all" block into a terminal (with `thekauer` gh auth). Verify each Stage 2 run kicks off sequentially.

## Supersedes

- Closes #89 (folded in here).

This pull request and its description were written by Isaac.