### PR TITLE
chore(deps): pin fastify >= 5.8.5 (GHSA-247c-9743-5963)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
       "next": "16.2.3",
       "defu": "6.1.7",
       "vite": "7.3.2",
-      "fastify": "5.8.3"
+      "fastify": ">=5.8.5"
     },
     "supportedArchitectures": {
       "os": ["linux", "darwin", "win32"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   next: 16.2.3
   defu: 6.1.7
   vite: 7.3.2
-  fastify: 5.8.3
+  fastify: '>=5.8.5'
 
 importers:
 
@@ -5337,13 +5337,13 @@ packages:
   fastify-metrics@10.6.0:
     resolution: {integrity: sha512-QIPncCnwBOEObMn+VaRhsBC1ox8qEsaiYF2sV/A1UbXj7ic70W8/HNn/hlEC2W8JQbBeZMx++o1um2fPfhsFDQ==}
     peerDependencies:
-      fastify: 5.8.3
+      fastify: '>=5.8.5'
 
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
 
-  fastify@5.8.3:
-    resolution: {integrity: sha512-XJXpRQ41+rsJ/GLeP9vyDC+fBXilcTlEXokMSexkdEkla4uf7ZQNaI5xl3el+kW5TZQulqYxLr659ey/KX7XmQ==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -11431,8 +11431,8 @@ snapshots:
       '@sinclair/typebox': 0.31.28
       close-with-grace: 2.5.0
       crypto-js: 4.2.0
-      fastify: 5.8.3
-      fastify-metrics: 10.6.0(fastify@5.8.3)
+      fastify: 5.8.5
+      fastify-metrics: 10.6.0(fastify@5.8.5)
       pg: '@supabase/pg@0.0.3(@supabase/pg@0.0.3)'
       pg-connection-string: 2.12.0
       pg-format: 1.0.4
@@ -13535,15 +13535,15 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fastify-metrics@10.6.0(fastify@5.8.3):
+  fastify-metrics@10.6.0(fastify@5.8.5):
     dependencies:
-      fastify: 5.8.3
+      fastify: 5.8.5
       fastify-plugin: 4.5.1
       prom-client: 14.2.0
 
   fastify-plugin@4.5.1: {}
 
-  fastify@5.8.3:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0


### PR DESCRIPTION
## Summary
- Adds pnpm override pinning `fastify` to `>=5.8.5` to fix GHSA-247c-9743-5963 / CVE-2026-33806.
- fastify is transitive via `@supabase/postgres-meta` and `fastify-metrics`.
- 5.8.5 is API-compatible with the 5.8.3 already in the lockfile — patch-level bump on the same major line.

## Test plan
- [x] pnpm install succeeds
- [x] pnpm-lock.yaml shows fastify >= 5.8.5
- [x] OSV query returns empty for resolved version
- [x] typecheck passes on packages/neon-js (CLI that uses postgres-meta)
- [ ] CI audit step clears

This pull request and its description were written by Isaac.