### PR TITLE
chore(ci): sign release commits via peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -291,8 +291,8 @@ jobs:
             echo "PR_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Commit version bumps
-        id: commit
+      - name: Compute commit message
+        id: commit-msg
         run: |
           PACKAGES='${{ steps.cascade.outputs.packages }}'
           VERSIONS='${{ steps.versions.outputs.versions }}'
@@ -303,14 +303,7 @@ jobs:
             COMMIT_MSG="$COMMIT_MSG @neondatabase/${pkg}@v${version}"
           done
           # No [skip ci] — we need checks to run on the PR.
-
-          git add -A
-          git commit -m "$COMMIT_MSG"
-
-      - name: Push release branch
-        id: push
-        run: |
-          git push origin "HEAD:${{ steps.meta.outputs.branch }}"
+          echo "message=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
 
       - name: Ensure `release` label exists
         env:
@@ -318,35 +311,42 @@ jobs:
         run: |
           gh label create release --color "0E8A16" --description "Automated release PR" --force || true
 
-      - name: Open PR
-        id: open-pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-          # Pass these via env rather than inline ${{ }} interpolation so that
-          # backticks / shell metacharacters in the body stay literal when
-          # bash parses the rendered script.
-          PR_BRANCH: ${{ steps.meta.outputs.branch }}
-          PR_TITLE: ${{ steps.meta.outputs.pr_title }}
-          PR_BODY: ${{ steps.meta.outputs.body }}
-        run: |
-          # NOTE: We intentionally do NOT enable auto-merge. Auto-merge enabled
-          # by GITHUB_TOKEN causes the eventual squash-merge push to main to be
-          # suppressed from triggering downstream `on: push` workflows (including
-          # post-release.yml). The approver must click "Squash and merge" manually
-          # in the UI so the push is attributed to a human and post-release fires.
-          # See https://docs.github.com/en/actions/concepts/security/github_token
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "$PR_BRANCH" \
-            --title "$PR_TITLE" \
-            --body "$PR_BODY" \
-            --label release)
+      - name: Create signed commit + open PR
+        id: cpr
+        # Pinned to the full SHA of v8.1.1 (released 2025-04-22).
+        # This action commits via the GitHub Contents API, which produces commits
+        # signed by the github-actions[bot] verified signature. That replaces the
+        # previous `git add && git commit && git push && gh pr create` block,
+        # which produced unsigned commits (see PR #115).
+        # NOTE: We intentionally do NOT enable auto-merge. Auto-merge enabled by
+        # GITHUB_TOKEN causes the eventual squash-merge push to main to be
+        # suppressed from triggering downstream `on: push` workflows (including
+        # post-release.yml). The approver must click "Squash and merge" manually
+        # in the UI so the push is attributed to a human and post-release fires.
+        # See https://docs.github.com/en/actions/concepts/security/github_token
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          sign-commits: true
+          commit-message: ${{ steps.commit-msg.outputs.message }}
+          branch: ${{ steps.meta.outputs.branch }}
+          base: main
+          title: ${{ steps.meta.outputs.pr_title }}
+          body: ${{ steps.meta.outputs.body }}
+          labels: release
+          # Don't delete the release branch on rerun — we want predictable, run-id-suffixed branches.
+          delete-branch: false
 
-          echo "Opened: $PR_URL"
+      - name: Summarize PR
+        if: steps.cpr.outputs.pull-request-url != ''
+        run: |
+          PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
+          PR_OP="${{ steps.cpr.outputs.pull-request-operation }}"
+          echo "Opened/updated: $PR_URL ($PR_OP)"
           echo "Reminder: approver must click 'Squash and merge' manually (not auto-merge)."
 
           echo "### PR" >> "$GITHUB_STEP_SUMMARY"
-          echo "$PR_URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "$PR_URL ($PR_OP)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Release failure guidance
         if: failure()
@@ -397,25 +397,12 @@ jobs:
             echo "git push origin :refs/tags/<pkg>@v<version>" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
 
