### PR TITLE
ci(post-release): fix GITHUB_OUTPUT multi-line JSON crash

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -98,9 +98,11 @@ jobs:
           # we still want to tag + write the summary; just skip the PR-comment step.
           PR_NUM=$(echo "$SUBJECT" | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+' || true)
 
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
-          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
-          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
+          # jq without -c pretty-prints with newlines, which breaks $GITHUB_OUTPUT's
+          # single-line key=value format ("Invalid format" error). Compact JSON fixes it.
+          echo "tags=$(echo "$TAGS" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "packages=$(echo "$PACKAGES" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "versions=$(echo "$VERSIONS" | jq -c .)" >> "$GITHUB_OUTPUT"
           echo "pr_number=${PR_NUM:-}" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Fixes a `$GITHUB_OUTPUT` serialization bug in `post-release.yml` that made the parse step fail on the first real release (run [24789521724](https://github.com/neondatabase/neon-js/actions/runs/24789521724)).

## Root cause

`jq` without `-c` pretty-prints JSON arrays across multiple lines:

```json
[
  "postgrest-js@v0.1.0-alpha.3",
  "neon-js@v0.2.0-beta.2"
]
```

When written to `$GITHUB_OUTPUT` via `echo "tags=$TAGS"`, that multi-line value breaks the single-line `key=value` format GitHub Actions requires:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '  "postgrest-js@v0.1.0-alpha.3",'
```

The exact same bug was fixed in `prepare-release.yml` via PR #79 (`ci: serialize release outputs as compact JSON`). `post-release.yml` was added in a separate PR and missed inheriting that lesson.

## Fix

Pipe each output JSON through `jq -c .` for compact single-line encoding before writing to `$GITHUB_OUTPUT`:

```yaml
echo "tags=$(echo "$TAGS" | jq -c .)" >> "$GITHUB_OUTPUT"
echo "packages=$(echo "$PACKAGES" | jq -c .)" >> "$GITHUB_OUTPUT"
echo "versions=$(echo "$VERSIONS" | jq -c .)" >> "$GITHUB_OUTPUT"
```

Inline comment added to explain why (so future edits don't reintroduce the bug).

## Test plan

- [ ] Merge this PR (manual Squash and merge — same rule as before).
- [ ] Dispatch `prepare-release.yml` with `package=postgrest-js`, `bump=prerelease`, `version=(blank)`, `ref=main`. Approve + manually merge.
- [ ] Verify `post-release.yml` runs to completion (not just the Parse step — all the way through tag creation + handoff comment).
- [ ] Verify the tagged commit has the expected tags (`postgrest-js@v0.1.0-alpha.X`, `neon-js@v0.2.0-beta.Y`).
- [ ] Verify the handoff comment appears on the merged PR with the numbered ordered list.

## Related

- Exposed by run 24789521724 (merge of PR #90, reverted via #91).
- Same pattern as #79 applied to post-release.yml.

This pull request and its description were written by Isaac.