### PR TITLE
ci(release): support all-package releases

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -148,6 +148,12 @@ jobs:
           SECPUB_OWNER="databricks"
           SECPUB_REPO="secure-public-registry-releases-eng"
           UI_LINK="${GITHUB_SERVER_URL}/${SECPUB_OWNER}/${SECPUB_REPO}/actions/workflows/neon-js.yml"
+          ALL_RELEASE_PACKAGES='["postgrest-js","auth-ui","auth","neon-js"]'
+          IS_ALL_RELEASE=false
+          if jq -e --argjson packages "$PACKAGES" --argjson all "$ALL_RELEASE_PACKAGES" -n '$packages == $all' >/dev/null; then
+            IS_ALL_RELEASE=true
+          fi
+          ALL_REF=$(jq -rn --argjson packages "$PACKAGES" --argjson tags "$TAGS" '($packages | index("neon-js")) as $idx | if $idx == null then empty else $tags[$idx] end')
 
           {
             echo "body<<HANDOFF_EOF"
@@ -155,42 +161,64 @@ jobs:
             echo ""
             echo "Release tagged on commit [\`${GITHUB_SHA:0:7}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})."
             echo ""
-            echo "### ⚠️ Publish order (leaf first)"
-            echo ""
-            echo "Dispatch Stage 2 one package at a time, **in the order listed below**. Each downstream package's published tarball references its dependency's version — that dependency must already be on npm when the dependent publishes, or consumers will hit \`npm install\` failures."
-            echo ""
-            # Ordered overview list (e.g. "1. auth-ui → auth-ui@v0.1.0-alpha.12").
-            i=1
-            paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
-            | while IFS=$'\t' read -r pkg tag; do
-                echo "${i}. \`@neondatabase/${pkg}\` → \`${tag}\`"
-                i=$((i+1))
-              done
-            echo ""
-            echo "---"
-            echo ""
-            # Per-package sections (CLI + UI), same order.
-            i=1
-            paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
-            | while IFS=$'\t' read -r pkg tag; do
-                echo "### ${i}. \`@neondatabase/${pkg}\` → \`${tag}\`"
-                echo ""
-                echo "**CLI** (one-liner):"
-                echo '```bash'
-                echo "gh workflow run -R ${SECPUB_OWNER}/${SECPUB_REPO} neon-js.yml \\"
-                echo "  -f package=${pkg} \\"
-                echo "  -f ref=${tag} \\"
-                echo "  -f dry-run=false"
-                echo '```'
-                echo ""
-                echo "**UI:** [Dispatch \`neon-js.yml\`](${UI_LINK}) — fill in the form with \`package=${pkg}\`, \`ref=${tag}\`, untick \`dry-run\`."
-                echo ""
-                echo "**Wait until this run finishes successfully before dispatching the next package.**"
-                echo ""
-                i=$((i+1))
-              done
-            echo "---"
-            echo ""
+            if [[ "$IS_ALL_RELEASE" == "true" ]]; then
+              echo "### Full release set"
+              echo ""
+              echo "Dispatch Stage 2 once for the full release set. Use the \`neon-js\` tag as the ref; all tags point at the same merge commit."
+              echo ""
+              paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
+              | while IFS=$'\t' read -r pkg tag; do
+                  echo "- \`@neondatabase/${pkg}\` → \`${tag}\`"
+                done
+              echo ""
+              echo "**CLI** (one-liner):"
+              echo '```bash'
+              echo "gh workflow run -R ${SECPUB_OWNER}/${SECPUB_REPO} neon-js.yml \\"
+              echo "  -f package=all \\"
+              echo "  -f ref=${ALL_REF} \\"
+              echo "  -f dry-run=false"
+              echo '```'
+              echo ""
+              echo "**UI:** [Dispatch \`neon-js.yml\`](${UI_LINK}) — fill in the form with \`package=all\`, \`ref=${ALL_REF}\`, untick \`dry-run\`."
+              echo ""
+            else
+              echo "### ⚠️ Publish order (leaf first)"
+              echo ""
+              echo "Dispatch Stage 2 one package at a time, **in the order listed below**. Each downstream package's published tarball references its dependency's version — that dependency must already be on npm when the dependent publishes, or consumers will hit \`npm install\` failures."
+              echo ""
+              # Ordered overview list (e.g. "1. auth-ui → auth-ui@v0.1.0-alpha.12").
+              i=1
+              paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
+              | while IFS=$'\t' read -r pkg tag; do
+                  echo "${i}. \`@neondatabase/${pkg}\` → \`${tag}\`"
+                  i=$((i+1))
+                done
+              echo ""
+              echo "---"
+              echo ""
+              # Per-package sections (CLI + UI), same order.
+              i=1
+              paste <(echo "$PACKAGES" | jq -r '.[]') <(echo "$TAGS" | jq -r '.[]') \
+              | while IFS=$'\t' read -r pkg tag; do
+                  echo "### ${i}. \`@neondatabase/${pkg}\` → \`${tag}\`"
+                  echo ""
+                  echo "**CLI** (one-liner):"
+                  echo '```bash'
+                  echo "gh workflow run -R ${SECPUB_OWNER}/${SECPUB_REPO} neon-js.yml \\"
+                  echo "  -f package=${pkg} \\"
+                  echo "  -f ref=${tag} \\"
+                  echo "  -f dry-run=false"
+                  echo '```'
+                  echo ""
+                  echo "**UI:** [Dispatch \`neon-js.yml\`](${UI_LINK}) — fill in the form with \`package=${pkg}\`, \`ref=${tag}\`, untick \`dry-run\`."
+                  echo ""
+                  echo "**Wait until this run finishes successfully before dispatching the next package.**"
+                  echo ""
+                  i=$((i+1))
+                done
+              echo "---"
+              echo ""
+            fi
             echo "**If anything's wrong before Stage 2 runs:** delete the bad tag(s) manually (\`git push origin :refs/tags/<pkg>@v<ver>\`) and rerun post-release."
             echo ""
             echo "**If anything's wrong after Stage 2 publishes:** npm versions are immutable, so cut a new patch release with the fix — do NOT try to revert the release commit (npm will reject republishing the same version)."

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -35,6 +35,7 @@ on:
           - auth-ui
           - postgrest-js
           - neon-js
+          - all
       bump:
         description: 'Semver bump kind (ignored if `version` is set)'
         required: false
@@ -94,10 +95,17 @@ jobs:
 
       - name: Validate ref input
         id: validate
+        env:
+          PACKAGE: ${{ inputs.package }}
+          VERSION_INPUT: ${{ inputs.version }}
         run: |
           REF="${{ inputs.ref || 'main' }}"
           if [[ "$REF" =~ ^[0-9a-f]{7,40}$ ]]; then
             echo "::error::Raw SHA refs are not supported. Please use a branch name (e.g., 'main')."
+            exit 1
+          fi
+          if [[ "$PACKAGE" == "all" && -n "$VERSION_INPUT" ]]; then
+            echo "::error::Custom \`version\` is not supported with \`package=all\`; use a bump kind so every public package is bumped once from its own current version."
             exit 1
           fi
 
@@ -117,6 +125,7 @@ jobs:
             auth-ui)      PACKAGES='["auth-ui","auth","neon-js"]' ;;
             auth)         PACKAGES='["auth","neon-js"]' ;;
             neon-js)      PACKAGES='["neon-js"]' ;;
