### PR TITLE
ci: remove auto-merge so post-release fires (require manual Squash and merge)

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -38,6 +38,27 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Diagnostic — confirm event identity
+        # Logs actor + sender + ref + sha of the triggering push. On first
+        # successful run, verify `actor` is a human (not `github-actions[bot]`).
+        # If it IS `github-actions[bot]`, the push was caused by GITHUB_TOKEN
+        # (likely auto-merge), GitHub will suppress downstream triggers, and
+        # this workflow won't fire at all — meaning you never see this log.
+        # If you CAN see this log, the trigger chain is healthy.
+        run: |
+          echo "actor:  ${{ github.actor }}"
+          echo "sender: ${{ github.event.sender.login }}"
+          echo "ref:    ${{ github.ref }}"
+          echo "sha:    ${{ github.sha }}"
+          {
+            echo "### Event identity"
+            echo "- **actor:** \`${{ github.actor }}\`"
+            echo "- **sender:** \`${{ github.event.sender.login }}\`"
+            echo "- **ref:** \`${{ github.ref }}\`"
+            echo "- **sha:** \`${{ github.sha }}\`"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: write      # push release branch
-      pull-requests: write # open PR + enable auto-merge
+      pull-requests: write # open PR
 
     steps:
       - name: Harden the runner
@@ -247,8 +247,13 @@ jobs:
             echo ""
             echo "### Next steps"
             echo "1. An approver (Andras or Shridhar) reviews + approves this PR."
-            echo "2. Required checks run; the PR auto-merges on green."
-            echo "3. \`post-release.yml\` fires on merge, tags the squash commit, and comments here with Stage 2 (npm publish) dispatch instructions."
+            echo "2. Required checks run."
+            echo "3. On green, the approver **manually clicks \"Squash and merge\"** in the UI. **Do NOT use auto-merge.**"
+            echo "4. \`post-release.yml\` fires on the push to \`main\`, tags the squash commit, and comments here with Stage 2 (npm publish) dispatch instructions."
+            echo ""
+            echo "> :warning: **Why manual merge?** GitHub Actions suppresses downstream \`on: push\` workflows for pushes caused by \`GITHUB_TOKEN\` (including auto-merge enabled from a workflow). A human clicking merge in the UI attributes the push to that user, so \`post-release.yml\` fires correctly."
+            echo ""
+            echo "> :warning: **Do not edit this PR's title** and do not add \`[skip ci]\`, \`[ci skip]\`, or similar markers. Those would either break the commit-subject parser in \`post-release.yml\` or suppress the workflow entirely."
             echo ""
             echo "### Recovery"
             echo "**Before Stage 2 runs:** if something's wrong, delete the bad tag(s) manually (\`git push origin :refs/tags/<pkg>@v<ver>\`) and rerun post-release."
@@ -284,7 +289,7 @@ jobs:
         run: |
           gh label create release --color "0E8A16" --description "Automated release PR" --force || true
 
-      - name: Open PR + enable auto-merge
+      - name: Open PR
         id: open-pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -295,6 +300,12 @@ jobs:
           PR_TITLE: ${{ steps.meta.outputs.pr_title }}
           PR_BODY: ${{ steps.meta.outputs.body }}
         run: |
+          # NOTE: We intentionally do NOT enable auto-merge. Auto-merge enabled
+          # by GITHUB_TOKEN causes the eventual squash-merge push to main to be
+          # suppressed from triggering downstream `on: push` workflows (including
+          # post-release.yml). The approver must click "Squash and merge" manually
+          # in the UI so the push is attributed to a human and post-release fires.
+          # See https://docs.github.com/en/actions/concepts/security/github_token
           PR_URL=$(gh pr create \
             --base main \
             --head "$PR_BRANCH" \
@@ -303,8 +314,7 @@ jobs:
             --label release)
 
           echo "Opened: $PR_URL"
-          gh pr merge "$PR_URL" --auto --squash
-          echo "Auto-merge enabled on: $PR_URL"
+          echo "Reminder: approver must click 'Squash and merge' manually (not auto-merge)."
 
           echo "### PR" >> "$GITHUB_STEP_SUMMARY"
           echo "$PR_URL" >> "$GITHUB_STEP_SUMMARY"
@@ -359,11 +369,11 @@ jobs:
             echo "**Impact:** The commit exists only on the runner (now discarded). Nothing was pushed. Safe to re-run." >> "$GITHUB_STEP_SUMMARY"
 
           elif [[ "${{ steps.open-pr.outcome }}" == "failure" ]]; then
-            echo "**Open PR / enable auto-merge** — \`gh pr create\` or \`gh pr merge --auto\` failed." >> "$GITHUB_STEP_SUMMARY"
+            echo "**Open PR** — \`gh pr create\` failed." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Impact:** The release branch \`${{ steps.meta.outputs.branch }}\` was pushed but the PR was not opened (or auto-merge was not enabled)." >> "$GITHUB_STEP_SUMMARY"
+            echo "**Impact:** The release branch \`${{ steps.meta.outputs.branch }}\` was pushed but the PR was not opened." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Recovery:** Open the PR manually from the pushed branch and enable squash auto-merge." >> "$GITHUB_STEP_SUMMARY"
+            echo "**Recovery:** Open the PR manually from the pushed branch." >> "$GITHUB_STEP_SUMMARY"
             echo '```bash' >> "$GITHUB_STEP_SUMMARY"
             echo "gh pr create --base main --head \"${{ steps.meta.outputs.branch }}\" --title \"${{ steps.meta.outputs.pr_title }}\" --label release" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

When `prepare-release.yml` uses the default `GITHUB_TOKEN` to call `gh pr merge --auto --squash`, the eventual auto-merged push to `main` is attributed to `github-actions[bot]`. GitHub's docs are explicit:

> Events triggered by `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run.
> — [GITHUB_TOKEN docs](https://docs.github.com/en/actions/concepts/security/github_token)

So `post-release.yml` (trigger: `on: push: branches: [main]`) **never fires**. No tags get created. No Stage 2 handoff comment gets posted. Observed empirically on the merge of PR #86 (zero workflow runs for that SHA).

## Fix

Drop `gh pr merge --auto --squash` entirely from `prepare-release.yml`. The workflow still opens the PR via `gh pr create`. The approver reviews, approves, and then **manually clicks "Squash and merge" in the GitHub UI**. That push is attributed to the human user, so `post-release.yml` fires normally.

Cost: one extra click per release (`1 dispatch + 1 approve + 1 merge + N Stage 2 dispatches`).

## Changes

- **`prepare-release.yml`** — removed `gh pr merge --auto --squash` call. Renamed step from `"Open PR + enable auto-merge"` to `"Open PR"`. Updated the PR body `"Next steps"` section to say "manually click Squash and merge" + explain why + warn against editing the title or adding `[skip ci]` markers. Updated the failure-guidance step to drop auto-merge recovery instructions.
- **`post-release.yml`** — added a first-step diagnostic that logs the triggering event's `actor`, `sender`, `ref`, `sha` to the workflow summary. On first successful run, verify `actor` is a human (not `github-actions[bot]`). Can be removed once confirmed.

## Why not `on: pull_request: closed` (Option 1)?

Also evaluated. Rejected based on GPT-5.4-xhigh analysis (cited GitHub docs):

> If the PR is still merged by a workflow using `GITHUB_TOKEN`, that event can be suppressed too. And `workflow_run` is not a clean substitute if what you actually need is "run after the merge landed on main."

The GITHUB_TOKEN suppression rule doesn't care whether the event is `push` or `pull_request.closed` — it cares about the credential that caused it. So auto-merge by workflow token can suppress both. Manual merge by human avoids the problem entirely, regardless of event type.

## Why not a PAT / GitHub App?

Both rejected earlier due to organizational infrastructure constraints (no PATs allowed, no App provisioning without admin approval).

## Test plan

- [ ] Dispatch `prepare-release.yml` with `package=postgrest-js`, `bump=prerelease`.
- [ ] Verify the opened PR body includes the new `Next steps` and `Why manual merge` warnings.
- [ ] Approve the PR.
- [ ] Click **"Squash and merge"** (not "Enable auto-merge"). Verify the squash commit lands on main.
- [ ] Verify `post-release.yml` runs.
- [ ] Verify the diagnostic step reports `actor: thekauer` (or whoever merged) — NOT `github-actions[bot]`.
- [ ] Verify tags `postgrest-js@v0.1.0-alpha.3` and `neon-js@v0.2.0-beta.2` are created.
- [ ] Verify the Stage 2 handoff comment is posted on the merged PR.
- [ ] Once verified end-to-end, the diagnostic step can be removed in a follow-up.

## Related PRs

- #84 (merged) — prerelease/custom-version inputs + backtick fix
- #87 (draft) — handoff enhancements (subject-line parse, "publish all" one-liner). **Depends on this PR landing first** to actually exercise post-release.yml.

This pull request and its description were written by Isaac.