### PR TITLE
chore(ci): trigger required checks via workflow_dispatch on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Build & Lint & Typecheck
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -79,6 +79,7 @@ jobs:
     permissions:
       contents: write      # push release branch
       pull-requests: write # open PR
+      actions: write       # dispatch ci.yml + unit-tests.yml on the release branch
 
     steps:
       - name: Harden the runner
@@ -347,6 +348,22 @@ jobs:
 
           echo "### PR" >> "$GITHUB_STEP_SUMMARY"
           echo "$PR_URL ($PR_OP)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Trigger required checks on release branch
+        if: steps.cpr.outputs.pull-request-url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.meta.outputs.branch }}
+        run: |
+          # Release PRs opened by peter-evans/create-pull-request via GITHUB_TOKEN
+          # don't trigger pull_request workflows (GitHub recursion guard).
+          # workflow_dispatch is exempt — dispatch ci.yml + unit-tests.yml manually
+          # so branch protection's required contexts (ci, unit-tests) report on the
+          # release branch HEAD SHA.
+          # See https://docs.github.com/en/actions/concepts/security/github_token
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh workflow run unit-tests.yml --ref "$BRANCH"
+          echo "Dispatched ci.yml and unit-tests.yml on $BRANCH" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Release failure guidance
         if: failure()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

PR #118 (the auth-ui release PR opened by `prepare-release.yml`) is stuck on **"Expected — Waiting for status to be reported"** for the required `ci` and `unit-tests` contexts. They never run, so the PR is gated forever.

## Root cause

PR #116 switched release-PR creation to `peter-evans/create-pull-request@v8` with `token: ${{ github.token }}` so commit signatures show up as verified `github-actions[bot]` (good). But that means the PR is opened by `GITHUB_TOKEN`.

Per [GitHub docs](https://docs.github.com/en/actions/concepts/security/github_token):

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run.

Our `ci.yml` and `unit-tests.yml` only trigger on `pull_request: branches:[main]`, so the recursion guard suppresses them on release PRs. Branch protection on `main` requires the `ci` and `unit-tests` contexts → never reported → PR stuck.

GitHub Apps and PATs are **not allowed in this org**, so we can't sidestep the guard with a different identity. `workflow_dispatch` is the only `GITHUB_TOKEN`-compatible escape hatch.

## Fix

- `ci.yml`, `unit-tests.yml`: add `workflow_dispatch:` trigger (no inputs needed). Existing `pull_request` triggers stay.
- `prepare-release.yml`:
  - Grant `actions: write` to the `prepare` job (needed to dispatch workflows via the API).
  - After the `Summarize PR` step, add a new `Trigger required checks on release branch` step that runs `gh workflow run ci.yml --ref "$BRANCH"` and the same for `unit-tests.yml`. Gated on `steps.cpr.outputs.pull-request-url != ''` so it's a no-op when nothing changed.

The dispatched runs register check-runs named `ci` and `unit-tests` on the release branch HEAD SHA. Branch protection sees them and the PR becomes mergeable.

## Why this works

- `workflow_dispatch` is exempt from the recursion guard, so it fires fine from inside another `GITHUB_TOKEN`-driven workflow.
- `gh workflow run --ref <branch>` runs the workflow at the branch's current HEAD, so check-runs land on the right SHA.
- No new tokens, secrets, or apps. `GITHUB_TOKEN` only.

## Refs

- #116 — introduced signed commits via `peter-evans/create-pull-request`, which surfaced this regression.
- #118 — currently stuck release PR that this fix unblocks for future releases.

Jira: #0000

## Verification

Once merged, the next `prepare-release` dispatch should:
1. Open the release PR with verified github-actions[bot] signatures (as today).
2. Immediately dispatch `ci.yml` and `unit-tests.yml` on the release branch.
3. Show both check-runs reporting on the PR within minutes — no more "Expected — Waiting for status to be reported".

PR #118 itself is unaffected by this PR (the dispatch step only runs on future `prepare-release` invocations). To unblock #118 specifically, an admin can manually run `gh workflow run ci.yml --ref release/auth-ui-<run-id>` and the same for `unit-tests.yml` after this change merges, or just re-trigger `prepare-release` for the same package.