### PR TITLE
feat(neon-js): single-URL initialization for createClient (LKB-11187)

### DIFF
--- a/packages/neon-js/src/__tests__/client-factory.test.ts
+++ b/packages/neon-js/src/__tests__/client-factory.test.ts
@@ -89,6 +89,27 @@ describe('createClient — string form', () => {
       /Invalid Neon base URL/
     );
   });
+
+  it('forwards options.auth.adapter to the auth factory', () => {
+    const sentinelAdapter = vi.fn();
+    createClient(BASE_URL, {
+      auth: { adapter: sentinelAdapter as any },
+    });
+
+    const authConfig = createInternalNeonAuthMock.mock.calls[0]?.[1] as {
+      adapter: unknown;
+    };
+    expect(authConfig.adapter).toBe(sentinelAdapter);
+  });
+
+  it('defaults allowAnonymous to false when not provided', () => {
+    createClient(BASE_URL);
+
+    const authConfig = createInternalNeonAuthMock.mock.calls[0]?.[1] as {
+      allowAnonymous: boolean;
+    };
+    expect(authConfig.allowAnonymous).toBe(false);
+  });
 });
 
 describe('createClient — object form (backward compat)', () => {

--- a/packages/neon-js/src/__tests__/client-factory.test.ts
+++ b/packages/neon-js/src/__tests__/client-factory.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock createInternalNeonAuth so we can capture the URL passed to it
+// without touching the network.
+const createInternalNeonAuthMock = vi.fn(() => ({
+  adapter: { getJWTToken: async () => null },
+  getJWTToken: async () => null,
+}));
+
+vi.mock('@neondatabase/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@neondatabase/auth')>();
+  return {
+    ...actual,
+    createInternalNeonAuth: (...args: unknown[]) =>
+      createInternalNeonAuthMock(...args),
+  };
+});
+
+import { createClient } from '../client/client-factory';
+import { defaultDeriveNeonUrls } from '../client/derive-urls';
+
+const BASE_URL = 'https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname';
+const EXPECTED = defaultDeriveNeonUrls(BASE_URL);
+
+describe('createClient — string form', () => {
+  beforeEach(() => {
+    createInternalNeonAuthMock.mockClear();
+  });
+
+  it('derives auth and Data API URLs from a single base URL', () => {
+    const client = createClient(BASE_URL);
+
+    // Auth URL: first arg to createInternalNeonAuth
+    expect(createInternalNeonAuthMock).toHaveBeenCalledTimes(1);
+    expect(createInternalNeonAuthMock.mock.calls[0]?.[0]).toBe(EXPECTED.auth);
+
+    // Data API URL: stored on the underlying PostgrestClient as `url`
+    expect((client as unknown as { url: string }).url).toBe(EXPECTED.dataApi);
+  });
+
+  it('lets options.auth.url override the derived auth URL', () => {
+    createClient(BASE_URL, {
+      auth: { url: 'https://override-auth.example.com' },
+    });
+
+    expect(createInternalNeonAuthMock.mock.calls[0]?.[0]).toBe(
+      'https://override-auth.example.com'
+    );
+  });
+
+  it('lets options.dataApi.url override the derived Data API URL', () => {
+    const client = createClient(BASE_URL, {
+      dataApi: { url: 'https://override-data.example.com/rest/v1' },
+    });
+
+    expect((client as unknown as { url: string }).url).toBe(
+      'https://override-data.example.com/rest/v1'
+    );
+  });
+
+  it('uses a custom deriveUrls function when provided', () => {
+    const customDerive = vi.fn(() => ({
+      auth: 'https://custom-auth.example.com',
+      dataApi: 'https://custom-data.example.com/rest/v1',
+    }));
+
+    const client = createClient(BASE_URL, { deriveUrls: customDerive });
+
+    expect(customDerive).toHaveBeenCalledWith(BASE_URL);
+    expect(createInternalNeonAuthMock.mock.calls[0]?.[0]).toBe(
+      'https://custom-auth.example.com'
+    );
+    expect((client as unknown as { url: string }).url).toBe(
+      'https://custom-data.example.com/rest/v1'
+    );
+  });
+
+  it('forwards allowAnonymous to the auth adapter', () => {
+    createClient(BASE_URL, { auth: { allowAnonymous: true } });
+
+    const authConfig = createInternalNeonAuthMock.mock.calls[0]?.[1] as {
+      allowAnonymous: boolean;
+    };
+    expect(authConfig.allowAnonymous).toBe(true);
+  });
+
+  it('throws on an invalid base URL (default derivation)', () => {
+    expect(() => createClient('https://example.com/db')).toThrow(
+      /Invalid Neon base URL/
+    );
+  });
+});
+
+describe('createClient — object form (backward compat)', () => {
+  beforeEach(() => {
+    createInternalNeonAuthMock.mockClear();
+  });
+
+  it('passes through auth.url and dataApi.url unchanged', () => {
+    const client = createClient({
+      auth: { url: 'https://auth.example.com' },
+      dataApi: { url: 'https://data-api.example.com/rest/v1' },
+    });
+
+    expect(createInternalNeonAuthMock.mock.calls[0]?.[0]).toBe(
+      'https://auth.example.com'
+    );
+    expect((client as unknown as { url: string }).url).toBe(
+      'https://data-api.example.com/rest/v1'
+    );
+  });
+});