+            all)          PACKAGES='["postgrest-js","auth-ui","auth","neon-js"]' ;;
             *)            echo "Unknown package: $PACKAGE"; exit 1 ;;
           esac
           echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Releases use a two-stage pipeline. No GitHub App is needed.
 
 **Stage 1** (`prepare-release.yml` in this repo, manual `workflow_dispatch`):
 1. Select the trigger package and bump type
-2. The workflow builds, bumps versions via cascade, commits, tags, and pushes
-3. Build artifacts (tarballs + SHA256SUMS) are uploaded as workflow artifacts
+2. The workflow bumps versions via cascade, pushes a release branch, and opens a PR
+3. After manual squash merge, `post-release.yml` tags the merge commit and posts Stage 2 dispatch instructions
 
 **Stage 2** (`neon-js.yml` in [`secure-public-registry-releases-eng`](https://github.com/databricks/secure-public-registry-releases-eng), manual `workflow_dispatch`):
-1. Point it at the tag/ref from Stage 1
+1. Point it at the tag/ref from the post-release handoff
 2. It checks out the tagged commit, builds from source, scans, and publishes via npm OIDC
 3. If publish fails, a prominent warning is shown with remediation steps
 
@@ -72,12 +72,18 @@ directing you to the two-stage pipeline.
 | `auth-ui`       | auth-ui, auth, neon-js         |
 | `auth`          | auth, neon-js                  |
 | `neon-js`       | neon-js only                   |
+| `all`           | postgrest-js, auth-ui, auth, neon-js |
+
+`all` releases every public package together, while keeping independent package
+versions. It bumps each package once from its own current version; it does not
+force every package to share the same version number.
 
 ### Release tooling
 
 All release logic lives inside the two GitHub Actions workflows:
 
-- **`prepare-release.yml`** (this repo) -- bumps versions via cascade, commits, tags, and uploads build artifacts
+- **`prepare-release.yml`** (this repo) -- bumps versions via cascade and opens the release PR
+- **`post-release.yml`** (this repo) -- tags the merged release commit and writes the Stage 2 handoff
 - **`neon-js.yml`** (`secure-public-registry-releases-eng`) -- checks out the tagged commit, builds from source, scans, and publishes via npm OIDC
 
 ## Support

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -6,9 +6,11 @@ The neon-js release pipeline has two stages:
 
 1. **Stage 1 — `prepare-release.yml`** (this repo, `neondatabase/neon-js`):
    Computes the release cascade from the selected trigger package, bumps versions
-   in each `packages/*/package.json`, commits the version bumps, creates annotated
-   git tags (e.g. `auth@v0.2.1`), and pushes everything to the repo. No build,
-   no publish — just version bookkeeping.
+   in each `packages/*/package.json`, commits the version bumps to a release
+   branch, and opens a release PR. After the PR is manually squash-merged,
+   `post-release.yml` creates annotated git tags (e.g. `auth@v0.2.1`) on the
+   merge commit and comments with Stage 2 dispatch instructions. No build, no
+   pack, no scan, no publish — just version bookkeeping and handoff.
 
 2. **Stage 2 — `neon-js.yml`** (`databricks/secure-public-registry-releases-eng`):
    Checks out the tagged source, installs dependencies (via JFrog proxy), audits,
@@ -41,20 +43,24 @@ hardened runners and security scanning mandate lives in
 3. Click **Run workflow**. Stage 1 will:
    - Compute the cascade (e.g. `auth` triggers `["auth", "neon-js"]`)
    - Bump versions in each cascaded package
-   - Commit with message `chore: release @neondatabase/auth@vX.Y.Z @neondatabase/neon-js@vX.Y.Z [skip ci]`
-   - Create annotated tags (e.g. `auth@v0.2.1`, `neon-js@v1.3.5`)
-   - Push commit + tags
-4. Go to **secure-public-registry-releases-eng > Actions > neon-js** (`neon-js.yml`).
-5. Select the **same package and bump type**. Set **ref** to the tag or `main`.
+   - Push a release branch
+   - Open a release PR with a title like `chore: release @neondatabase/auth@vX.Y.Z @neondatabase/neon-js@vX.Y.Z`
+4. Have an approver manually click **Squash and merge**. Do not use auto-merge.
+   The merge commit triggers `post-release.yml`, which creates the annotated tags
+   and comments with Stage 2 dispatch instructions.
+5. Go to **secure-public-registry-releases-eng > Actions > neon-js** (`neon-js.yml`).
+6. Select the **same package**. For an all-packages release, select `all` and use
+   the `neon-js@v...` tag from the post-release handoff as the canonical **ref**
+   (all release tags point at the same merge commit).
    Set **dry-run** to `false` for a real publish.
-6. Click **Run workflow**. Stage 2 will:
+7. Click **Run workflow**. Stage 2 will:
    - Check actor permissions
    - Checkout neon-js source at the specified ref
    - Install deps, audit, build
    - Pack tarballs for all cascaded packages
    - Run security scan
    - Publish each package to npm via OIDC (skips already-published versions)
-7. Verify on npmjs.com that all packages were published at the expected versions.
+8. Verify on npmjs.com that all packages were published at the expected versions.
 
 ### Cascade Reference
 
@@ -64,6 +70,11 @@ hardened runners and security scanning mandate lives in
 | `auth-ui` | `auth-ui`, `auth`, `neon-js` |
 | `auth` | `auth`, `neon-js` |
 | `neon-js` | `neon-js` |
+| `all` | `postgrest-js`, `auth-ui`, `auth`, `neon-js` |
+
+`all` releases every public package together, but it does **not** align all
+packages to one shared version. Each package is bumped once from its own current
+version.
 
 ## Dry Run
 
@@ -80,12 +91,12 @@ A dry run does not modify any state — no tags, no npm publishes.
 
 ## Failure Scenarios & Recovery
 
-### 1. Stage 1 fails before push
+### 1. Stage 1 fails before branch push
 
-**Symptoms**: Workflow fails at version bump, commit, or tag step.
+**Symptoms**: Workflow fails at version bump or commit step.
 
-**State**: Nothing was pushed. The commit and tags existed only on the
-ephemeral runner and are discarded when it terminates.
+**State**: Nothing was pushed. The commit existed only on the ephemeral runner
+and is discarded when it terminates.
 
 **Recovery**: Just re-run the workflow. No cleanup needed.
 
@@ -93,36 +104,24 @@ ephemeral runner and are discarded when it terminates.
 
 ---
 
-### 2. Stage 1 push fails (partial push)
+### 2. Stage 1 branch push or PR creation fails
 
-**Symptoms**: The "Push commits and tags" step fails. Since `git push --follow-tags`
-is a single command, it may have partially succeeded.
+**Symptoms**: The "Push release branch" or "Open PR" step fails.
 
-**State**: One of three states:
-- Commit pushed but tags missing
-- Tags pushed but commit missing (unlikely but possible with network issues)
-- Nothing pushed (push rejected entirely)
+**State**: Either nothing was pushed, or a release branch exists without a PR.
+No tags are created by Stage 1.
 
 **Recovery**:
 
 ```bash
-# Check what got pushed
-git ls-remote --tags origin | grep "@v"
-git log origin/main --oneline -5
+# Check for a pushed release branch
+git ls-remote --heads origin "release/*"
 
-# If commit is on main but tags are missing, push tags manually:
-git fetch origin main
-git checkout origin/main
-git tag -a "auth@v0.2.1" -m "Release auth@v0.2.1"
-git push origin "auth@v0.2.1"
-
-# If tags exist but commit is missing (very unlikely), delete the orphan tags:
-git push --delete origin "auth@v0.2.1"
-# Then re-run Stage 1
+# If the branch exists, open the PR manually or delete the branch and rerun Stage 1
+git push origin --delete "release/<package>-<run-id>"
 ```
 
-**Verify**: Both `git log origin/main` and `git ls-remote --tags origin` show
-consistent versions.
+**Verify**: The release PR exists, or the bad release branch is gone.
 
 ---
 
@@ -273,9 +272,12 @@ fetched from JFrog.
   pipeline (install, build, scan) without touching npm. Always do a dry run
   first for major or minor releases.
 
-- **No secrets in Stage 1**: The prepare-release workflow only needs
-  `contents: write` to push commits and tags. No npm tokens, no JFrog tokens.
+- **No secrets in Stage 1**: The prepare-release workflow only needs GitHub
+  permissions to push the release branch and open a PR. No npm tokens, no JFrog
+  tokens.
 
 - **Cascade logic**: Both stages compute the cascade independently from the
   same hardcoded map. If you add a new package, update the cascade `case`
-  block in both `prepare-release.yml` and `neon-js.yml`.
+  block in both `prepare-release.yml` and `neon-js.yml`. `post-release.yml`
+  also recognizes the `all` package set so it can emit a single Stage 2
+  `package=all` dispatch instead of one dispatch per package.

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -10,11 +10,14 @@ Releases are published through the two-stage secure publishing pipeline.
 
 How it works:
   Stage 1: Run the "Prepare Release" workflow in neondatabase/neon-js
-           (workflow_dispatch). It bumps versions, commits, tags, pushes,
-           and uploads build artifacts.
+           (workflow_dispatch). It bumps versions, pushes a release branch,
+           and opens a PR. For all public packages, choose package="all".
+
+  Handoff: After the release PR is manually squash-merged, "Post-release"
+           tags the merge commit and comments with Stage 2 dispatch instructions.
 
   Stage 2: Run the "neon-js" workflow in secure-public-registry-releases-eng
-           (workflow_dispatch). Point it at the tag from Stage 1.
+           (workflow_dispatch). Point it at the tag from the handoff.
            It builds from the tagged commit, scans, and publishes via OIDC.
 
 See: https://github.com/databricks/secure-public-registry-releases-eng


### PR DESCRIPTION
## Summary
- Adds `package=all` to the prepare-release workflow so all public packages can be version-bumped in one release PR.
- Updates post-release handoff to emit one Stage 2 dispatch with `package=all` when the full public package set is released.
- Refreshes release docs to describe the current prepare PR, post-release tagging, and secure publish handoff flow.

## Paired PR
- databricks/secure-public-registry-releases-eng#92

## Test plan
- `python3` YAML/static workflow validation
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- Local all-package `pnpm pack` + `sha256sum -c SHA256SUMS`
- Stage 2 audit filter simulation: `Blocking advisories: 0`
- `pnpm test:ci`