-          elif [[ "${{ steps.commit.outcome }}" == "failure" ]]; then
-            echo "**Commit** — \`git commit\` failed (no changes staged, or git config issue)." >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "${{ steps.cpr.outcome }}" == "failure" ]]; then
+            echo "**Create signed commit + open PR** — \`peter-evans/create-pull-request\` failed." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Impact:** Nothing was pushed. Safe to re-run." >> "$GITHUB_STEP_SUMMARY"
-
-          elif [[ "${{ steps.push.outcome }}" == "failure" ]]; then
-            echo "**Push release branch** — \`git push origin HEAD:<branch>\` failed." >> "$GITHUB_STEP_SUMMARY"
+            echo "**Impact:** Depending on the failure point, the release branch \`${{ steps.meta.outputs.branch }}\` may or may not exist on the remote, and the PR may or may not have been opened. Check the workflow log and the branch list before re-running." >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Impact:** The commit exists only on the runner (now discarded). Nothing was pushed. Safe to re-run." >> "$GITHUB_STEP_SUMMARY"
-
-          elif [[ "${{ steps.open-pr.outcome }}" == "failure" ]]; then
-            echo "**Open PR** — \`gh pr create\` failed." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Impact:** The release branch \`${{ steps.meta.outputs.branch }}\` was pushed but the PR was not opened." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Recovery:** Open the PR manually from the pushed branch." >> "$GITHUB_STEP_SUMMARY"
-            echo '```bash' >> "$GITHUB_STEP_SUMMARY"
-            echo "gh pr create --base main --head \"${{ steps.meta.outputs.branch }}\" --title \"${{ steps.meta.outputs.pr_title }}\" --label release" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "**Recovery:** Re-run the workflow. The action is idempotent — it will update an existing branch/PR rather than creating duplicates." >> "$GITHUB_STEP_SUMMARY"
 
           else
             echo "An unexpected step failed. Check the workflow log above for details." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

The `prepare-release.yml` workflow currently runs `git add && git commit && git push` followed by `gh pr create` from inside the runner. Commits produced this way are **unsigned** — the runner has no signing key, and `GITHUB_TOKEN` over HTTPS does not retroactively sign anything.

This is visible on #115, where commit [`f9f25f8`](https://github.com/neondatabase/neon-js/pull/115/commits/f9f25f8) on `release/all-25179173528` lacks the green "Verified" badge.

## What

Replace the manual `commit + push + gh pr create` block with [`peter-evans/create-pull-request@v8.1.1`](https://github.com/peter-evans/create-pull-request).

That action creates the commit via the GitHub **Contents API** rather than `git push`. Commits made through that API path are auto-signed by the `github-actions[bot]` verified signature, so future release branches will ship with "Verified".

The action is pinned to the **full SHA** of `v8.1.1` (`5f6978faf089d4d20b00c7766989d076bb2fc7f1`, released 2025-04-22) per supply-chain policy — no floating tag references.

## Behavior preserved

- Same commit message format: `chore: release @neondatabase/<pkg>@v<ver> ...`
- Same release branch naming: `release/<package>-<run-id>`
- Same PR title, body, and `release` label
- Same auto-merge stance: **NOT** enabled — the approver must still click "Squash and merge" manually so `post-release.yml` fires on the push to `main` (workflows triggered via `GITHUB_TOKEN` are suppressed from triggering downstream `on: push` workflows; a human merge attribution is required)
- Existing version-bump, tag-preflight, ref validation, role check, and failure-guidance steps are untouched
- `Ensure release label exists` step is also untouched

## Side cleanups

- The three `commit / push / open-pr` step IDs in the failure-guidance block collapsed into a single `cpr` step ID, so the corresponding `elif` branch is consolidated.
- A small `Compute commit message` shell step still builds the message string, but only writes it to `$GITHUB_OUTPUT` for the action to consume — no actual `git commit` happens in shell anymore.

## Doesn't affect #115

PR #115 keeps its existing unsigned commit; it'll get superseded by the next release run, which will use the new signed-commit path.

## Test plan

- [ ] Manually dispatch `prepare-release.yml` against a throw-away package (or with a custom version) once this lands
- [ ] Confirm the resulting release branch's commit shows "Verified" with `github-actions[bot]` as the signer
- [ ] Confirm the PR body, title, label, and branch name match the previous format byte-for-byte (apart from the commit signature)
- [ ] Confirm `post-release.yml` still fires correctly when the approver squash-merges