--- a/packages/neon-js/src/__tests__/derive-urls.test.ts
+++ b/packages/neon-js/src/__tests__/derive-urls.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { defaultDeriveNeonUrls } from '../client/derive-urls';
+
+describe('defaultDeriveNeonUrls', () => {
+  it('derives auth and dataApi URLs from a standard Neon base URL', () => {
+    const result = defaultDeriveNeonUrls(
+      'https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname'
+    );
+    expect(result).toEqual({
+      auth: 'https://ep-xxx.neonauth.c-2.us-east-2.aws.neon.build/dbname/auth',
+      dataApi:
+        'https://ep-xxx.apirest.c-2.us-east-2.aws.neon.build/dbname/rest/v1',
+    });
+  });
+
+  it('tolerates a trailing slash on the path', () => {
+    const result = defaultDeriveNeonUrls(
+      'https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname/'
+    );
+    expect(result).toEqual({
+      auth: 'https://ep-xxx.neonauth.c-2.us-east-2.aws.neon.build/dbname/auth',
+      dataApi:
+        'https://ep-xxx.apirest.c-2.us-east-2.aws.neon.build/dbname/rest/v1',
+    });
+  });
+
+  it('preserves a custom port', () => {
+    const result = defaultDeriveNeonUrls(
+      'https://ep-xxx.c-2.us-east-2.aws.neon.build:8443/dbname'
+    );
+    expect(result).toEqual({
+      auth: 'https://ep-xxx.neonauth.c-2.us-east-2.aws.neon.build:8443/dbname/auth',
+      dataApi:
+        'https://ep-xxx.apirest.c-2.us-east-2.aws.neon.build:8443/dbname/rest/v1',
+    });
+  });
+
+  it('preserves a deeper path', () => {
+    const result = defaultDeriveNeonUrls(
+      'https://ep-xxx.c-2.us-east-2.aws.neon.build/proj/db'
+    );
+    expect(result).toEqual({
+      auth: 'https://ep-xxx.neonauth.c-2.us-east-2.aws.neon.build/proj/db/auth',
+      dataApi:
+        'https://ep-xxx.apirest.c-2.us-east-2.aws.neon.build/proj/db/rest/v1',
+    });
+  });
+
+  it('preserves http protocol', () => {
+    const result = defaultDeriveNeonUrls(
+      'http://ep-xxx.c-2.us-east-2.aws.neon.build/dbname'
+    );
+    expect(result.auth.startsWith('http://')).toBe(true);
+    expect(result.dataApi.startsWith('http://')).toBe(true);
+  });
+
+  it('throws when the hostname has fewer than 3 labels', () => {
+    expect(() => defaultDeriveNeonUrls('https://example.com/db')).toThrow(
+      /Invalid Neon base URL/
+    );
+  });
+
+  it('throws when the input is not a valid URL', () => {
+    expect(() => defaultDeriveNeonUrls('not a url')).toThrow();
+  });
+});

--- a/packages/neon-js/src/__tests__/derive-urls.test.ts
+++ b/packages/neon-js/src/__tests__/derive-urls.test.ts
@@ -70,6 +70,19 @@ describe('defaultDeriveNeonUrls', () => {
     ).toThrow(/must not include a query string or hash fragment/);
   });
 
