### PR TITLE
ci: make act work locally for workflow testing

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,3 @@
+-P neondatabase-protected-runner-group=catthehacker/ubuntu:medium-latest
+-P linux-ubuntu-latest=catthehacker/ubuntu:medium-latest
+-P ubuntu-latest=catthehacker/ubuntu:medium-latest

--- a/.github/act/README.md
+++ b/.github/act/README.md
@@ -1,0 +1,55 @@
+# Local act runbook
+
+Run GitHub Actions workflows locally with [nektos/act](https://github.com/nektos/act) (invoked via `gh act`).
+
+Steps that require live GitHub API access (git push to origin, `gh pr create`, `gh pr comment`, `gh label create`, role-check) are guarded with `if: env.ACT != 'true'` and are automatically skipped when act sets `ACT=true`. Everything else — version bumps, cascade computation, PR-body rendering, handoff-message construction, and `$GITHUB_STEP_SUMMARY` writes — runs normally, giving you full local visibility.
+
+## Prerequisites
+
+```bash
+# Install act extension for gh
+gh extension install nektos/gh-act
+```
+
+The `.actrc` at the repo root maps all custom runner labels to `catthehacker/ubuntu:medium-latest`, which ships with `gh`, `node`, `pnpm`, and `jq` pre-installed.
+
+## Commands
+
+### Test `post-release.yml` end-to-end
+
+Exercises: parse release metadata from commit message, tag-decision logic, Build Stage 2 handoff message, write handoff to `$GITHUB_STEP_SUMMARY`. Tags are NOT pushed (skipped under act).
+
+```bash
+gh act push \
+  -W .github/workflows/post-release.yml \
+  -j tag-and-handoff \
+  --eventpath .github/act/push-release.json
+```
+
+### Test `prepare-release.yml` end-to-end
+
+Exercises: ref validation, cascade computation, version bumps (the critical multi-package JSON step), PR-body construction. No push to origin, no `gh pr create` (skipped under act).
+
+```bash
+gh act workflow_dispatch \
+  -W .github/workflows/prepare-release.yml \
+  -j prepare \
+  --eventpath .github/act/workflow-dispatch.json
+```
+
+## What you will see
+
+- Computed version bumps for each package in the cascade, printed to the step log.
+- The rendered PR-body string and handoff comment body written to `$GITHUB_STEP_SUMMARY` (act streams this to stdout).
+- Skipped steps are shown as `SKIP` in the act output — that is expected.
+
+## What does NOT happen locally
+
+- No git push to origin.
+- No `gh pr create` / `gh pr comment`.
+- No `gh label create`.
+- No actor role check against the GitHub API.
+
+## Interpreting failures
+
+If any non-skipped step fails locally, that is a real bug to fix before pushing. The version-bump step (`Bump versions`) is the most important to validate — it is where multi-line JSON output bugs have bitten us before (see PR #92).

--- a/.github/act/push-release.json
+++ b/.github/act/push-release.json
@@ -1,0 +1,11 @@
+{
+  "ref": "refs/heads/main",
+  "repository": { "default_branch": "main", "name": "neon-js", "full_name": "neondatabase/neon-js" },
+  "pusher": { "name": "thekauer" },
+  "sender": { "login": "thekauer", "type": "User" },
+  "head_commit": {
+    "id": "fakesha0000000000000000000000000000000000",
+    "message": "chore: release @neondatabase/postgrest-js@v0.1.0-alpha.3 @neondatabase/neon-js@v0.2.0-beta.2 (#90)",
+    "author": { "name": "thekauer", "email": "thekauer@users.noreply.github.com" }
+  }
+}

--- a/.github/act/workflow-dispatch.json
+++ b/.github/act/workflow-dispatch.json
@@ -1,0 +1,8 @@
+{
+  "inputs": {
+    "package": "postgrest-js",
+    "bump": "prerelease",
+    "version": "",
+    "ref": "main"
+  }
+}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -105,7 +105,7 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Create + push tags on merge commit
-        if: steps.parse.outputs.skip != 'true'
+        if: steps.parse.outputs.skip != 'true' && env.ACT != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -203,7 +203,7 @@ jobs:
           SUMMARY_EOF
 
       - name: Post handoff as PR comment
-        if: steps.parse.outputs.skip != 'true' && steps.parse.outputs.pr_number != ''
+        if: steps.parse.outputs.skip != 'true' && steps.parse.outputs.pr_number != '' && env.ACT != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUM: ${{ steps.parse.outputs.pr_number }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -82,6 +82,7 @@ jobs:
           egress-policy: audit
 
       - name: Check actor has admin/maintain role
+        if: env.ACT != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -280,10 +281,12 @@ jobs:
 
       - name: Push release branch
         id: push
+        if: env.ACT != 'true'
         run: |
           git push origin "HEAD:${{ steps.meta.outputs.branch }}"
 
       - name: Ensure `release` label exists
+        if: env.ACT != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -291,6 +294,7 @@ jobs:
 
       - name: Open PR
         id: open-pr
+        if: env.ACT != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           # Pass these via env rather than inline ${{ }} interpolation so that


### PR DESCRIPTION
## Summary

- Add `.actrc` mapping all custom runner labels to `catthehacker/ubuntu:medium-latest` (ships `gh`, `node`, `pnpm`, `jq`)
- Add `if: env.ACT != 'true'` guards to git-write and gh-write steps in both `prepare-release.yml` and `post-release.yml` so they are skipped when running locally under act
- Add `.github/act/` with event fixtures (`push-release.json`, `workflow-dispatch.json`) and a tight runbook README

## Motivation

PR #92 introduced a compact-JSON fix that was only caught after pushing because there was no way to run the release workflows locally. This PR makes that possible: version bumps, cascade computation, PR-body rendering, and handoff-message construction all execute under act; only steps that genuinely need live GitHub API access (git push to origin, `gh pr create`, `gh pr comment`, actor role check) are skipped.

## Runbook

```bash
# Test post-release.yml (parse + handoff build + summary write)
gh act push \
  -W .github/workflows/post-release.yml \
  -j tag-and-handoff \
  --eventpath .github/act/push-release.json

# Test prepare-release.yml (cascade + bump + metadata + PR-body)
gh act workflow_dispatch \
  -W .github/workflows/prepare-release.yml \
  -j prepare \
  --eventpath .github/act/workflow-dispatch.json
```

## Test plan

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/prepare-release.yml'))"` passes (verified)
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/post-release.yml'))"` passes (verified)
- [ ] Run `gh act workflow_dispatch` for `prepare-release.yml` locally and confirm version bumps are logged and no auth errors
- [ ] Run `gh act push` for `post-release.yml` locally and confirm handoff message appears in step summary output

Fixes: #0000
See also: PR #92 (compact-JSON bug that would have been caught locally with this in place)

This pull request and its description were written by Isaac.