+  it('throws when the URL contains embedded credentials', () => {
+    expect(() =>
+      defaultDeriveNeonUrls(
+        'https://user:pass@ep-xxx.c-2.us-east-2.aws.neon.build/dbname'
+      )
+    ).toThrow(/must not include credentials/);
+    expect(() =>
+      defaultDeriveNeonUrls(
+        'https://user@ep-xxx.c-2.us-east-2.aws.neon.build/dbname'
+      )
+    ).toThrow(/must not include credentials/);
+  });
+
   it('throws when the hostname has fewer than 3 labels', () => {
     expect(() => defaultDeriveNeonUrls('https://example.com/db')).toThrow(
       /Invalid Neon base URL/

--- a/packages/neon-js/src/__tests__/derive-urls.test.ts
+++ b/packages/neon-js/src/__tests__/derive-urls.test.ts
@@ -50,8 +50,24 @@ describe('defaultDeriveNeonUrls', () => {
     const result = defaultDeriveNeonUrls(
       'http://ep-xxx.c-2.us-east-2.aws.neon.build/dbname'
     );
-    expect(result.auth.startsWith('http://')).toBe(true);
-    expect(result.dataApi.startsWith('http://')).toBe(true);
+    expect(result).toEqual({
+      auth: 'http://ep-xxx.neonauth.c-2.us-east-2.aws.neon.build/dbname/auth',
+      dataApi:
+        'http://ep-xxx.apirest.c-2.us-east-2.aws.neon.build/dbname/rest/v1',
+    });
+  });
+
+  it('throws when the URL contains a query string or hash fragment', () => {
+    expect(() =>
+      defaultDeriveNeonUrls(
+        'https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname?x=1'
+      )
+    ).toThrow(/must not include a query string or hash fragment/);
+    expect(() =>
+      defaultDeriveNeonUrls(
+        'https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname#frag'
+      )
+    ).toThrow(/must not include a query string or hash fragment/);
   });
 
   it('throws when the hostname has fewer than 3 labels', () => {

--- a/packages/neon-js/src/__tests__/type-tests.test-d.ts
+++ b/packages/neon-js/src/__tests__/type-tests.test-d.ts
@@ -179,3 +179,84 @@ describe('Database type parameter with adapter inference', () => {
     expectTypeOf(typedClient.auth.signIn.email).toBeFunction();
   });
 });
+
+// =============================================================================
+// Test 6: String form — default adapter
+// =============================================================================
+describe('String form — default adapter type inference', () => {
+  const client = createClient('https://ep-xxx.c-2.us-east-2.aws.neon.build/db');
+
+  it('should default to BetterAuthVanillaAdapter API', () => {
+    expectTypeOf(client.auth.signIn.email).toBeFunction();
+    expectTypeOf(client.auth.getSession).toBeFunction();
+  });
+});
+
+// =============================================================================
+// Test 7: String form — explicit SupabaseAuthAdapter
+// =============================================================================
+describe('String form — SupabaseAuthAdapter type inference', () => {
+  const client = createClient(
+    'https://ep-xxx.c-2.us-east-2.aws.neon.build/db',
+    {
+      auth: { adapter: SupabaseAuthAdapter() },
+    }
+  );
+
+  it('should expose Supabase API', () => {
+    expectTypeOf(client.auth.signInWithPassword).toBeFunction();
+    expectTypeOf(client.auth.signUp).toBeFunction();
+    expectTypeOf(client.auth.signOut).toBeFunction();
+  });
+});
+
+// =============================================================================
+// Test 8: String form — explicit BetterAuthReactAdapter
+// =============================================================================
+describe('String form — BetterAuthReactAdapter type inference', () => {
+  const client = createClient(
+    'https://ep-xxx.c-2.us-east-2.aws.neon.build/db',
+    {
+      auth: { adapter: BetterAuthReactAdapter() },
+    }
+  );
+
+  it('should expose React adapter API', () => {
+    expectTypeOf(client.auth.useSession).toBeFunction();
+    expectTypeOf(client.auth.signIn.email).toBeFunction();
+  });
+});
+
+// =============================================================================
+// Test 9: String form — Database type parameter
+// =============================================================================
+describe('String form with Database type parameter', () => {
+  interface TestDatabaseStringForm {
+    public: {
+      Tables: {
+        items: {
+          Row: { id: number };
+          Insert: { id?: number };
+          Update: { id?: number };
+        };
+      };
+      Views: Record<string, never>;
+      Functions: Record<string, never>;
+    };
+  }
+
+  it('should preserve Database type with default adapter', () => {
+    const typed = createClient<TestDatabaseStringForm>(
+      'https://ep-xxx.c-2.us-east-2.aws.neon.build/db'
+    );
+    expectTypeOf(typed.auth.signIn.email).toBeFunction();
+  });
+
+  it('should preserve Database type with explicit Supabase adapter', () => {
+    const typed = createClient<TestDatabaseStringForm>(
+      'https://ep-xxx.c-2.us-east-2.aws.neon.build/db',
+      { auth: { adapter: SupabaseAuthAdapter() } }
+    );
+    expectTypeOf(typed.auth.signInWithPassword).toBeFunction();
+  });
+});

--- a/packages/neon-js/src/client/client-factory.ts
+++ b/packages/neon-js/src/client/client-factory.ts
@@ -21,7 +21,7 @@ import {
 import { defaultDeriveNeonUrls, type DeriveNeonUrls } from './derive-urls';
 
 /**
- * Auth configuration for createClient (object form)
+ * Auth configuration for createClient
  */
 export type CreateClientAuthConfig<T extends NeonAuthAdapter> = {
   /** The auth service URL */
@@ -29,7 +29,7 @@ export type CreateClientAuthConfig<T extends NeonAuthAdapter> = {
 } & NeonAuthConfig<T>;
 
 /**
- * Data API configuration for createClient (object form)
+ * Data API configuration for createClient
  */
 export type CreateClientDataApiConfig<
   SchemaName,
@@ -45,7 +45,7 @@ export type CreateClientDataApiConfig<
 };
 
 /**
- * Configuration for createClient (object form)
+ * Configuration for createClient
  */
 export type CreateClientConfig<SchemaName, T extends NeonAuthAdapter> = {
   /** Auth service configuration */
@@ -55,34 +55,67 @@ export type CreateClientConfig<SchemaName, T extends NeonAuthAdapter> = {
 };
 
 /**
- * Per-call overrides accepted alongside a single base URL.
+ * Factory function to create NeonClient with seamless auth integration.
  *
- * Every field is optional; defaults come from `deriveUrls(baseUrl)`.
+ * @param config - Configuration with auth and dataApi sections
+ * @returns NeonClient instance with auth-aware fetch wrapper
+ * @throws AuthRequiredError when making requests without authentication
+ *
+ * @example
+ * ```typescript
+ * // Simple usage with default BetterAuthVanillaAdapter
+ * import { createClient } from '@neondatabase/neon-js';
+ *
+ * const client = createClient({
+ *   auth: { url: 'https://auth.example.com' },
+ *   dataApi: { url: 'https://data-api.example.com/rest/v1' },
+ * });
+ *
+ * // Better Auth API
+ * await client.auth.signIn.email({ email, password });
+ *
+ * // Database queries (automatic token injection)
+ * const { data: items } = await client.from('items').select();
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With SupabaseAuthAdapter for Supabase-compatible API
+ * import { createClient, SupabaseAuthAdapter } from '@neondatabase/neon-js';
+ *
+ * const client = createClient({
+ *   auth: {
+ *     adapter: SupabaseAuthAdapter,
+ *     url: 'https://auth.example.com',
+ *   },
+ *   dataApi: {
+ *     url: 'https://data-api.example.com/rest/v1',
+ *   },
+ * });
+ *
+ * // Supabase-compatible auth methods
+ * await client.auth.signInWithPassword({ email, password });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Single base URL — auth and Data API URLs are derived automatically.
+ * const client = createClient(
+ *   'https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname'
+ * );
+ * ```
  */
-export type CreateClientStringOptions<
-  SchemaName,
-  T extends NeonAuthAdapter,
-> = {
-  auth?: Partial<CreateClientAuthConfig<T>>;
-  dataApi?: Partial<CreateClientDataApiConfig<SchemaName, T>>;
-  /**
-   * Override the auth/Data API URL derivation. End users do not need this;
-   * it is intended for wrapper packages (e.g. `@databricks/lakebase-js`)
-   * that have their own endpoint pattern.
-   */
-  deriveUrls?: DeriveNeonUrls;
-};
 
+/**
+ * Helper type to create NeonClient with proper schema resolution.
+ * Uses 'public' as the default schema since it's the most common case.
+ */
 type CreateClientResult<
   Database,
   TAdapter extends NeonAuthAdapter,
 > = NeonClient<Database, DefaultSchemaName<Database>, TAdapter>;
 
-// =============================================================================
-// Object-form overloads (existing behaviour — unchanged)
-// =============================================================================
-
-// Object form, no adapter specified → defaults to BetterAuthVanillaAdapter
+// Overload: No adapter specified (defaults to BetterAuthVanillaAdapter)
 export function createClient<Database = any>(config: {
   auth: { url: string; allowAnonymous?: boolean };
   dataApi: CreateClientDataApiConfig<
@@ -91,7 +124,7 @@ export function createClient<Database = any>(config: {
   >;
 }): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
 
-// Object form, SupabaseAuthAdapter
+// Overload: SupabaseAuthAdapter
 export function createClient<Database = any>(
   config: CreateClientConfig<
     DefaultSchemaName<Database>,
@@ -99,7 +132,7 @@ export function createClient<Database = any>(
   >
 ): CreateClientResult<Database, SupabaseAuthAdapterInstance>;
 
-// Object form, BetterAuthVanillaAdapter
+// Overload: BetterAuthVanillaAdapter
 export function createClient<Database = any>(
   config: CreateClientConfig<
     DefaultSchemaName<Database>,
@@ -107,7 +140,7 @@ export function createClient<Database = any>(
   >
 ): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
 
-// Object form, BetterAuthReactAdapter
+// Overload: BetterAuthReactAdapter
 export function createClient<Database = any>(
   config: CreateClientConfig<
     DefaultSchemaName<Database>,
@@ -115,11 +148,7 @@ export function createClient<Database = any>(
   >
 ): CreateClientResult<Database, BetterAuthReactAdapterInstance>;
 
-// =============================================================================
-// String-form overloads (new)
-// =============================================================================
-
-// String form, no adapter specified → defaults to BetterAuthVanillaAdapter
+// Overload: String form, no adapter specified (defaults to BetterAuthVanillaAdapter)
 export function createClient<Database = any>(
   baseUrl: string,
   options?: CreateClientStringOptions<
@@ -128,7 +157,7 @@ export function createClient<Database = any>(
   >
 ): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
 
-// String form, SupabaseAuthAdapter
+// Overload: String form, SupabaseAuthAdapter
 export function createClient<Database = any>(
   baseUrl: string,
   options: CreateClientStringOptions<
@@ -137,7 +166,7 @@ export function createClient<Database = any>(
   > & { auth: { adapter: SupabaseAuthAdapterInstance } }
 ): CreateClientResult<Database, SupabaseAuthAdapterInstance>;
 
-// String form, BetterAuthVanillaAdapter
+// Overload: String form, BetterAuthVanillaAdapter
 export function createClient<Database = any>(
   baseUrl: string,
   options: CreateClientStringOptions<
@@ -146,7 +175,7 @@ export function createClient<Database = any>(
   > & { auth: { adapter: BetterAuthVanillaAdapterInstance } }
 ): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
 
-// String form, BetterAuthReactAdapter
+// Overload: String form, BetterAuthReactAdapter
 export function createClient<Database = any>(
   baseUrl: string,
   options: CreateClientStringOptions<
@@ -155,18 +184,13 @@ export function createClient<Database = any>(
   > & { auth: { adapter: BetterAuthReactAdapterInstance } }
 ): CreateClientResult<Database, BetterAuthReactAdapterInstance>;
 
-// =============================================================================
-// Implementation
-// =============================================================================
-
+// Implementation signature
 export function createClient<
   Database = any,
   SchemaName extends string & keyof Database = DefaultSchemaName<Database>,
   TAuthAdapter extends NeonAuthAdapter = BetterAuthVanillaAdapterInstance,
 >(
-  arg1:
-    | string
-    | CreateClientConfig<SchemaName, TAuthAdapter>,
+  arg1: string | CreateClientConfig<SchemaName, TAuthAdapter>,
   arg2?: CreateClientStringOptions<SchemaName, TAuthAdapter>
 ): NeonClient<Database, SchemaName, TAuthAdapter> {
   const config: CreateClientConfig<SchemaName, TAuthAdapter> =
@@ -191,6 +215,7 @@ export function createClient<
   });
 
   // Step 2: Create lazy token accessor - called on every request
+  // Returns null if no session (will throw AuthRequiredError in fetchWithToken)
   const getAccessToken = async (): Promise<string | null> => {
     return auth.getJWTToken();
   };
@@ -220,6 +245,25 @@ export function createClient<
 
   return client;
 }
+
+/**
+ * Per-call overrides accepted alongside a single base URL.
+ *
+ * Every field is optional; defaults come from `deriveUrls(baseUrl)`.
+ */
+export type CreateClientStringOptions<
+  SchemaName,
+  T extends NeonAuthAdapter,
+> = {
+  auth?: Partial<CreateClientAuthConfig<T>>;
+  dataApi?: Partial<CreateClientDataApiConfig<SchemaName, T>>;
+  /**
+   * Override the auth/Data API URL derivation. End users do not need this;
+   * it is intended for wrapper packages (e.g. `@databricks/lakebase-js`)
+   * that have their own endpoint pattern.
+   */
+  deriveUrls?: DeriveNeonUrls;
+};
 
 function buildConfigFromBaseUrl<
   SchemaName,

--- a/packages/neon-js/src/client/client-factory.ts
+++ b/packages/neon-js/src/client/client-factory.ts
@@ -18,9 +18,10 @@ import {
   buildNeonJsClientInfo,
   X_NEON_CLIENT_INFO_HEADER,
 } from '../utils/client-info';
+import { defaultDeriveNeonUrls, type DeriveNeonUrls } from './derive-urls';
 
 /**
- * Auth configuration for createClient
+ * Auth configuration for createClient (object form)
  */
 export type CreateClientAuthConfig<T extends NeonAuthAdapter> = {
   /** The auth service URL */
@@ -28,7 +29,7 @@ export type CreateClientAuthConfig<T extends NeonAuthAdapter> = {
 } & NeonAuthConfig<T>;
 
 /**
- * Data API configuration for createClient
+ * Data API configuration for createClient (object form)
  */
 export type CreateClientDataApiConfig<
   SchemaName,
@@ -44,7 +45,7 @@ export type CreateClientDataApiConfig<
 };
 
 /**
- * Configuration for createClient
+ * Configuration for createClient (object form)
  */
 export type CreateClientConfig<SchemaName, T extends NeonAuthAdapter> = {
   /** Auth service configuration */
@@ -54,59 +55,34 @@ export type CreateClientConfig<SchemaName, T extends NeonAuthAdapter> = {
 };
 
 /**
- * Factory function to create NeonClient with seamless auth integration.
+ * Per-call overrides accepted alongside a single base URL.
  *
- * @param config - Configuration with auth and dataApi sections
- * @returns NeonClient instance with auth-aware fetch wrapper
- * @throws AuthRequiredError when making requests without authentication
- *
- * @example
- * ```typescript
- * // Simple usage with default BetterAuthVanillaAdapter
- * import { createClient } from '@neondatabase/neon-js';
- *
- * const client = createClient({
- *   auth: { url: 'https://auth.example.com' },
- *   dataApi: { url: 'https://data-api.example.com/rest/v1' },
- * });
- *
- * // Better Auth API
- * await client.auth.signIn.email({ email, password });
- *
- * // Database queries (automatic token injection)
- * const { data: items } = await client.from('items').select();
- * ```
- *
- * @example
- * ```typescript
- * // With SupabaseAuthAdapter for Supabase-compatible API
- * import { createClient, SupabaseAuthAdapter } from '@neondatabase/neon-js';
- *
- * const client = createClient({
- *   auth: {
- *     adapter: SupabaseAuthAdapter,
- *     url: 'https://auth.example.com',
- *   },
- *   dataApi: {
- *     url: 'https://data-api.example.com/rest/v1',
- *   },
- * });
- *
- * // Supabase-compatible auth methods
- * await client.auth.signInWithPassword({ email, password });
- * ```
+ * Every field is optional; defaults come from `deriveUrls(baseUrl)`.
  */
+export type CreateClientStringOptions<
+  SchemaName,
+  T extends NeonAuthAdapter,
+> = {
+  auth?: Partial<CreateClientAuthConfig<T>>;
+  dataApi?: Partial<CreateClientDataApiConfig<SchemaName, T>>;
+  /**
+   * Override the auth/Data API URL derivation. End users do not need this;
+   * it is intended for wrapper packages (e.g. `@databricks/lakebase-js`)
+   * that have their own endpoint pattern.
+   */
+  deriveUrls?: DeriveNeonUrls;
+};
 
-/**
- * Helper type to create NeonClient with proper schema resolution.
- * Uses 'public' as the default schema since it's the most common case.
- */
 type CreateClientResult<
   Database,
   TAdapter extends NeonAuthAdapter,
 > = NeonClient<Database, DefaultSchemaName<Database>, TAdapter>;
 
-// Overload: No adapter specified (defaults to BetterAuthVanillaAdapter)
+// =============================================================================
+// Object-form overloads (existing behaviour — unchanged)
+// =============================================================================
+
+// Object form, no adapter specified → defaults to BetterAuthVanillaAdapter
 export function createClient<Database = any>(config: {
   auth: { url: string; allowAnonymous?: boolean };
   dataApi: CreateClientDataApiConfig<
@@ -115,7 +91,7 @@ export function createClient<Database = any>(config: {
   >;
 }): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
 
-// Overload: SupabaseAuthAdapter
+// Object form, SupabaseAuthAdapter
 export function createClient<Database = any>(
   config: CreateClientConfig<
     DefaultSchemaName<Database>,
@@ -123,7 +99,7 @@ export function createClient<Database = any>(
   >
 ): CreateClientResult<Database, SupabaseAuthAdapterInstance>;
 
-// Overload: BetterAuthVanillaAdapter
+// Object form, BetterAuthVanillaAdapter
 export function createClient<Database = any>(
   config: CreateClientConfig<
     DefaultSchemaName<Database>,
@@ -131,7 +107,7 @@ export function createClient<Database = any>(
   >
 ): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
 
-// Overload: BetterAuthReactAdapter
+// Object form, BetterAuthReactAdapter
 export function createClient<Database = any>(
   config: CreateClientConfig<
     DefaultSchemaName<Database>,
@@ -139,14 +115,65 @@ export function createClient<Database = any>(
   >
 ): CreateClientResult<Database, BetterAuthReactAdapterInstance>;
 
-// Implementation signature
+// =============================================================================
+// String-form overloads (new)
+// =============================================================================
+
+// String form, no adapter specified → defaults to BetterAuthVanillaAdapter
+export function createClient<Database = any>(
+  baseUrl: string,
+  options?: CreateClientStringOptions<
+    DefaultSchemaName<Database>,
+    BetterAuthVanillaAdapterInstance
+  >
+): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
+
+// String form, SupabaseAuthAdapter
+export function createClient<Database = any>(
+  baseUrl: string,
+  options: CreateClientStringOptions<
+    DefaultSchemaName<Database>,
+    SupabaseAuthAdapterInstance
+  > & { auth: { adapter: SupabaseAuthAdapterInstance } }
+): CreateClientResult<Database, SupabaseAuthAdapterInstance>;
+
+// String form, BetterAuthVanillaAdapter
+export function createClient<Database = any>(
+  baseUrl: string,
+  options: CreateClientStringOptions<
+    DefaultSchemaName<Database>,
+    BetterAuthVanillaAdapterInstance
+  > & { auth: { adapter: BetterAuthVanillaAdapterInstance } }
+): CreateClientResult<Database, BetterAuthVanillaAdapterInstance>;
+
+// String form, BetterAuthReactAdapter
+export function createClient<Database = any>(
+  baseUrl: string,
+  options: CreateClientStringOptions<
+    DefaultSchemaName<Database>,
+    BetterAuthReactAdapterInstance
+  > & { auth: { adapter: BetterAuthReactAdapterInstance } }
+): CreateClientResult<Database, BetterAuthReactAdapterInstance>;
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
 export function createClient<
   Database = any,
   SchemaName extends string & keyof Database = DefaultSchemaName<Database>,
   TAuthAdapter extends NeonAuthAdapter = BetterAuthVanillaAdapterInstance,
 >(
-  config: CreateClientConfig<SchemaName, TAuthAdapter>
+  arg1:
+    | string
+    | CreateClientConfig<SchemaName, TAuthAdapter>,
+  arg2?: CreateClientStringOptions<SchemaName, TAuthAdapter>
 ): NeonClient<Database, SchemaName, TAuthAdapter> {
+  const config: CreateClientConfig<SchemaName, TAuthAdapter> =
+    typeof arg1 === 'string'
+      ? buildConfigFromBaseUrl<SchemaName, TAuthAdapter>(arg1, arg2)
+      : arg1;
+
   const { auth: authConfig, dataApi: dataApiConfig } = config;
 
   // Build client info once - sub-packages will see it and skip their own injection
@@ -164,7 +191,6 @@ export function createClient<
   });
 
   // Step 2: Create lazy token accessor - called on every request
-  // Returns null if no session (will throw AuthRequiredError in fetchWithToken)
   const getAccessToken = async (): Promise<string | null> => {
     return auth.getJWTToken();
   };
@@ -193,4 +219,29 @@ export function createClient<
   });
 
   return client;
+}
+
+function buildConfigFromBaseUrl<
+  SchemaName,
+  TAuthAdapter extends NeonAuthAdapter,
+>(
+  baseUrl: string,
+  options: CreateClientStringOptions<SchemaName, TAuthAdapter> | undefined
+): CreateClientConfig<SchemaName, TAuthAdapter> {
+  const derive = options?.deriveUrls ?? defaultDeriveNeonUrls;
+  const derived = derive(baseUrl);
+
+  const authOverrides = options?.auth ?? {};
+  const dataApiOverrides = options?.dataApi ?? {};
+
+  return {
+    auth: {
+      ...authOverrides,
+      url: authOverrides.url ?? derived.auth,
+    } as CreateClientAuthConfig<TAuthAdapter>,
+    dataApi: {
+      ...dataApiOverrides,
+      url: dataApiOverrides.url ?? derived.dataApi,
+    } as CreateClientDataApiConfig<SchemaName, TAuthAdapter>,
+  };
 }

--- a/packages/neon-js/src/client/derive-urls.ts
+++ b/packages/neon-js/src/client/derive-urls.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure function: given a Neon base URL, returns the corresponding
+ * auth and Data API URLs.
+ *
+ * Wrappers (e.g. @databricks/lakebase-js) can supply a different implementation
+ * via the `deriveUrls` option on createClient.
+ */
+export type DeriveNeonUrls = (baseUrl: string) => {
+  auth: string;
+  dataApi: string;
+};
+
+/**
+ * Default URL derivation for Neon endpoints.
+ *
+ * Insert `neonauth` / `apirest` after the first hostname label and append
+ * `/auth` / `/rest/v1` to the path.
+ *
+ * Example:
+ *   https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname
+ *     → auth:    https://ep-xxx.neonauth.c-2.us-east-2.aws.neon.build/dbname/auth
+ *     → dataApi: https://ep-xxx.apirest.c-2.us-east-2.aws.neon.build/dbname/rest/v1
+ */
+export const defaultDeriveNeonUrls: DeriveNeonUrls = (baseUrl) => {
+  const url = new URL(baseUrl);
+
+  const labels = url.hostname.split('.');
+  if (labels.length < 3) {
+    throw new Error(
+      `Invalid Neon base URL: hostname "${url.hostname}" must have at least 3 dot-separated labels (e.g. ep-xxx.region.tld).`
+    );
+  }
+
+  const [first, ...rest] = labels;
+  const authHost = [first, 'neonauth', ...rest].join('.');
+  const dataApiHost = [first, 'apirest', ...rest].join('.');
+
+  const basePath = url.pathname.replace(/\/+$/, '');
+  const authPath = `${basePath}/auth`;
+  const dataApiPath = `${basePath}/rest/v1`;
+
+  const portSuffix = url.port ? `:${url.port}` : '';
+
+  return {
+    auth: `${url.protocol}//${authHost}${portSuffix}${authPath}`,
+    dataApi: `${url.protocol}//${dataApiHost}${portSuffix}${dataApiPath}`,
+  };
+};

--- a/packages/neon-js/src/client/derive-urls.ts
+++ b/packages/neon-js/src/client/derive-urls.ts
@@ -24,6 +24,12 @@ export type DeriveNeonUrls = (baseUrl: string) => {
 export const defaultDeriveNeonUrls: DeriveNeonUrls = (baseUrl) => {
   const url = new URL(baseUrl);
 
+  if (url.search !== '' || url.hash !== '') {
+    throw new Error(
+      `Invalid Neon base URL: must not include a query string or hash fragment (got "${baseUrl}").`
+    );
+  }
+
   const labels = url.hostname.split('.');
   if (labels.length < 3) {
     throw new Error(
@@ -36,13 +42,10 @@ export const defaultDeriveNeonUrls: DeriveNeonUrls = (baseUrl) => {
   const dataApiHost = [first, 'apirest', ...rest].join('.');
 
   const basePath = url.pathname.replace(/\/+$/, '');
-  const authPath = `${basePath}/auth`;
-  const dataApiPath = `${basePath}/rest/v1`;
-
-  const portSuffix = url.port ? `:${url.port}` : '';
+  const port = url.port ? `:${url.port}` : '';
 
   return {
-    auth: `${url.protocol}//${authHost}${portSuffix}${authPath}`,
-    dataApi: `${url.protocol}//${dataApiHost}${portSuffix}${dataApiPath}`,
+    auth: `${url.protocol}//${authHost}${port}${basePath}/auth`,
+    dataApi: `${url.protocol}//${dataApiHost}${port}${basePath}/rest/v1`,
   };
 };

--- a/packages/neon-js/src/client/derive-urls.ts
+++ b/packages/neon-js/src/client/derive-urls.ts
@@ -16,6 +16,16 @@ export type DeriveNeonUrls = (baseUrl: string) => {
  * Insert `neonauth` / `apirest` after the first hostname label and append
  * `/auth` / `/rest/v1` to the path.
  *
+ * Only the protocol, host, port, and path are used. A query string, hash
+ * fragment, or embedded credentials (`user:pass@host`) are rejected.
+ *
+ * Constraints (use the object form or a custom `deriveUrls` to bypass them):
+ *   - The hostname must have at least 3 dot-separated labels, so `localhost`
+ *     and single-host proxies are intentionally rejected.
+ *   - A single port is applied to both derived hosts, so split-port local
+ *     setups (e.g. `neonauth:30443` vs `apirest:9443`) cannot be expressed
+ *     via the string form. In production both services share port 443.
+ *
  * Example:
  *   https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname
  *     → auth:    https://ep-xxx.neonauth.c-2.us-east-2.aws.neon.build/dbname/auth
@@ -27,6 +37,12 @@ export const defaultDeriveNeonUrls: DeriveNeonUrls = (baseUrl) => {
   if (url.search !== '' || url.hash !== '') {
     throw new Error(
       `Invalid Neon base URL: must not include a query string or hash fragment (got "${baseUrl}").`
+    );
+  }
+
+  if (url.username !== '' || url.password !== '') {
+    throw new Error(
+      `Invalid Neon base URL: must not include credentials (got "${baseUrl}").`
     );
   }
 

--- a/packages/neon-js/src/client/index.ts
+++ b/packages/neon-js/src/client/index.ts
@@ -1,3 +1,4 @@
 // Internal exports only - not exposed as public subpath
 export { NeonClient } from './neon-client';
 export { createClient } from './client-factory';
+export { defaultDeriveNeonUrls, type DeriveNeonUrls } from './derive-urls';

--- a/packages/neon-js/src/index.ts
+++ b/packages/neon-js/src/index.ts
@@ -1,6 +1,12 @@
 // Main client factory
 export { createClient } from './client/client-factory';
 
+// URL derivation (mostly used by wrappers; end users don't need this)
+export {
+  defaultDeriveNeonUrls,
+  type DeriveNeonUrls,
+} from './client/derive-urls';
+
 // Re-export utilities from postgrest-js for convenience
 export { fetchWithToken, AuthRequiredError } from '@neondatabase/postgrest-js';
 

--- a/packages/neon-js/src/index.ts
+++ b/packages/neon-js/src/index.ts
@@ -1,5 +1,6 @@
 // Main client factory
 export { createClient } from './client/client-factory';
+export type { CreateClientStringOptions } from './client/client-factory';
 
 // URL derivation (mostly used by wrappers; end users don't need this)
 export {


### PR DESCRIPTION
## Summary
  - Adds a string-form to `createClient` so apps can initialize with a single base URL instead of two (`auth` + `dataApi`). The existing object form is unchanged.
  - Derivation is configurable: `defaultDeriveNeonUrls` is the built-in for Neon endpoints.
  - Public exports added: `defaultDeriveNeonUrls`, `DeriveNeonUrls`, `CreateClientStringOptions`.

  ## API
  ```ts
  // New: single URL
  const client = createClient<DB>('https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname');

  // New: with overrides
  const client = createClient<DB>(baseUrl, {
    auth: { allowAnonymous: true, adapter: SupabaseAuthAdapter() },
    dataApi: { options: { /* … */ } },
  });

  // Backward compatible: object form
  const client = createClient<DB>({ auth: { url }, dataApi: { url } });
```

  Test plan

  - defaultDeriveNeonUrls unit tests (8 cases incl. trailing slash, custom port, deeper path, http, query/hash rejection, label-count guard).
  - createClient runtime tests with mocked auth factory: derivation, per-call URL overrides, custom deriveUrls, adapter forwarding, allowAnonymous default + flow-through, invalid URL throws,
  object-form backward compat.
  - Type tests for the string form: default adapter, SupabaseAuthAdapter, BetterAuthReactAdapter, Database type-parameter inference.
  - Repo-level typecheck + build clean; package lint clean.
  - Documentation/READMEs (intentionally out of scope — handled separately).

  Refs: LKB-11187. Parent: LKB-11182.