### PR TITLE
[neon-js] feat: Vendor supabase/postgres-meta to drop vulnerable transitive deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,7 @@ Auth-UI CSS is designed to **never override user's theme**. This is achieved thr
 **CLI Tool**: `src/cli/`
 - `index.ts` - CLI entry point (bin: `neon-js`)
 - `commands/gen-types.ts` - Type generation command
-- `commands/generate-types.ts` - Core logic using postgres-meta
+- `commands/generate-types.ts` - Core logic using vendored postgres-meta (see `packages/neon-js/src/vendor/postgres-meta/README.md`)
 - `utils/parse-duration.ts` - Duration parsing
 
 **Dependencies**: Imports from `@neondatabase/postgrest-js` and `@neondatabase/auth`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,11 @@ export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   unicorn.configs.recommended, // Use Unicorn's recommended preset
-  globalIgnores(['**/dist/**', '**/examples/**']),
+  globalIgnores([
+    '**/dist/**',
+    '**/examples/**',
+    'packages/neon-js/src/vendor/**',
+  ]),
   {
     // Set tsconfigRootDir to resolve multiple tsconfig issue
     languageOptions: {

--- a/packages/neon-js/.prettierignore
+++ b/packages/neon-js/.prettierignore
@@ -1,0 +1,3 @@
+src/vendor/**
+dist/**
+node_modules/**

--- a/packages/neon-js/CHANGELOG.md
+++ b/packages/neon-js/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CLI internals**: Vendored `@supabase/postgres-meta` @ v0.93.1 (Apache-2.0)
+  into `src/vendor/postgres-meta/` and removed it from runtime `dependencies`.
+  Drops the upstream Fastify HTTP server, `@sentry/node`, `pgsql-parser`,
+  `prettier-plugin-sql`, `@sinclair/typebox`, and the `npm:@supabase/pg@0.0.3`
+  fork from the published tarball's transitive dependency tree. The
+  `neon-js gen-types` CLI behaviour is unchanged. Direct runtime deps gained:
+  `pg ^8.13`, `pg-format 1.0.4`, `postgres-array 3.0.4`, `prettier 3.8.1`.
+  See `src/vendor/postgres-meta/README.md` for license + update procedure.
+
 ### Added
 
 - **Client Telemetry**: Automatically injects `X-Neon-Client-Info` header with SDK name, version, runtime environment (Node.js, Deno, Bun, Edge, Browser), and framework detection (Next.js, Remix, React, Vue, Angular).

--- a/packages/neon-js/package.json
+++ b/packages/neon-js/package.json
@@ -98,7 +98,9 @@
   "files": [
     "dist",
     "llms.txt",
-    "sbom.cdx.json"
+    "sbom.cdx.json",
+    "src/vendor/postgres-meta/LICENSE",
+    "src/vendor/postgres-meta/README.md"
   ],
   "publishConfig": {
     "access": "public"
@@ -116,13 +118,18 @@
     "clean": "rm -rf node_modules dist"
   },
   "devDependencies": {
+    "@types/pg": "8.20.0",
+    "@types/pg-format": "1.0.5",
     "msw": "2.6.8"
   },
   "dependencies": {
     "@neondatabase/auth": "workspace:*",
     "@neondatabase/postgrest-js": "workspace:*",
-    "@supabase/postgres-meta": "0.93.1",
     "meow": "14.0.0",
+    "pg": "^8.13.0",
+    "pg-format": "1.0.4",
+    "postgres-array": "3.0.4",
+    "prettier": "3.8.1",
     "zod": "4.1.12"
   }
 }

--- a/packages/neon-js/src/cli/commands/generate-types.ts
+++ b/packages/neon-js/src/cli/commands/generate-types.ts
@@ -1,6 +1,6 @@
-import { PostgresMeta } from '@supabase/postgres-meta';
-import { getGeneratorMetadata } from '@supabase/postgres-meta/dist/lib/generators.js';
-import { apply as applyTypescriptTemplate } from '@supabase/postgres-meta/dist/server/templates/typescript.js';
+import PostgresMeta from '../../vendor/postgres-meta/lib/PostgresMeta.js';
+import { getGeneratorMetadata } from '../../vendor/postgres-meta/lib/generators.js';
+import { apply as applyTypescriptTemplate } from '../../vendor/postgres-meta/templates/typescript.js';
 
 export interface GenerateTypesOptions {
   connectionString: string;

--- a/packages/neon-js/src/vendor/postgres-meta/LICENSE
+++ b/packages/neon-js/src/vendor/postgres-meta/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/neon-js/src/vendor/postgres-meta/README.md
+++ b/packages/neon-js/src/vendor/postgres-meta/README.md
@@ -1,0 +1,101 @@
+# Vendored: `@supabase/postgres-meta`
+
+A pruned, in-tree copy of the introspection portion of [supabase/postgres-meta](https://github.com/supabase/postgres-meta).
+
+| | |
+|---|---|
+| Source | https://github.com/supabase/postgres-meta |
+| Pinned tag | `v0.93.1` |
+| Pinned commit | `dc50199ca163b32ba4bdfa601dd3a9076ed2b640` |
+| Copied on | 2026-04-30 |
+| License | Apache-2.0 — see [`./LICENSE`](./LICENSE) |
+| Upstream license | Apache-2.0, copyright (c) Supabase Inc. (note: upstream `package.json` declares `"license": "MIT"`, but the LICENSE file shipped in the upstream tree is Apache-2.0; we ship the file verbatim and treat the sub-tree as Apache-2.0 to stay safe) |
+
+## Why we vendor instead of depending on it
+
+Upstream ships the introspection library and a Fastify HTTP server in a single
+npm tarball, dragging in a chain of vulnerable transitive dependencies (Fastify
+≤ 4.x CVE chain, Sentry's heavy node SDK, `pgsql-parser`, `prettier-plugin-sql`,
+`pino`, `swagger`, `fastify-metrics`, …) every time a downstream consumer of
+`@neondatabase/neon-js` runs `npm install`.
+
+`pnpm` overrides cannot fix this for our consumers — overrides only apply when
+*they* install transitively from us, and would not propagate through their own
+overrides. Vendoring the ~1% of postgres-meta we actually use lets us drop
+the entire HTTP server subtree (and its CVE surface) from the published tarball.
+
+## What we vendor
+
+Only the pieces the `neon-js gen-types` CLI uses:
+
+- `lib/PostgresMeta.ts` and the per-introspector classes (`PostgresMetaTables`,
+  `PostgresMetaColumns`, …).
+- `lib/db.ts` (pg pool init), `lib/types.ts`, `lib/helpers.ts`, `lib/constants.ts`.
+- `lib/generators.ts` — the `getGeneratorMetadata()` driver.
+- `lib/sql/*.ts` — the introspection SQL strings.
+- `templates/typescript.ts` — the TypeScript codegen template (`apply()`).
+- `LICENSE` — full upstream MIT license text.
+
+## What we deliberately did **not** vendor
+
+- `src/server/**` (Fastify routes, Sentry init, swagger, pino, fastify-metrics,
+  admin routes, crypto secret loaders).
+- `src/server/templates/go.ts`, `swift.ts` — neon-js only generates TypeScript.
+- `src/lib/Parser.ts` — pulls `pgsql-parser` and `prettier-plugin-sql`. It only
+  exposes `parse`/`deparse`/`format` on `PostgresMeta`, none of which the CLI
+  uses. Removed from the vendored `PostgresMeta` class.
+- All test files.
+
+## Modifications applied
+
+- **Removed `@sentry/node` calls** from `lib/db.ts`. The `Sentry.startSpan(...)`
+  wrappers are pure tracing; the CLI does not initialise a Sentry SDK so they
+  were no-ops anyway. Replaced each wrapped block with the inner callback body.
+- **Stripped the `RESULT_SIZE_EXCEEDED` branch** from `lib/db.ts`. That branch
+  is specific to `npm:@supabase/pg@0.0.3`'s libpq stream-error patches; we use
+  upstream `pg@^8` which does not surface that error code.
+- **Switched from `npm:@supabase/pg@0.0.3` to upstream `pg@^8`** as the
+  PostgreSQL driver. The Supabase fork only exists for libpq result-size limits
+  the CLI does not need.
+- **Removed `@sinclair/typebox` runtime dependency** from `lib/types.ts`. The
+  upstream file declared every `Postgres*` shape twice — once as a typebox
+  `Type.Object(...)` schema (used by Fastify route validators we are not
+  vendoring) and once via `Static<typeof …>`. We dropped the schema constants
+  and rewrote the `Postgres*` types as plain TypeScript interfaces / unions.
+- **Removed `Parser` import + `parse`/`deparse`/`format` fields** from
+  `lib/PostgresMeta.ts` (see "What we deliberately did not vendor").
+- **Re-pointed `templates/typescript.ts`'s `'../../lib/index.js'` import** to
+  `'../lib/index.js'` to fit our flatter directory layout, and added a slim
+  `lib/index.ts` re-export that lists only the types the template needs.
+- **Added a slim `constants.ts`** containing only `GENERATE_TYPES_DEFAULT_SCHEMA`,
+  `VALID_FUNCTION_ARGS_MODE`, `VALID_UNNAMED_FUNCTION_ARG_TYPES`, the three
+  values pulled from upstream's `src/server/constants.ts`. The upstream file is
+  not vendored because everything else in it is server-side.
+
+Each vendored `.ts` file carries a top-of-file header listing the upstream
+SHA and any per-file modifications.
+
+## How to update
+
+1. Bump `Pinned tag` and `Pinned commit` above to the new upstream release.
+2. Re-fetch the file list (see the table in `Modifications applied` above)
+   from the new tag.
+3. Re-apply the modifications listed above. The git history of this directory
+   is the canonical record of what changed and why.
+4. Run `pnpm --filter @neondatabase/neon-js typecheck` and `pnpm test`.
+5. Update the `Copied on` date.
+6. Bump per-file headers' tag/commit/date.
+
+## License notes
+
+Upstream's `package.json` declares MIT, but the actual `LICENSE` file shipped
+in the upstream tree (and copied verbatim here) is Apache-2.0. To stay on the
+strictly safer side we treat the vendored sub-tree as Apache-2.0:
+
+- Per-file headers include `SPDX-License-Identifier: Apache-2.0`.
+- Each file lists the modifications made by Neon (Apache-2.0 §4(b)).
+- The LICENSE file is shipped verbatim in this directory (Apache-2.0 §4(a)).
+- No NOTICE file exists upstream, so none is required here (Apache-2.0 §4(d)).
+
+The rest of `@neondatabase/neon-js` is also Apache-2.0, so license compatibility
+is trivial.

--- a/packages/neon-js/src/vendor/postgres-meta/constants.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/constants.ts
@@ -1,0 +1,16 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ./LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   - This file is a slim subset of upstream's `src/server/constants.ts`.
+//     It contains only the three values imported by `templates/typescript.ts`.
+//     The rest of upstream's `server/constants.ts` configures a Fastify HTTP
+//     server we do not vendor and pulls in `crypto-js` and a `getSecret`
+//     loader, neither of which we want.
+
+export const GENERATE_TYPES_DEFAULT_SCHEMA =
+  process.env.PG_META_GENERATE_TYPES_DEFAULT_SCHEMA || 'public'
+
+export const VALID_UNNAMED_FUNCTION_ARG_TYPES = new Set([114, 3802, 25])
+export const VALID_FUNCTION_ARGS_MODE = new Set(['in', 'inout', 'variadic'])

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMeta.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMeta.ts
@@ -28,7 +28,7 @@ import PostgresMetaTypes from './PostgresMetaTypes.js'
 import PostgresMetaVersion from './PostgresMetaVersion.js'
 import PostgresMetaViews from './PostgresMetaViews.js'
 import { init } from './db.js'
-import { PostgresMetaResult, PoolConfig } from './types.js'
+import type { PostgresMetaResult, PoolConfig } from './types.js'
 
 export default class PostgresMeta {
   query: (

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMeta.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMeta.ts
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) Supabase Inc. — see ../LICENSE
 // Modified by Neon for vendoring purposes, 2026-04-30:
-//   none
+//   - dropped `import * as Parser from './Parser.js'` and the
+//     `parse` / `deparse` / `format` field assignments. The Parser depends on
+//     `pgsql-parser` + `prettier-plugin-sql`, which we do not vendor; the
+//     CLI's `generateTypes` path never calls those methods.
 
-import * as Parser from './Parser.js'
 import PostgresMetaColumnPrivileges from './PostgresMetaColumnPrivileges.js'
 import PostgresMetaColumns from './PostgresMetaColumns.js'
 import PostgresMetaConfig from './PostgresMetaConfig.js'
@@ -53,10 +55,6 @@ export default class PostgresMeta {
   types: PostgresMetaTypes
   version: PostgresMetaVersion
   views: PostgresMetaViews
-
-  parse = Parser.Parse
-  deparse = Parser.Deparse
-  format = Parser.Format
 
   constructor(config: PoolConfig) {
     const { query, end } = init(config)

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMeta.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMeta.ts
@@ -1,0 +1,85 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import * as Parser from './Parser.js'
+import PostgresMetaColumnPrivileges from './PostgresMetaColumnPrivileges.js'
+import PostgresMetaColumns from './PostgresMetaColumns.js'
+import PostgresMetaConfig from './PostgresMetaConfig.js'
+import PostgresMetaExtensions from './PostgresMetaExtensions.js'
+import PostgresMetaForeignTables from './PostgresMetaForeignTables.js'
+import PostgresMetaFunctions from './PostgresMetaFunctions.js'
+import PostgresMetaIndexes from './PostgresMetaIndexes.js'
+import PostgresMetaMaterializedViews from './PostgresMetaMaterializedViews.js'
+import PostgresMetaPolicies from './PostgresMetaPolicies.js'
+import PostgresMetaPublications from './PostgresMetaPublications.js'
+import PostgresMetaRelationships from './PostgresMetaRelationships.js'
+import PostgresMetaRoles from './PostgresMetaRoles.js'
+import PostgresMetaSchemas from './PostgresMetaSchemas.js'
+import PostgresMetaTablePrivileges from './PostgresMetaTablePrivileges.js'
+import PostgresMetaTables from './PostgresMetaTables.js'
+import PostgresMetaTriggers from './PostgresMetaTriggers.js'
+import PostgresMetaTypes from './PostgresMetaTypes.js'
+import PostgresMetaVersion from './PostgresMetaVersion.js'
+import PostgresMetaViews from './PostgresMetaViews.js'
+import { init } from './db.js'
+import { PostgresMetaResult, PoolConfig } from './types.js'
+
+export default class PostgresMeta {
+  query: (
+    sql: string,
+    opts?: { statementQueryTimeout?: number; trackQueryInSentry?: boolean; parameters?: unknown[] }
+  ) => Promise<PostgresMetaResult<any>>
+  end: () => Promise<void>
+  columnPrivileges: PostgresMetaColumnPrivileges
+  columns: PostgresMetaColumns
+  config: PostgresMetaConfig
+  extensions: PostgresMetaExtensions
+  foreignTables: PostgresMetaForeignTables
+  functions: PostgresMetaFunctions
+  indexes: PostgresMetaIndexes
+  materializedViews: PostgresMetaMaterializedViews
+  policies: PostgresMetaPolicies
+  publications: PostgresMetaPublications
+  relationships: PostgresMetaRelationships
+  roles: PostgresMetaRoles
+  schemas: PostgresMetaSchemas
+  tablePrivileges: PostgresMetaTablePrivileges
+  tables: PostgresMetaTables
+  triggers: PostgresMetaTriggers
+  types: PostgresMetaTypes
+  version: PostgresMetaVersion
+  views: PostgresMetaViews
+
+  parse = Parser.Parse
+  deparse = Parser.Deparse
+  format = Parser.Format
+
+  constructor(config: PoolConfig) {
+    const { query, end } = init(config)
+    this.query = query
+    this.end = end
+    this.columnPrivileges = new PostgresMetaColumnPrivileges(this.query)
+    this.columns = new PostgresMetaColumns(this.query)
+    this.config = new PostgresMetaConfig(this.query)
+    this.extensions = new PostgresMetaExtensions(this.query)
+    this.foreignTables = new PostgresMetaForeignTables(this.query)
+    this.functions = new PostgresMetaFunctions(this.query)
+    this.indexes = new PostgresMetaIndexes(this.query)
+    this.materializedViews = new PostgresMetaMaterializedViews(this.query)
+    this.policies = new PostgresMetaPolicies(this.query)
+    this.publications = new PostgresMetaPublications(this.query)
+    this.relationships = new PostgresMetaRelationships(this.query)
+    this.roles = new PostgresMetaRoles(this.query)
+    this.schemas = new PostgresMetaSchemas(this.query)
+    this.tablePrivileges = new PostgresMetaTablePrivileges(this.query)
+    this.tables = new PostgresMetaTables(this.query)
+    this.triggers = new PostgresMetaTriggers(this.query)
+    this.types = new PostgresMetaTypes(this.query)
+    this.version = new PostgresMetaVersion(this.query)
+    this.views = new PostgresMetaViews(this.query)
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumnPrivileges.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumnPrivileges.ts
@@ -9,7 +9,7 @@ import { ident, literal } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { filterByValue, filterByList } from './helpers.js'
 import { COLUMN_PRIVILEGES_SQL } from './sql/column_privileges.sql.js'
-import {
+import type {
   PostgresMetaResult,
   PostgresColumnPrivileges,
   PostgresColumnPrivilegesGrant,

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumnPrivileges.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumnPrivileges.ts
@@ -1,0 +1,127 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByValue, filterByList } from './helpers.js'
+import { COLUMN_PRIVILEGES_SQL } from './sql/column_privileges.sql.js'
+import {
+  PostgresMetaResult,
+  PostgresColumnPrivileges,
+  PostgresColumnPrivilegesGrant,
+  PostgresColumnPrivilegesRevoke,
+} from './types.js'
+
+export default class PostgresMetaColumnPrivileges {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresColumnPrivileges[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = COLUMN_PRIVILEGES_SQL({ schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async grant(
+    grants: PostgresColumnPrivilegesGrant[]
+  ): Promise<PostgresMetaResult<PostgresColumnPrivileges[]>> {
+    let sql = `
+do $$
+declare
+  col record;
+begin
+${grants
+  .map(({ privilege_type, column_id, grantee, is_grantable }) => {
+    const [relationId, columnNumber] = column_id.split('.')
+    return `
+select *
+from pg_attribute a
+where a.attrelid = ${literal(relationId)}
+  and a.attnum = ${literal(columnNumber)}
+into col;
+execute format(
+  'grant ${privilege_type} (%I) on %s to ${
+    grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
+  } ${is_grantable ? 'with grant option' : ''}',
+  col.attname,
+  col.attrelid::regclass
+);`
+  })
+  .join('\n')}
+end $$;
+`
+    const { data, error } = await this.query(sql)
+    if (error) {
+      return { data, error }
+    }
+
+    // Return the updated column privileges for modified columns.
+    const columnIds = [...new Set(grants.map(({ column_id }) => column_id))]
+    const columnIdsFilter = filterByValue(columnIds)
+    sql = COLUMN_PRIVILEGES_SQL({ columnIdsFilter })
+    return await this.query(sql)
+  }
+
+  async revoke(
+    revokes: PostgresColumnPrivilegesRevoke[]
+  ): Promise<PostgresMetaResult<PostgresColumnPrivileges[]>> {
+    let sql = `
+do $$
+declare
+  col record;
+begin
+${revokes
+  .map(({ privilege_type, column_id, grantee }) => {
+    const [relationId, columnNumber] = column_id.split('.')
+    return `
+select *
+from pg_attribute a
+where a.attrelid = ${literal(relationId)}
+  and a.attnum = ${literal(columnNumber)}
+into col;
+execute format(
+  'revoke ${privilege_type} (%I) on %s from ${
+    grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
+  }',
+  col.attname,
+  col.attrelid::regclass
+);`
+  })
+  .join('\n')}
+end $$;
+`
+    const { data, error } = await this.query(sql)
+    if (error) {
+      return { data, error }
+    }
+
+    // Return the updated column privileges for modified columns.
+    const columnIds = [...new Set(revokes.map(({ column_id }) => column_id))]
+    const columnIdsFilter = filterByValue(columnIds)
+    sql = COLUMN_PRIVILEGES_SQL({ columnIdsFilter })
+    return await this.query(sql)
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumns.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumns.ts
@@ -1,0 +1,419 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import PostgresMetaTables from './PostgresMetaTables.js'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { PostgresMetaResult, PostgresColumn } from './types.js'
+import { filterByValue, filterByList } from './helpers.js'
+import { COLUMNS_SQL } from './sql/columns.sql.js'
+
+export default class PostgresMetaColumns {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+  metaTables: PostgresMetaTables
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+    this.metaTables = new PostgresMetaTables(query)
+  }
+
+  async list({
+    tableId,
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    tableId?: number
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresColumn[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const tableIdFilter = tableId ? filterByValue([`${tableId}`]) : undefined
+    const sql = COLUMNS_SQL({ schemaFilter, tableIdFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: string }): Promise<PostgresMetaResult<PostgresColumn>>
+  async retrieve({
+    name,
+    table,
+    schema,
+  }: {
+    name: string
+    table: string
+    schema: string
+  }): Promise<PostgresMetaResult<PostgresColumn>>
+  async retrieve({
+    id,
+    name,
+    table,
+    schema = 'public',
+  }: {
+    id?: string
+    name?: string
+    table?: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresColumn>> {
+    const schemaFilter = schema ? filterByList([schema], []) : undefined
+    if (id) {
+      const regexp = /^(\d+)\.(\d+)$/
+      if (!regexp.test(id)) {
+        return { data: null, error: { message: 'Invalid format for column ID' } }
+      }
+      const matches = id.match(regexp) as RegExpMatchArray
+      const [tableId, ordinalPos] = matches.slice(1).map(Number)
+      const idsFilter = filterByValue([`${tableId}.${ordinalPos}`])
+      const sql = COLUMNS_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a column with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name && table) {
+      const columnNameFilter = filterByValue([`${table}.${name}`])
+      const sql = `${COLUMNS_SQL({ schemaFilter, columnNameFilter })};`
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: { message: `Cannot find a column named ${name} in table ${schema}.${table}` },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on column retrieve' } }
+    }
+  }
+
+  async create({
+    table_id,
+    name,
+    type,
+    default_value,
+    default_value_format = 'literal',
+    is_identity = false,
+    identity_generation = 'BY DEFAULT',
+    // Can't pick a value as default since regular columns are nullable by default but PK columns aren't
+    is_nullable,
+    is_primary_key = false,
+    is_unique = false,
+    comment,
+    check,
+  }: {
+    table_id: number
+    name: string
+    type: string
+    default_value?: any
+    default_value_format?: 'expression' | 'literal'
+    is_identity?: boolean
+    identity_generation?: 'BY DEFAULT' | 'ALWAYS'
+    is_nullable?: boolean
+    is_primary_key?: boolean
+    is_unique?: boolean
+    comment?: string
+    check?: string
+  }): Promise<PostgresMetaResult<PostgresColumn>> {
+    const { data, error } = await this.metaTables.retrieve({ id: table_id })
+    if (error) {
+      return { data: null, error }
+    }
+    const { name: table, schema } = data!
+
+    let defaultValueClause = ''
+    if (is_identity) {
+      if (default_value !== undefined) {
+        return {
+          data: null,
+          error: { message: 'Columns cannot both be identity and have a default value' },
+        }
+      }
+
+      defaultValueClause = `GENERATED ${identity_generation} AS IDENTITY`
+    } else {
+      if (default_value === undefined) {
+        // skip
+      } else if (default_value_format === 'expression') {
+        defaultValueClause = `DEFAULT ${default_value}`
+      } else {
+        defaultValueClause = `DEFAULT ${literal(default_value)}`
+      }
+    }
+
+    let isNullableClause = ''
+    if (is_nullable !== undefined) {
+      isNullableClause = is_nullable ? 'NULL' : 'NOT NULL'
+    }
+    const isPrimaryKeyClause = is_primary_key ? 'PRIMARY KEY' : ''
+    const isUniqueClause = is_unique ? 'UNIQUE' : ''
+    const checkSql = check === undefined ? '' : `CHECK (${check})`
+    const commentSql =
+      comment === undefined
+        ? ''
+        : `COMMENT ON COLUMN ${ident(schema)}.${ident(table)}.${ident(name)} IS ${literal(comment)}`
+
+    const sql = `
+BEGIN;
+  ALTER TABLE ${ident(schema)}.${ident(table)} ADD COLUMN ${ident(name)} ${typeIdent(type)}
+    ${defaultValueClause}
+    ${isNullableClause}
+    ${isPrimaryKeyClause}
+    ${isUniqueClause}
+    ${checkSql};
+  ${commentSql};
+COMMIT;`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return await this.retrieve({ name, table, schema })
+  }
+
+  async update(
+    id: string,
+    {
+      name,
+      type,
+      drop_default = false,
+      default_value,
+      default_value_format = 'literal',
+      is_identity,
+      identity_generation = 'BY DEFAULT',
+      is_nullable,
+      is_unique,
+      comment,
+      check,
+    }: {
+      name?: string
+      type?: string
+      drop_default?: boolean
+      default_value?: any
+      default_value_format?: 'expression' | 'literal'
+      is_identity?: boolean
+      identity_generation?: 'BY DEFAULT' | 'ALWAYS'
+      is_nullable?: boolean
+      is_unique?: boolean
+      comment?: string
+      check?: string | null
+    }
+  ): Promise<PostgresMetaResult<PostgresColumn>> {
+    const { data: old, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+
+    const nameSql =
+      name === undefined || name === old!.name
+        ? ''
+        : `ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} RENAME COLUMN ${ident(
+            old!.name
+          )} TO ${ident(name)};`
+    // We use USING to allow implicit conversion of incompatible types (e.g. int4 -> text).
+    const typeSql =
+      type === undefined
+        ? ''
+        : `ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} ALTER COLUMN ${ident(
+            old!.name
+          )} SET DATA TYPE ${typeIdent(type)} USING ${ident(old!.name)}::${typeIdent(type)};`
+
+    let defaultValueSql: string
+    if (drop_default) {
+      defaultValueSql = `ALTER TABLE ${ident(old!.schema)}.${ident(
+        old!.table
+      )} ALTER COLUMN ${ident(old!.name)} DROP DEFAULT;`
+    } else if (default_value === undefined) {
+      defaultValueSql = ''
+    } else {
+      const defaultValue =
+        default_value_format === 'expression' ? default_value : literal(default_value)
+      defaultValueSql = `ALTER TABLE ${ident(old!.schema)}.${ident(
+        old!.table
+      )} ALTER COLUMN ${ident(old!.name)} SET DEFAULT ${defaultValue};`
+    }
+    // What identitySql does vary depending on the old and new values of
+    // is_identity and identity_generation.
+    //
+    // | is_identity: old \ new | undefined          | true               | false          |
+    // |------------------------+--------------------+--------------------+----------------|
+    // | true                   | maybe set identity | maybe set identity | drop if exists |
+    // |------------------------+--------------------+--------------------+----------------|
+    // | false                  | -                  | add identity       | drop if exists |
+    let identitySql = `ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} ALTER COLUMN ${ident(
+      old!.name
+    )}`
+    if (is_identity === false) {
+      identitySql += ' DROP IDENTITY IF EXISTS;'
+    } else if (old!.is_identity === true) {
+      if (identity_generation === undefined) {
+        identitySql = ''
+      } else {
+        identitySql += ` SET GENERATED ${identity_generation};`
+      }
+    } else if (is_identity === undefined) {
+      identitySql = ''
+    } else {
+      identitySql += ` ADD GENERATED ${identity_generation} AS IDENTITY;`
+    }
+    let isNullableSql: string
+    if (is_nullable === undefined) {
+      isNullableSql = ''
+    } else {
+      isNullableSql = is_nullable
+        ? `ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} ALTER COLUMN ${ident(
+            old!.name
+          )} DROP NOT NULL;`
+        : `ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} ALTER COLUMN ${ident(
+            old!.name
+          )} SET NOT NULL;`
+    }
+    let isUniqueSql = ''
+    if (old!.is_unique === true && is_unique === false) {
+      isUniqueSql = `
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT conname FROM pg_constraint WHERE
+      contype = 'u'
+      AND cardinality(conkey) = 1
+      AND conrelid = ${literal(old!.table_id)}
+      AND conkey[1] = ${literal(old!.ordinal_position)}
+  LOOP
+    EXECUTE ${literal(
+      `ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} DROP CONSTRAINT `
+    )} || quote_ident(r.conname);
+  END LOOP;
+END
+$$;
+`
+    } else if (old!.is_unique === false && is_unique === true) {
+      isUniqueSql = `ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} ADD UNIQUE (${ident(
+        old!.name
+      )});`
+    }
+    const commentSql =
+      comment === undefined
+        ? ''
+        : `COMMENT ON COLUMN ${ident(old!.schema)}.${ident(old!.table)}.${ident(
+            old!.name
+          )} IS ${literal(comment)};`
+
+    const checkSql =
+      check === undefined
+        ? ''
+        : `
+DO $$
+DECLARE
+  v_conname name;
+  v_conkey int2[];
+BEGIN
+  SELECT conname into v_conname FROM pg_constraint WHERE
+    contype = 'c'
+    AND cardinality(conkey) = 1
+    AND conrelid = ${literal(old!.table_id)}
+    AND conkey[1] = ${literal(old!.ordinal_position)}
+    ORDER BY oid asc
+    LIMIT 1;
+
+  IF v_conname IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE ${ident(old!.schema)}.${ident(
+      old!.table
+    )} DROP CONSTRAINT %s', v_conname);
+  END IF;
+
+  ${
+    check !== null
+      ? `
+  ALTER TABLE ${ident(old!.schema)}.${ident(old!.table)} ADD CONSTRAINT ${ident(
+    `${old!.table}_${old!.name}_check`
+  )} CHECK (${check});
+
+  SELECT conkey into v_conkey FROM pg_constraint WHERE conname = ${literal(
+    `${old!.table}_${old!.name}_check`
+  )};
+
+  ASSERT v_conkey IS NOT NULL, 'error creating column constraint: check condition must refer to this column';
+  ASSERT cardinality(v_conkey) = 1, 'error creating column constraint: check condition cannot refer to multiple columns';
+  ASSERT v_conkey[1] = ${literal(
+    old!.ordinal_position
+  )}, 'error creating column constraint: check condition cannot refer to other columns';
+  `
+      : ''
+  }
+END
+$$;
+`
+
+    // TODO: Can't set default if column is previously identity even if
+    // is_identity: false. Must do two separate PATCHes (once to drop identity
+    // and another to set default).
+    // NOTE: nameSql must be last. defaultValueSql must be after typeSql.
+    // identitySql must be after isNullableSql.
+    const sql = `
+BEGIN;
+  ${isNullableSql}
+  ${typeSql}
+  ${defaultValueSql}
+  ${identitySql}
+  ${isUniqueSql}
+  ${commentSql}
+  ${checkSql}
+  ${nameSql}
+COMMIT;`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return await this.retrieve({ id })
+  }
+
+  async remove(id: string, { cascade = false } = {}): Promise<PostgresMetaResult<PostgresColumn>> {
+    const { data: column, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `ALTER TABLE ${ident(column!.schema)}.${ident(column!.table)} DROP COLUMN ${ident(
+      column!.name
+    )} ${cascade ? 'CASCADE' : 'RESTRICT'};`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: column!, error: null }
+  }
+}
+
+// TODO: make this more robust - use type_id or type_schema + type_name instead
+// of just type.
+const typeIdent = (type: string) => {
+  return type.endsWith('[]')
+    ? `${ident(type.slice(0, -2))}[]`
+    : type.includes('.')
+      ? type
+      : ident(type)
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumns.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaColumns.ts
@@ -8,7 +8,7 @@
 import { ident, literal } from 'pg-format'
 import PostgresMetaTables from './PostgresMetaTables.js'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
-import { PostgresMetaResult, PostgresColumn } from './types.js'
+import type { PostgresMetaResult, PostgresColumn } from './types.js'
 import { filterByValue, filterByList } from './helpers.js'
 import { COLUMNS_SQL } from './sql/columns.sql.js'
 

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaConfig.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaConfig.ts
@@ -6,7 +6,7 @@
 //   none
 
 import { CONFIG_SQL } from './sql/config.sql.js'
-import { PostgresMetaResult, PostgresConfig } from './types.js'
+import type { PostgresMetaResult, PostgresConfig } from './types.js'
 
 export default class PostgresMetaConfig {
   query: (sql: string) => Promise<PostgresMetaResult<any>>

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaConfig.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaConfig.ts
@@ -1,0 +1,28 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { CONFIG_SQL } from './sql/config.sql.js'
+import { PostgresMetaResult, PostgresConfig } from './types.js'
+
+export default class PostgresMetaConfig {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    limit,
+    offset,
+  }: {
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresConfig[]>> {
+    const sql = CONFIG_SQL({ limit, offset })
+    return await this.query(sql)
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaExtensions.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaExtensions.ts
@@ -1,0 +1,113 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import { PostgresMetaResult, PostgresExtension } from './types.js'
+import { EXTENSIONS_SQL } from './sql/extensions.sql.js'
+import { filterByValue } from './helpers.js'
+
+export default class PostgresMetaExtensions {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    limit,
+    offset,
+  }: {
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresExtension[]>> {
+    const sql = EXTENSIONS_SQL({ limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ name }: { name: string }): Promise<PostgresMetaResult<PostgresExtension>> {
+    const nameFilter = filterByValue([name])
+    const sql = EXTENSIONS_SQL({ nameFilter })
+    const { data, error } = await this.query(sql)
+    if (error) {
+      return { data, error }
+    } else if (data.length === 0) {
+      return { data: null, error: { message: `Cannot find an extension named ${name}` } }
+    } else {
+      return { data: data[0], error }
+    }
+  }
+
+  async create({
+    name,
+    schema,
+    version,
+    cascade = false,
+  }: {
+    name: string
+    schema?: string
+    version?: string
+    cascade?: boolean
+  }): Promise<PostgresMetaResult<PostgresExtension>> {
+    const sql = `
+CREATE EXTENSION ${ident(name)}
+  ${schema === undefined ? '' : `SCHEMA ${ident(schema)}`}
+  ${version === undefined ? '' : `VERSION ${literal(version)}`}
+  ${cascade ? 'CASCADE' : ''};`
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name })
+  }
+
+  async update(
+    name: string,
+    {
+      update = false,
+      version,
+      schema,
+    }: {
+      update?: boolean
+      version?: string
+      schema?: string
+    }
+  ): Promise<PostgresMetaResult<PostgresExtension>> {
+    let updateSql = ''
+    if (update) {
+      updateSql = `ALTER EXTENSION ${ident(name)} UPDATE ${
+        version === undefined ? '' : `TO ${literal(version)}`
+      };`
+    }
+    const schemaSql =
+      schema === undefined ? '' : `ALTER EXTENSION ${ident(name)} SET SCHEMA ${ident(schema)};`
+
+    const sql = `BEGIN; ${updateSql} ${schemaSql} COMMIT;`
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name })
+  }
+
+  async remove(
+    name: string,
+    { cascade = false } = {}
+  ): Promise<PostgresMetaResult<PostgresExtension>> {
+    const { data: extension, error } = await this.retrieve({ name })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `DROP EXTENSION ${ident(name)} ${cascade ? 'CASCADE' : 'RESTRICT'};`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: extension!, error: null }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaExtensions.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaExtensions.ts
@@ -6,7 +6,7 @@
 //   none
 
 import { ident, literal } from 'pg-format'
-import { PostgresMetaResult, PostgresExtension } from './types.js'
+import type { PostgresMetaResult, PostgresExtension } from './types.js'
 import { EXTENSIONS_SQL } from './sql/extensions.sql.js'
 import { filterByValue } from './helpers.js'
 

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaForeignTables.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaForeignTables.ts
@@ -1,0 +1,130 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { coalesceRowsToArray, filterByList, filterByValue } from './helpers.js'
+import { PostgresMetaResult, PostgresForeignTable } from './types.js'
+import { FOREIGN_TABLES_SQL } from './sql/foreign_tables.sql.js'
+import { COLUMNS_SQL } from './sql/columns.sql.js'
+
+export default class PostgresMetaForeignTables {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list(options: {
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns: false
+  }): Promise<PostgresMetaResult<(PostgresForeignTable & { columns: never })[]>>
+  async list(options?: {
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns?: boolean
+  }): Promise<PostgresMetaResult<(PostgresForeignTable & { columns: unknown[] })[]>>
+  async list({
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+    includeColumns = true,
+  }: {
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns?: boolean
+  } = {}): Promise<PostgresMetaResult<PostgresForeignTable[]>> {
+    const schemaFilter = filterByList(includedSchemas, excludedSchemas)
+    const sql = generateEnrichedForeignTablesSql({ includeColumns, schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresForeignTable>>
+  async retrieve({
+    name,
+    schema,
+  }: {
+    name: string
+    schema: string
+  }): Promise<PostgresMetaResult<PostgresForeignTable>>
+  async retrieve({
+    id,
+    name,
+    schema = 'public',
+  }: {
+    id?: number
+    name?: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresForeignTable>> {
+    if (id) {
+      const idsFilter = filterByValue([`${id}`])
+      const sql = generateEnrichedForeignTablesSql({
+        includeColumns: true,
+        idsFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a foreign table with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const nameFilter = filterByValue([`${schema}.${name}`])
+      const sql = generateEnrichedForeignTablesSql({
+        includeColumns: true,
+        tableIdentifierFilter: nameFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: { message: `Cannot find a foreign table named ${name} in schema ${schema}` },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on foreign table retrieve' } }
+    }
+  }
+}
+
+const generateEnrichedForeignTablesSql = ({
+  includeColumns,
+  schemaFilter,
+  idsFilter,
+  tableIdentifierFilter,
+  limit,
+  offset,
+}: {
+  includeColumns: boolean
+  schemaFilter?: string
+  idsFilter?: string
+  tableIdentifierFilter?: string
+  limit?: number
+  offset?: number
+}) => `
+with foreign_tables as (${FOREIGN_TABLES_SQL({ schemaFilter, tableIdentifierFilter, limit, offset })})
+  ${includeColumns ? `, columns as (${COLUMNS_SQL({ schemaFilter, tableIdentifierFilter, tableIdFilter: idsFilter })})` : ''}
+select
+  *
+  ${
+    includeColumns
+      ? `, ${coalesceRowsToArray('columns', 'columns.table_id = foreign_tables.id')}`
+      : ''
+  }
+from foreign_tables`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaForeignTables.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaForeignTables.ts
@@ -6,7 +6,7 @@
 //   none
 
 import { coalesceRowsToArray, filterByList, filterByValue } from './helpers.js'
-import { PostgresMetaResult, PostgresForeignTable } from './types.js'
+import type { PostgresMetaResult, PostgresForeignTable } from './types.js'
 import { FOREIGN_TABLES_SQL } from './sql/foreign_tables.sql.js'
 import { COLUMNS_SQL } from './sql/columns.sql.js'
 

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaFunctions.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaFunctions.ts
@@ -1,0 +1,271 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByList, filterByValue } from './helpers.js'
+import { PostgresMetaResult, PostgresFunction, PostgresFunctionCreate } from './types.js'
+import { FUNCTIONS_SQL } from './sql/functions.sql.js'
+
+export default class PostgresMetaFunctions {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresFunction[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = FUNCTIONS_SQL({ schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresFunction>>
+  async retrieve({
+    name,
+    schema,
+    args,
+  }: {
+    name: string
+    schema: string
+    args: string[]
+  }): Promise<PostgresMetaResult<PostgresFunction>>
+  async retrieve({
+    id,
+    name,
+    schema = 'public',
+    args = [],
+  }: {
+    id?: number
+    name?: string
+    schema?: string
+    args?: string[]
+  }): Promise<PostgresMetaResult<PostgresFunction>> {
+    const schemaFilter = schema ? filterByList([schema], []) : undefined
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = FUNCTIONS_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a function with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name && schema && args) {
+      const nameFilter = filterByValue([name])
+      const sql = FUNCTIONS_SQL({ schemaFilter, nameFilter, args: args.map(literal) })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: {
+            message: `Cannot find function "${schema}"."${name}"(${args.join(', ')})`,
+          },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on function retrieve' } }
+    }
+  }
+
+  async create({
+    name,
+    schema = 'public',
+    args = [],
+    definition,
+    return_type = 'void',
+    language = 'sql',
+    behavior = 'VOLATILE',
+    security_definer = false,
+    config_params = {},
+  }: PostgresFunctionCreate): Promise<PostgresMetaResult<PostgresFunction>> {
+    const sql = this.generateCreateFunctionSql({
+      name,
+      schema,
+      args,
+      definition,
+      return_type,
+      language,
+      behavior,
+      security_definer,
+      config_params,
+    })
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name, schema, args })
+  }
+
+  async update(
+    id: number,
+    {
+      name,
+      schema,
+      definition,
+    }: {
+      name?: string
+      schema?: string
+      definition?: string
+    }
+  ): Promise<PostgresMetaResult<PostgresFunction>> {
+    const { data: currentFunc, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+
+    const args = currentFunc!.argument_types.split(', ')
+    const identityArgs = currentFunc!.identity_argument_types
+
+    const updateDefinitionSql =
+      typeof definition === 'string'
+        ? this.generateCreateFunctionSql(
+            {
+              ...currentFunc!,
+              definition,
+              args,
+              config_params: currentFunc!.config_params ?? {},
+            },
+            { replace: true }
+          )
+        : ''
+
+    const updateNameSql =
+      name && name !== currentFunc!.name
+        ? `ALTER FUNCTION ${ident(currentFunc!.schema)}.${ident(
+            currentFunc!.name
+          )}(${identityArgs}) RENAME TO ${ident(name)};`
+        : ''
+
+    const updateSchemaSql =
+      schema && schema !== currentFunc!.schema
+        ? `ALTER FUNCTION ${ident(currentFunc!.schema)}.${ident(
+            name || currentFunc!.name
+          )}(${identityArgs})  SET SCHEMA ${ident(schema)};`
+        : ''
+
+    const currentSchemaFilter = currentFunc!.schema
+      ? filterByList([currentFunc!.schema], [])
+      : undefined
+    const currentNameFilter = currentFunc!.name ? filterByValue([currentFunc!.name]) : undefined
+
+    const sql = `
+      DO LANGUAGE plpgsql $$
+      BEGIN
+        IF ${typeof definition === 'string' ? 'TRUE' : 'FALSE'} THEN
+          ${updateDefinitionSql}
+
+          IF (
+            SELECT id
+            FROM (${FUNCTIONS_SQL({ schemaFilter: currentSchemaFilter, nameFilter: currentNameFilter })}) AS f
+            WHERE f.schema = ${literal(currentFunc!.schema)}
+            AND f.name = ${literal(currentFunc!.name)}
+            AND f.identity_argument_types = ${literal(identityArgs)}
+          ) != ${id} THEN
+            RAISE EXCEPTION 'Cannot find function "${currentFunc!.schema}"."${
+              currentFunc!.name
+            }"(${identityArgs})';
+          END IF;
+        END IF;
+
+        ${updateNameSql}
+
+        ${updateSchemaSql}
+      END;
+      $$;
+    `
+
+    {
+      const { error } = await this.query(sql)
+
+      if (error) {
+        return { data: null, error }
+      }
+    }
+
+    return await this.retrieve({ id })
+  }
+
+  async remove(
+    id: number,
+    { cascade = false } = {}
+  ): Promise<PostgresMetaResult<PostgresFunction>> {
+    const { data: func, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `DROP FUNCTION ${ident(func!.schema)}.${ident(func!.name)}
+    (${func!.identity_argument_types})
+    ${cascade ? 'CASCADE' : 'RESTRICT'};`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: func!, error: null }
+  }
+
+  private generateCreateFunctionSql(
+    {
+      name,
+      schema,
+      args,
+      definition,
+      return_type,
+      language,
+      behavior,
+      security_definer,
+      config_params,
+    }: PostgresFunctionCreate,
+    { replace = false } = {}
+  ): string {
+    return `
+      CREATE ${replace ? 'OR REPLACE' : ''} FUNCTION ${ident(schema!)}.${ident(name!)}(${
+        args?.join(', ') || ''
+      })
+      RETURNS ${return_type}
+      AS ${literal(definition)}
+      LANGUAGE ${language}
+      ${behavior}
+      CALLED ON NULL INPUT
+      ${security_definer ? 'SECURITY DEFINER' : 'SECURITY INVOKER'}
+      ${
+        config_params
+          ? Object.entries(config_params)
+              .map(
+                ([param, value]: string[]) =>
+                  `SET ${param} ${value[0] === 'FROM CURRENT' ? 'FROM CURRENT' : 'TO ' + value}`
+              )
+              .join('\n')
+          : ''
+      };
+    `
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaFunctions.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaFunctions.ts
@@ -8,7 +8,7 @@
 import { ident, literal } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { filterByList, filterByValue } from './helpers.js'
-import { PostgresMetaResult, PostgresFunction, PostgresFunctionCreate } from './types.js'
+import type { PostgresMetaResult, PostgresFunction, PostgresFunctionCreate } from './types.js'
 import { FUNCTIONS_SQL } from './sql/functions.sql.js'
 
 export default class PostgresMetaFunctions {

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaIndexes.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaIndexes.ts
@@ -7,7 +7,7 @@
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { filterByList, filterByValue } from './helpers.js'
-import { PostgresMetaResult, PostgresIndex } from './types.js'
+import type { PostgresMetaResult, PostgresIndex } from './types.js'
 import { INDEXES_SQL } from './sql/indexes.sql.js'
 
 export default class PostgresMetaIndexes {

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaIndexes.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaIndexes.ts
@@ -1,0 +1,73 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByList, filterByValue } from './helpers.js'
+import { PostgresMetaResult, PostgresIndex } from './types.js'
+import { INDEXES_SQL } from './sql/indexes.sql.js'
+
+export default class PostgresMetaIndexes {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresIndex[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = INDEXES_SQL({ schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresIndex>>
+  async retrieve({
+    name,
+    schema,
+    args,
+  }: {
+    name: string
+    schema: string
+    args: string[]
+  }): Promise<PostgresMetaResult<PostgresIndex>>
+  async retrieve({
+    id,
+  }: {
+    id?: number
+    args?: string[]
+  }): Promise<PostgresMetaResult<PostgresIndex>> {
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = INDEXES_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a index with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on function retrieve' } }
+    }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaMaterializedViews.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaMaterializedViews.ts
@@ -6,7 +6,7 @@
 //   none
 
 import { filterByList, coalesceRowsToArray, filterByValue } from './helpers.js'
-import { PostgresMetaResult, PostgresMaterializedView } from './types.js'
+import type { PostgresMetaResult, PostgresMaterializedView } from './types.js'
 import { MATERIALIZED_VIEWS_SQL } from './sql/materialized_views.sql.js'
 import { COLUMNS_SQL } from './sql/columns.sql.js'
 

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaMaterializedViews.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaMaterializedViews.ts
@@ -1,0 +1,116 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { filterByList, coalesceRowsToArray, filterByValue } from './helpers.js'
+import { PostgresMetaResult, PostgresMaterializedView } from './types.js'
+import { MATERIALIZED_VIEWS_SQL } from './sql/materialized_views.sql.js'
+import { COLUMNS_SQL } from './sql/columns.sql.js'
+
+export default class PostgresMetaMaterializedViews {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+    includeColumns = false,
+  }: {
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns?: boolean
+  } = {}): Promise<PostgresMetaResult<PostgresMaterializedView[]>> {
+    const schemaFilter = filterByList(includedSchemas, excludedSchemas, undefined)
+    let sql = generateEnrichedMaterializedViewsSql({ includeColumns, schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresMaterializedView>>
+  async retrieve({
+    name,
+    schema,
+  }: {
+    name: string
+    schema: string
+  }): Promise<PostgresMetaResult<PostgresMaterializedView>>
+  async retrieve({
+    id,
+    name,
+    schema = 'public',
+  }: {
+    id?: number
+    name?: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresMaterializedView>> {
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = generateEnrichedMaterializedViewsSql({
+        includeColumns: true,
+        idsFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a materialized view with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const materializedViewIdentifierFilter = filterByValue([`${schema}.${name}`])
+      const sql = generateEnrichedMaterializedViewsSql({
+        includeColumns: true,
+        materializedViewIdentifierFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: { message: `Cannot find a materialized view named ${name} in schema ${schema}` },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on materialized view retrieve' } }
+    }
+  }
+}
+
+const generateEnrichedMaterializedViewsSql = ({
+  includeColumns,
+  schemaFilter,
+  materializedViewIdentifierFilter,
+  idsFilter,
+  limit,
+  offset,
+}: {
+  includeColumns: boolean
+  schemaFilter?: string
+  materializedViewIdentifierFilter?: string
+  idsFilter?: string
+  limit?: number
+  offset?: number
+}) => `
+with materialized_views as (${MATERIALIZED_VIEWS_SQL({ schemaFilter, limit, offset, materializedViewIdentifierFilter, idsFilter })})
+  ${includeColumns ? `, columns as (${COLUMNS_SQL({ schemaFilter, limit, offset, tableIdentifierFilter: materializedViewIdentifierFilter, tableIdFilter: idsFilter })})` : ''}
+select
+  *
+  ${
+    includeColumns
+      ? `, ${coalesceRowsToArray('columns', 'columns.table_id = materialized_views.id')}`
+      : ''
+  }
+from materialized_views`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPolicies.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPolicies.ts
@@ -8,7 +8,7 @@
 import { ident } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { filterByList, filterByValue } from './helpers.js'
-import { PostgresMetaResult, PostgresPolicy } from './types.js'
+import type { PostgresMetaResult, PostgresPolicy } from './types.js'
 import { POLICIES_SQL } from './sql/policies.sql.js'
 
 export default class PostgresMetaPolicies {

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPolicies.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPolicies.ts
@@ -1,0 +1,181 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident } from 'pg-format'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByList, filterByValue } from './helpers.js'
+import { PostgresMetaResult, PostgresPolicy } from './types.js'
+import { POLICIES_SQL } from './sql/policies.sql.js'
+
+export default class PostgresMetaPolicies {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresPolicy[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    let sql = POLICIES_SQL({ schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresPolicy>>
+  async retrieve({
+    name,
+    table,
+    schema,
+  }: {
+    name: string
+    table: string
+    schema: string
+  }): Promise<PostgresMetaResult<PostgresPolicy>>
+  async retrieve({
+    id,
+    name,
+    table,
+    schema = 'public',
+  }: {
+    id?: number
+    name?: string
+    table?: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresPolicy>> {
+    const schemaFilter = schema ? filterByList([schema], []) : undefined
+    if (id) {
+      const idsFilter = filterByValue([`${id}`])
+      const sql = POLICIES_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a policy with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name && table) {
+      const functionNameIdentifierFilter = filterByValue([`${table}.${name}`])
+      const sql = POLICIES_SQL({ schemaFilter, functionNameIdentifierFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: { message: `Cannot find a policy named ${name} for table ${schema}.${table}` },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on policy retrieve' } }
+    }
+  }
+
+  async create({
+    name,
+    table,
+    schema = 'public',
+    definition,
+    check,
+    action = 'PERMISSIVE',
+    command = 'ALL',
+    roles = ['public'],
+  }: {
+    name: string
+    table: string
+    schema?: string
+    definition?: string
+    check?: string
+    action?: string
+    command?: string
+    roles?: string[]
+  }): Promise<PostgresMetaResult<PostgresPolicy>> {
+    const definitionClause = definition === undefined ? '' : `USING (${definition})`
+    const checkClause = check === undefined ? '' : `WITH CHECK (${check})`
+    const sql = `
+CREATE POLICY ${ident(name)} ON ${ident(schema)}.${ident(table)}
+  AS ${action}
+  FOR ${command}
+  TO ${roles.map(ident).join(',')}
+  ${definitionClause} ${checkClause};`
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name, table, schema })
+  }
+
+  async update(
+    id: number,
+    {
+      name,
+      definition,
+      check,
+      roles,
+    }: {
+      name: string
+      definition?: string
+      check?: string
+      roles?: string[]
+    }
+  ): Promise<PostgresMetaResult<PostgresPolicy>> {
+    const { data: old, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+
+    const alter = `ALTER POLICY ${ident(old!.name)} ON ${ident(old!.schema)}.${ident(old!.table)}`
+    const nameSql = name === undefined ? '' : `${alter} RENAME TO ${ident(name)};`
+    const definitionSql = definition === undefined ? '' : `${alter} USING (${definition});`
+    const checkSql = check === undefined ? '' : `${alter} WITH CHECK (${check});`
+    const rolesSql = roles === undefined ? '' : `${alter} TO ${roles.map(ident).join(',')};`
+
+    // nameSql must be last
+    const sql = `BEGIN; ${definitionSql} ${checkSql} ${rolesSql} ${nameSql} COMMIT;`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return await this.retrieve({ id })
+  }
+
+  async remove(id: number): Promise<PostgresMetaResult<PostgresPolicy>> {
+    const { data: policy, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `DROP POLICY ${ident(policy!.name)} ON ${ident(policy!.schema)}.${ident(
+      policy!.table
+    )};`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: policy!, error: null }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPublications.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPublications.ts
@@ -1,0 +1,253 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import { PostgresMetaResult, PostgresPublication } from './types.js'
+import { PUBLICATIONS_SQL } from './sql/publications.sql.js'
+import { filterByValue } from './helpers.js'
+
+export default class PostgresMetaPublications {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    limit,
+    offset,
+  }: {
+    limit?: number
+    offset?: number
+  }): Promise<PostgresMetaResult<PostgresPublication[]>> {
+    let sql = PUBLICATIONS_SQL({ limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresPublication>>
+  async retrieve({ name }: { name: string }): Promise<PostgresMetaResult<PostgresPublication>>
+  async retrieve({
+    id,
+    name,
+  }: {
+    id?: number
+    name?: string
+  }): Promise<PostgresMetaResult<PostgresPublication>> {
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = PUBLICATIONS_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a publication with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const nameFilter = filterByValue([name])
+      const sql = PUBLICATIONS_SQL({ nameFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a publication named ${name}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on publication retrieve' } }
+    }
+  }
+
+  async create({
+    name,
+    publish_insert = false,
+    publish_update = false,
+    publish_delete = false,
+    publish_truncate = false,
+    tables = null,
+  }: {
+    name: string
+    publish_insert?: boolean
+    publish_update?: boolean
+    publish_delete?: boolean
+    publish_truncate?: boolean
+    tables?: string[] | null
+  }): Promise<PostgresMetaResult<PostgresPublication>> {
+    let tableClause: string
+    if (tables === undefined || tables === null) {
+      tableClause = 'FOR ALL TABLES'
+    } else if (tables.length === 0) {
+      tableClause = ''
+    } else {
+      tableClause = `FOR TABLE ${tables
+        .map((t) => {
+          if (!t.includes('.')) {
+            return ident(t)
+          }
+
+          const [schema, ...rest] = t.split('.')
+          const table = rest.join('.')
+          return `${ident(schema)}.${ident(table)}`
+        })
+        .join(',')}`
+    }
+
+    let publishOps = []
+    if (publish_insert) publishOps.push('insert')
+    if (publish_update) publishOps.push('update')
+    if (publish_delete) publishOps.push('delete')
+    if (publish_truncate) publishOps.push('truncate')
+
+    const sql = `
+CREATE PUBLICATION ${ident(name)} ${tableClause}
+  WITH (publish = '${publishOps.join(',')}');`
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name })
+  }
+
+  async update(
+    id: number,
+    {
+      name,
+      owner,
+      publish_insert,
+      publish_update,
+      publish_delete,
+      publish_truncate,
+      tables,
+    }: {
+      name?: string
+      owner?: string
+      publish_insert?: boolean
+      publish_update?: boolean
+      publish_delete?: boolean
+      publish_truncate?: boolean
+      tables?: string[] | null
+    }
+  ): Promise<PostgresMetaResult<PostgresPublication>> {
+    const sql = `
+do $$
+declare
+  id oid := ${literal(id)};
+  old record;
+  new_name text := ${name === undefined ? null : literal(name)};
+  new_owner text := ${owner === undefined ? null : literal(owner)};
+  new_publish_insert bool := ${publish_insert ?? null};
+  new_publish_update bool := ${publish_update ?? null};
+  new_publish_delete bool := ${publish_delete ?? null};
+  new_publish_truncate bool := ${publish_truncate ?? null};
+  new_tables text := ${
+    tables === undefined
+      ? null
+      : literal(
+          tables === null
+            ? 'all tables'
+            : tables
+                .map((t) => {
+                  if (!t.includes('.')) {
+                    return ident(t)
+                  }
+
+                  const [schema, ...rest] = t.split('.')
+                  const table = rest.join('.')
+                  return `${ident(schema)}.${ident(table)}`
+                })
+                .join(',')
+        )
+  };
+begin
+  select * into old from pg_publication where oid = id;
+  if old is null then
+    raise exception 'Cannot find publication with id %', id;
+  end if;
+
+  if new_tables is null then
+    null;
+  elsif new_tables = 'all tables' then
+    if old.puballtables then
+      null;
+    else
+      -- Need to recreate because going from list of tables <-> all tables with alter is not possible.
+      execute(format('drop publication %1$I; create publication %1$I for all tables;', old.pubname));
+    end if;
+  else
+    if old.puballtables then
+      -- Need to recreate because going from list of tables <-> all tables with alter is not possible.
+      execute(format('drop publication %1$I; create publication %1$I;', old.pubname));
+    elsif exists(select from pg_publication_rel where prpubid = id) then
+      execute(
+        format(
+          'alter publication %I drop table %s',
+          old.pubname,
+          (select string_agg(prrelid::regclass::text, ', ') from pg_publication_rel where prpubid = id)
+        )
+      );
+    end if;
+
+    -- At this point the publication must have no tables.
+
+    if new_tables != '' then
+      execute(format('alter publication %I add table %s', old.pubname, new_tables));
+    end if;
+  end if;
+
+  execute(
+    format(
+      'alter publication %I set (publish = %L);',
+      old.pubname,
+      concat_ws(
+        ', ',
+        case when coalesce(new_publish_insert, old.pubinsert) then 'insert' end,
+        case when coalesce(new_publish_update, old.pubupdate) then 'update' end,
+        case when coalesce(new_publish_delete, old.pubdelete) then 'delete' end,
+        case when coalesce(new_publish_truncate, old.pubtruncate) then 'truncate' end
+      )
+    )
+  );
+
+  execute(format('alter publication %I owner to %I;', old.pubname, coalesce(new_owner, old.pubowner::regrole::name)));
+
+  -- Using the same name in the rename clause gives an error, so only do it if the new name is different.
+  if new_name is not null and new_name != old.pubname then
+    execute(format('alter publication %I rename to %I;', old.pubname, coalesce(new_name, old.pubname)));
+  end if;
+
+  -- We need to retrieve the publication later, so we need a way to uniquely identify which publication this is.
+  -- We can't rely on id because it gets changed if it got recreated.
+  -- We use a temp table to store the unique name - DO blocks can't return a value.
+  create temp table pg_meta_publication_tmp (name) on commit drop as values (coalesce(new_name, old.pubname));
+end $$;
+
+with publications as (${PUBLICATIONS_SQL({})}) select * from publications where name = (select name from pg_meta_publication_tmp);
+`
+    const { data, error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return { data: data[0], error }
+  }
+
+  async remove(id: number): Promise<PostgresMetaResult<PostgresPublication>> {
+    const { data: publication, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `DROP PUBLICATION IF EXISTS ${ident(publication!.name)};`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: publication!, error: null }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPublications.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaPublications.ts
@@ -6,7 +6,7 @@
 //   none
 
 import { ident, literal } from 'pg-format'
-import { PostgresMetaResult, PostgresPublication } from './types.js'
+import type { PostgresMetaResult, PostgresPublication } from './types.js'
 import { PUBLICATIONS_SQL } from './sql/publications.sql.js'
 import { filterByValue } from './helpers.js'
 

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaRelationships.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaRelationships.ts
@@ -1,0 +1,171 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByList } from './helpers.js'
+import type { PostgresMetaResult, PostgresRelationship } from './types.js'
+import { TABLE_RELATIONSHIPS_SQL } from './sql/table_relationships.sql.js'
+import { VIEWS_KEY_DEPENDENCIES_SQL } from './sql/views_key_dependencies.sql.js'
+
+/*
+ * Only used for generating types at the moment. Will need some cleanups before
+ * using it for other things, e.g. /relationships endpoint.
+ */
+export default class PostgresMetaRelationships {
+  query: (sql: string) => Promise<PostgresMetaResult<unknown>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<unknown>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+  } = {}): Promise<PostgresMetaResult<PostgresRelationship[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    let allTableM2oAndO2oRelationships: PostgresRelationship[]
+    {
+      const sql = TABLE_RELATIONSHIPS_SQL({ schemaFilter })
+      const { data, error } = (await this.query(sql)) as PostgresMetaResult<PostgresRelationship[]>
+      if (error) {
+        return { data: null, error }
+      }
+      allTableM2oAndO2oRelationships = data
+    }
+
+    /*
+     * Adapted from:
+     * https://github.com/PostgREST/postgrest/blob/f9f0f79fa914ac00c11fbf7f4c558e14821e67e2/src/PostgREST/SchemaCache.hs#L392
+     */
+    let allViewM2oAndO2oRelationships: PostgresRelationship[]
+    {
+      type ColDep = {
+        table_column: string
+        view_columns: string[]
+      }
+      type KeyDep = {
+        table_schema: string
+        table_name: string
+        view_schema: string
+        view_name: string
+        constraint_name: string
+        constraint_type: 'f' | 'f_ref' | 'p' | 'p_ref'
+        column_dependencies: ColDep[]
+      }
+
+      const viewsKeyDependenciesSql = VIEWS_KEY_DEPENDENCIES_SQL({ schemaFilter })
+      const { data: viewsKeyDependencies, error } = (await this.query(
+        viewsKeyDependenciesSql
+      )) as PostgresMetaResult<KeyDep[]>
+      if (error) {
+        return { data: null, error }
+      }
+
+      const viewRelationships = allTableM2oAndO2oRelationships.flatMap((r) => {
+        const expandKeyDepCols = (
+          colDeps: ColDep[]
+        ): { tableColumns: string[]; viewColumns: string[] }[] => {
+          const tableColumns = colDeps.map(({ table_column }) => table_column)
+          // https://gist.github.com/ssippe/1f92625532eef28be6974f898efb23ef?permalink_comment_id=3474581#gistcomment-3474581
+          const cartesianProduct = <T>(allEntries: T[][]): T[][] => {
+            return allEntries.reduce<T[][]>(
+              (results, entries) =>
+                results
+                  .map((result) => entries.map((entry) => result.concat(entry)))
+                  .reduce((subResults, result) => subResults.concat(result), []),
+              [[]]
+            )
+          }
+          const viewColumnsPermutations = cartesianProduct(colDeps.map((cd) => cd.view_columns))
+          return viewColumnsPermutations.map((viewColumns) => ({ tableColumns, viewColumns }))
+        }
+
+        const viewToTableKeyDeps = viewsKeyDependencies.filter(
+          (vkd) =>
+            vkd.table_schema === r.schema &&
+            vkd.table_name === r.relation &&
+            vkd.constraint_name === r.foreign_key_name &&
+            vkd.constraint_type === 'f'
+        )
+        const tableToViewKeyDeps = viewsKeyDependencies.filter(
+          (vkd) =>
+            vkd.table_schema === r.referenced_schema &&
+            vkd.table_name === r.referenced_relation &&
+            vkd.constraint_name === r.foreign_key_name &&
+            vkd.constraint_type === 'f_ref'
+        )
+
+        const viewToTableRelationships = viewToTableKeyDeps.flatMap((vtkd) =>
+          expandKeyDepCols(vtkd.column_dependencies).map(({ viewColumns }) => ({
+            foreign_key_name: r.foreign_key_name,
+            schema: vtkd.view_schema,
+            relation: vtkd.view_name,
+            columns: viewColumns,
+            is_one_to_one: r.is_one_to_one,
+            referenced_schema: r.referenced_schema,
+            referenced_relation: r.referenced_relation,
+            referenced_columns: r.referenced_columns,
+          }))
+        )
+
+        const tableToViewRelationships = tableToViewKeyDeps.flatMap((tvkd) =>
+          expandKeyDepCols(tvkd.column_dependencies).map(({ viewColumns }) => ({
+            foreign_key_name: r.foreign_key_name,
+            schema: r.schema,
+            relation: r.relation,
+            columns: r.columns,
+            is_one_to_one: r.is_one_to_one,
+            referenced_schema: tvkd.view_schema,
+            referenced_relation: tvkd.view_name,
+            referenced_columns: viewColumns,
+          }))
+        )
+
+        const viewToViewRelationships = viewToTableKeyDeps.flatMap((vtkd) =>
+          expandKeyDepCols(vtkd.column_dependencies).flatMap(({ viewColumns }) =>
+            tableToViewKeyDeps.flatMap((tvkd) =>
+              expandKeyDepCols(tvkd.column_dependencies).map(
+                ({ viewColumns: referencedViewColumns }) => ({
+                  foreign_key_name: r.foreign_key_name,
+                  schema: vtkd.view_schema,
+                  relation: vtkd.view_name,
+                  columns: viewColumns,
+                  is_one_to_one: r.is_one_to_one,
+                  referenced_schema: tvkd.view_schema,
+                  referenced_relation: tvkd.view_name,
+                  referenced_columns: referencedViewColumns,
+                })
+              )
+            )
+          )
+        )
+
+        return [
+          ...viewToTableRelationships,
+          ...tableToViewRelationships,
+          ...viewToViewRelationships,
+        ]
+      })
+
+      allViewM2oAndO2oRelationships = viewRelationships
+    }
+
+    return {
+      data: allTableM2oAndO2oRelationships.concat(allViewM2oAndO2oRelationships),
+      error: null,
+    }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaRoles.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaRoles.ts
@@ -1,0 +1,278 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import { ROLES_SQL } from './sql/roles.sql.js'
+import {
+  PostgresMetaResult,
+  PostgresRole,
+  PostgresRoleCreate,
+  PostgresRoleUpdate,
+} from './types.js'
+import { filterByValue } from './helpers.js'
+export function changeRoleConfig2Object(config: string[]) {
+  if (!config) {
+    return null
+  }
+  return config.reduce((acc: any, cur) => {
+    const [key, value] = cur.split('=')
+    acc[key] = value
+    return acc
+  }, {})
+}
+export default class PostgresMetaRoles {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeDefaultRoles = false,
+    limit,
+    offset,
+  }: {
+    includeDefaultRoles?: boolean
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresRole[]>> {
+    const sql = ROLES_SQL({ limit, offset, includeDefaultRoles })
+    const result = await this.query(sql)
+    if (result.data) {
+      result.data = result.data.map((role: any) => {
+        role.config = changeRoleConfig2Object(role.config)
+        return role
+      })
+    }
+    return result
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresRole>>
+  async retrieve({ name }: { name: string }): Promise<PostgresMetaResult<PostgresRole>>
+  async retrieve({
+    id,
+    name,
+  }: {
+    id?: number
+    name?: string
+  }): Promise<PostgresMetaResult<PostgresRole>> {
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = ROLES_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a role with ID ${id}` } }
+      } else {
+        data[0].config = changeRoleConfig2Object(data[0].config)
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const nameFilter = filterByValue([name])
+      const sql = ROLES_SQL({ nameFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a role named ${name}` } }
+      } else {
+        data[0].config = changeRoleConfig2Object(data[0].config)
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on role retrieve' } }
+    }
+  }
+
+  async create({
+    name,
+    is_superuser = false,
+    can_create_db = false,
+    can_create_role = false,
+    inherit_role = true,
+    can_login = false,
+    is_replication_role = false,
+    can_bypass_rls = false,
+    connection_limit = -1,
+    password,
+    valid_until,
+    member_of,
+    members,
+    admins,
+    config,
+  }: PostgresRoleCreate): Promise<PostgresMetaResult<PostgresRole>> {
+    const isSuperuserClause = is_superuser ? 'SUPERUSER' : 'NOSUPERUSER'
+    const canCreateDbClause = can_create_db ? 'CREATEDB' : 'NOCREATEDB'
+    const canCreateRoleClause = can_create_role ? 'CREATEROLE' : 'NOCREATEROLE'
+    const inheritRoleClause = inherit_role ? 'INHERIT' : 'NOINHERIT'
+    const canLoginClause = can_login ? 'LOGIN' : 'NOLOGIN'
+    const isReplicationRoleClause = is_replication_role ? 'REPLICATION' : 'NOREPLICATION'
+    const canBypassRlsClause = can_bypass_rls ? 'BYPASSRLS' : 'NOBYPASSRLS'
+    const connectionLimitClause = `CONNECTION LIMIT ${connection_limit}`
+    const passwordClause = password === undefined ? '' : `PASSWORD ${literal(password)}`
+    const validUntilClause = valid_until === undefined ? '' : `VALID UNTIL ${literal(valid_until)}`
+    const memberOfClause = member_of === undefined ? '' : `IN ROLE ${member_of.join(',')}`
+    const membersClause = members === undefined ? '' : `ROLE ${members.join(',')}`
+    const adminsClause = admins === undefined ? '' : `ADMIN ${admins.join(',')}`
+    let configClause = ''
+    if (config !== undefined) {
+      configClause = Object.keys(config)
+        .map((k) => {
+          const v = config[k]
+          if (!k || !v) {
+            return ''
+          }
+          return `ALTER ROLE ${name} SET ${k} = ${v};`
+        })
+        .join('\n')
+    }
+    const sql = `
+BEGIN;
+CREATE ROLE ${ident(name)}
+WITH
+  ${isSuperuserClause}
+  ${canCreateDbClause}
+  ${canCreateRoleClause}
+  ${inheritRoleClause}
+  ${canLoginClause}
+  ${isReplicationRoleClause}
+  ${canBypassRlsClause}
+  ${connectionLimitClause}
+  ${passwordClause}
+  ${validUntilClause}
+  ${memberOfClause}
+  ${membersClause}
+  ${adminsClause};
+${configClause ? configClause : ''}
+COMMIT;`
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name })
+  }
+
+  async update(
+    id: number,
+    {
+      name,
+      is_superuser,
+      can_create_db,
+      can_create_role,
+      inherit_role,
+      can_login,
+      is_replication_role,
+      can_bypass_rls,
+      connection_limit,
+      password,
+      valid_until,
+      config,
+    }: PostgresRoleUpdate
+  ): Promise<PostgresMetaResult<PostgresRole>> {
+    const { data: old, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+
+    const nameSql =
+      name === undefined ? '' : `ALTER ROLE ${ident(old!.name)} RENAME TO ${ident(name)};`
+    let isSuperuserClause = ''
+    if (is_superuser !== undefined) {
+      isSuperuserClause = is_superuser ? 'SUPERUSER' : 'NOSUPERUSER'
+    }
+    let canCreateDbClause = ''
+    if (can_create_db !== undefined) {
+      canCreateDbClause = can_create_db ? 'CREATEDB' : 'NOCREATEDB'
+    }
+    let canCreateRoleClause = ''
+    if (can_create_role !== undefined) {
+      canCreateRoleClause = can_create_role ? 'CREATEROLE' : 'NOCREATEROLE'
+    }
+    let inheritRoleClause = ''
+    if (inherit_role !== undefined) {
+      inheritRoleClause = inherit_role ? 'INHERIT' : 'NOINHERIT'
+    }
+    let canLoginClause = ''
+    if (can_login !== undefined) {
+      canLoginClause = can_login ? 'LOGIN' : 'NOLOGIN'
+    }
+    let isReplicationRoleClause = ''
+    if (is_replication_role !== undefined) {
+      isReplicationRoleClause = is_replication_role ? 'REPLICATION' : 'NOREPLICATION'
+    }
+    let canBypassRlsClause = ''
+    if (can_bypass_rls !== undefined) {
+      canBypassRlsClause = can_bypass_rls ? 'BYPASSRLS' : 'NOBYPASSRLS'
+    }
+    const connectionLimitClause =
+      connection_limit === undefined ? '' : `CONNECTION LIMIT ${connection_limit}`
+    const passwordClause = password === undefined ? '' : `PASSWORD ${literal(password)}`
+    const validUntilClause = valid_until === undefined ? '' : `VALID UNTIL ${literal(valid_until)}`
+    let configClause = ''
+    if (config !== undefined) {
+      const configSql = config.map((c) => {
+        const { op, path, value } = c
+        const k = path
+        const v = value || null
+        if (!k) {
+          throw new Error(`Invalid config value ${value}`)
+        }
+        switch (op) {
+          case 'add':
+          case 'replace':
+            return `ALTER ROLE ${ident(old!.name)} SET ${ident(k)} = ${literal(v)};`
+          case 'remove':
+            return `ALTER ROLE ${ident(old!.name)} RESET ${ident(k)};`
+          default:
+            throw new Error(`Invalid config op ${op}`)
+        }
+      })
+      configClause = configSql.filter(Boolean).join('')
+    }
+    // nameSql must be last
+    const sql = `
+BEGIN;
+  ALTER ROLE ${ident(old!.name)}
+    ${isSuperuserClause}
+    ${canCreateDbClause}
+    ${canCreateRoleClause}
+    ${inheritRoleClause}
+    ${canLoginClause}
+    ${isReplicationRoleClause}
+    ${canBypassRlsClause}
+    ${connectionLimitClause}
+    ${passwordClause}
+    ${validUntilClause};
+  ${configClause ? configClause : ''}
+  ${nameSql}
+COMMIT;`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return await this.retrieve({ id })
+  }
+
+  async remove(id: number): Promise<PostgresMetaResult<PostgresRole>> {
+    const { data: role, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `DROP ROLE ${ident(role!.name)};`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: role!, error: null }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaRoles.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaRoles.ts
@@ -7,7 +7,7 @@
 
 import { ident, literal } from 'pg-format'
 import { ROLES_SQL } from './sql/roles.sql.js'
-import {
+import type {
   PostgresMetaResult,
   PostgresRole,
   PostgresRoleCreate,

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaSchemas.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaSchemas.ts
@@ -7,7 +7,7 @@
 
 import { ident } from 'pg-format'
 import { SCHEMAS_SQL } from './sql/schemas.sql.js'
-import {
+import type {
   PostgresMetaResult,
   PostgresSchema,
   PostgresSchemaCreate,

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaSchemas.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaSchemas.ts
@@ -1,0 +1,132 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident } from 'pg-format'
+import { SCHEMAS_SQL } from './sql/schemas.sql.js'
+import {
+  PostgresMetaResult,
+  PostgresSchema,
+  PostgresSchemaCreate,
+  PostgresSchemaUpdate,
+} from './types.js'
+import { filterByList, filterByValue } from './helpers.js'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+
+export default class PostgresMetaSchemas {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includedSchemas,
+    excludedSchemas,
+    includeSystemSchemas = false,
+    limit,
+    offset,
+  }: {
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    includeSystemSchemas?: boolean
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresSchema[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = SCHEMAS_SQL({ limit, offset, includeSystemSchemas, nameFilter: schemaFilter })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresSchema>>
+  async retrieve({ name }: { name: string }): Promise<PostgresMetaResult<PostgresSchema>>
+  async retrieve({
+    id,
+    name,
+  }: {
+    id?: number
+    name?: string
+  }): Promise<PostgresMetaResult<PostgresSchema>> {
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = SCHEMAS_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a schema with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const nameFilter = filterByValue([name])
+      const sql = SCHEMAS_SQL({ nameFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a schema named ${name}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on schema retrieve' } }
+    }
+  }
+
+  async create({
+    name,
+    owner = 'postgres',
+  }: PostgresSchemaCreate): Promise<PostgresMetaResult<PostgresSchema>> {
+    const sql = `CREATE SCHEMA ${ident(name)} AUTHORIZATION ${ident(owner)};`
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name })
+  }
+
+  async update(
+    id: number,
+    { name, owner }: PostgresSchemaUpdate
+  ): Promise<PostgresMetaResult<PostgresSchema>> {
+    const { data: old, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const nameSql =
+      name === undefined ? '' : `ALTER SCHEMA ${ident(old!.name)} RENAME TO ${ident(name)};`
+    const ownerSql =
+      owner === undefined ? '' : `ALTER SCHEMA ${ident(old!.name)} OWNER TO ${ident(owner)};`
+    const sql = `BEGIN; ${ownerSql} ${nameSql} COMMIT;`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return await this.retrieve({ id })
+  }
+
+  async remove(id: number, { cascade = false } = {}): Promise<PostgresMetaResult<PostgresSchema>> {
+    const { data: schema, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `DROP SCHEMA ${ident(schema!.name)} ${cascade ? 'CASCADE' : 'RESTRICT'};`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: schema!, error: null }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTablePrivileges.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTablePrivileges.ts
@@ -1,0 +1,146 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident } from 'pg-format'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByList, filterByValue } from './helpers.js'
+import {
+  PostgresMetaResult,
+  PostgresTablePrivileges,
+  PostgresTablePrivilegesGrant,
+  PostgresTablePrivilegesRevoke,
+} from './types.js'
+import { TABLE_PRIVILEGES_SQL } from './sql/table_privileges.sql.js'
+
+export default class PostgresMetaTablePrivileges {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresTablePrivileges[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = TABLE_PRIVILEGES_SQL({ schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresTablePrivileges>>
+  async retrieve({
+    name,
+    schema,
+  }: {
+    name: string
+    schema: string
+  }): Promise<PostgresMetaResult<PostgresTablePrivileges>>
+  async retrieve({
+    id,
+    name,
+    schema = 'public',
+  }: {
+    id?: number
+    name?: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresTablePrivileges>> {
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = TABLE_PRIVILEGES_SQL({ idsFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a relation with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const nameIdentifierFilter = filterByValue([`${schema}.${name}`])
+      const sql = TABLE_PRIVILEGES_SQL({ nameIdentifierFilter })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: { message: `Cannot find a relation named ${name} in schema ${schema}` },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on retrieving table privileges' } }
+    }
+  }
+
+  async grant(
+    grants: PostgresTablePrivilegesGrant[]
+  ): Promise<PostgresMetaResult<PostgresTablePrivileges[]>> {
+    let sql = `
+do $$
+begin
+${grants
+  .map(
+    ({ privilege_type, relation_id, grantee, is_grantable }) =>
+      `execute format('grant ${privilege_type} on table %s to ${
+        grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
+      } ${is_grantable ? 'with grant option' : ''}', ${relation_id}::regclass);`
+  )
+  .join('\n')}
+end $$;
+`
+    const { data, error } = await this.query(sql)
+    if (error) {
+      return { data, error }
+    }
+
+    // Return the updated table privileges for modified relations.
+    const relationIds = [...new Set(grants.map(({ relation_id }) => relation_id))]
+    sql = TABLE_PRIVILEGES_SQL({ idsFilter: filterByList(relationIds) })
+    return await this.query(sql)
+  }
+
+  async revoke(
+    revokes: PostgresTablePrivilegesRevoke[]
+  ): Promise<PostgresMetaResult<PostgresTablePrivileges[]>> {
+    let sql = `
+do $$
+begin
+${revokes
+  .map(
+    (revoke) =>
+      `execute format('revoke ${revoke.privilege_type} on table %s from ${revoke.grantee}', ${revoke.relation_id}::regclass);`
+  )
+  .join('\n')}
+end $$;
+`
+    const { data, error } = await this.query(sql)
+    if (error) {
+      return { data, error }
+    }
+
+    // Return the updated table privileges for modified relations.
+    const relationIds = [...new Set(revokes.map(({ relation_id }) => relation_id))]
+    sql = TABLE_PRIVILEGES_SQL({ idsFilter: filterByList(relationIds) })
+    return await this.query(sql)
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTablePrivileges.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTablePrivileges.ts
@@ -8,7 +8,7 @@
 import { ident } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { filterByList, filterByValue } from './helpers.js'
-import {
+import type {
   PostgresMetaResult,
   PostgresTablePrivileges,
   PostgresTablePrivilegesGrant,

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTables.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTables.ts
@@ -8,7 +8,7 @@
 import { ident, literal } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { coalesceRowsToArray, filterByValue, filterByList } from './helpers.js'
-import {
+import type {
   PostgresMetaResult,
   PostgresTable,
   PostgresTableCreate,

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTables.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTables.ts
@@ -1,0 +1,276 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { coalesceRowsToArray, filterByValue, filterByList } from './helpers.js'
+import {
+  PostgresMetaResult,
+  PostgresTable,
+  PostgresTableCreate,
+  PostgresTableUpdate,
+} from './types.js'
+import { TABLES_SQL } from './sql/table.sql.js'
+import { COLUMNS_SQL } from './sql/columns.sql.js'
+
+export default class PostgresMetaTables {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list(options: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns: false
+  }): Promise<PostgresMetaResult<(PostgresTable & { columns: never })[]>>
+  async list(options?: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns?: boolean
+  }): Promise<PostgresMetaResult<(PostgresTable & { columns: unknown[] })[]>>
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+    includeColumns = true,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns?: boolean
+  } = {}): Promise<PostgresMetaResult<PostgresTable[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = generateEnrichedTablesSql({ includeColumns, schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresTable>>
+  async retrieve({
+    name,
+    schema,
+  }: {
+    name: string
+    schema: string
+  }): Promise<PostgresMetaResult<PostgresTable>>
+  async retrieve({
+    id,
+    name,
+    schema = 'public',
+  }: {
+    id?: number
+    name?: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresTable>> {
+    const schemaFilter = schema ? filterByList([schema], []) : undefined
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = generateEnrichedTablesSql({
+        schemaFilter,
+        includeColumns: true,
+        idsFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a table with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const tableIdentifierFilter = filterByValue([`${schema}.${name}`])
+      const sql = generateEnrichedTablesSql({
+        schemaFilter,
+        includeColumns: true,
+        tableIdentifierFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: { message: `Cannot find a table named ${name} in schema ${schema}` },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on table retrieve' } }
+    }
+  }
+
+  async create({
+    name,
+    schema = 'public',
+    comment,
+  }: PostgresTableCreate): Promise<PostgresMetaResult<PostgresTable>> {
+    const tableSql = `CREATE TABLE ${ident(schema)}.${ident(name)} ();`
+    const commentSql =
+      comment === undefined
+        ? ''
+        : `COMMENT ON TABLE ${ident(schema)}.${ident(name)} IS ${literal(comment)};`
+    const sql = `BEGIN; ${tableSql} ${commentSql} COMMIT;`
+    const { error } = await this.query(sql)
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({ name, schema })
+  }
+
+  async update(
+    id: number,
+    {
+      name,
+      schema,
+      rls_enabled,
+      rls_forced,
+      replica_identity,
+      replica_identity_index,
+      primary_keys,
+      comment,
+    }: PostgresTableUpdate
+  ): Promise<PostgresMetaResult<PostgresTable>> {
+    const { data: old, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+
+    const alter = `ALTER TABLE ${ident(old!.schema)}.${ident(old!.name)}`
+    const schemaSql = schema === undefined ? '' : `${alter} SET SCHEMA ${ident(schema)};`
+    let nameSql = ''
+    if (name !== undefined && name !== old!.name) {
+      const currentSchema = schema === undefined ? old!.schema : schema
+      nameSql = `ALTER TABLE ${ident(currentSchema)}.${ident(old!.name)} RENAME TO ${ident(name)};`
+    }
+    let enableRls = ''
+    if (rls_enabled !== undefined) {
+      const enable = `${alter} ENABLE ROW LEVEL SECURITY;`
+      const disable = `${alter} DISABLE ROW LEVEL SECURITY;`
+      enableRls = rls_enabled ? enable : disable
+    }
+    let forceRls = ''
+    if (rls_forced !== undefined) {
+      const enable = `${alter} FORCE ROW LEVEL SECURITY;`
+      const disable = `${alter} NO FORCE ROW LEVEL SECURITY;`
+      forceRls = rls_forced ? enable : disable
+    }
+    let replicaSql = ''
+    if (replica_identity === undefined) {
+      // skip
+    } else if (replica_identity === 'INDEX') {
+      replicaSql = `${alter} REPLICA IDENTITY USING INDEX ${replica_identity_index};`
+    } else {
+      replicaSql = `${alter} REPLICA IDENTITY ${replica_identity};`
+    }
+    let primaryKeysSql = ''
+    if (primary_keys === undefined) {
+      // skip
+    } else {
+      if (old!.primary_keys.length !== 0) {
+        primaryKeysSql += `
+DO $$
+DECLARE
+  r record;
+BEGIN
+  SELECT conname
+    INTO r
+    FROM pg_constraint
+    WHERE contype = 'p' AND conrelid = ${literal(id)};
+  EXECUTE ${literal(`${alter} DROP CONSTRAINT `)} || quote_ident(r.conname);
+END
+$$;
+`
+      }
+
+      if (primary_keys.length === 0) {
+        // skip
+      } else {
+        primaryKeysSql += `${alter} ADD PRIMARY KEY (${primary_keys
+          .map((x) => ident(x.name))
+          .join(',')});`
+      }
+    }
+    const commentSql =
+      comment === undefined
+        ? ''
+        : `COMMENT ON TABLE ${ident(old!.schema)}.${ident(old!.name)} IS ${literal(comment)};`
+    // nameSql must be last, right below schemaSql
+    const sql = `
+BEGIN;
+  ${enableRls}
+  ${forceRls}
+  ${replicaSql}
+  ${primaryKeysSql}
+  ${commentSql}
+  ${schemaSql}
+  ${nameSql}
+COMMIT;`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return await this.retrieve({ id })
+  }
+
+  async remove(id: number, { cascade = false } = {}): Promise<PostgresMetaResult<PostgresTable>> {
+    const { data: table, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+    const sql = `DROP TABLE ${ident(table!.schema)}.${ident(table!.name)} ${
+      cascade ? 'CASCADE' : 'RESTRICT'
+    };`
+    {
+      const { error } = await this.query(sql)
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return { data: table!, error: null }
+  }
+}
+
+const generateEnrichedTablesSql = ({
+  includeColumns,
+  schemaFilter,
+  tableIdentifierFilter,
+  idsFilter,
+  limit,
+  offset,
+}: {
+  includeColumns: boolean
+  schemaFilter?: string
+  tableIdentifierFilter?: string
+  idsFilter?: string
+  limit?: number
+  offset?: number
+}) => `
+with tables as (${TABLES_SQL({ schemaFilter, tableIdentifierFilter, idsFilter, limit, offset })})
+  ${includeColumns ? `, columns as (${COLUMNS_SQL({ schemaFilter, tableIdFilter: idsFilter, tableIdentifierFilter: tableIdentifierFilter })})` : ''}
+select
+  *
+  ${includeColumns ? `, ${coalesceRowsToArray('columns', 'columns.table_id = tables.id')}` : ''}
+from tables`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTriggers.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTriggers.ts
@@ -8,7 +8,7 @@
 import { ident, literal } from 'pg-format'
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { filterByList, filterByValue } from './helpers.js'
-import { PostgresMetaResult, PostgresTrigger } from './types.js'
+import type { PostgresMetaResult, PostgresTrigger } from './types.js'
 import { TRIGGERS_SQL } from './sql/triggers.sql.js'
 
 export default class PostgresMetaTriggers {

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTriggers.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTriggers.ts
@@ -1,0 +1,255 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { ident, literal } from 'pg-format'
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByList, filterByValue } from './helpers.js'
+import { PostgresMetaResult, PostgresTrigger } from './types.js'
+import { TRIGGERS_SQL } from './sql/triggers.sql.js'
+
+export default class PostgresMetaTriggers {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresTrigger[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    let sql = TRIGGERS_SQL({ schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresTrigger>>
+  async retrieve({
+    name,
+    table,
+    schema,
+  }: {
+    name: string
+    table: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresTrigger>>
+  async retrieve({
+    id,
+    name,
+    schema = 'public',
+    table,
+  }: {
+    id?: number
+    name?: string
+    schema?: string
+    table?: string
+  }): Promise<PostgresMetaResult<PostgresTrigger>> {
+    const schemaFilter = schema ? filterByList([schema], []) : undefined
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = TRIGGERS_SQL({ idsFilter })
+
+      const { data, error } = await this.query(sql)
+
+      if (error) {
+        return { data: null, error }
+      }
+
+      const triggerRecord = data && data[0]
+
+      if (triggerRecord) {
+        return { data: triggerRecord, error: null }
+      }
+
+      return { data: null, error: { message: `Cannot find a trigger with ID ${id}` } }
+    }
+
+    if (name && schema && table) {
+      const nameFilter = filterByValue([name])
+      const tableNameFilter = filterByValue([table])
+      const sql = TRIGGERS_SQL({ schemaFilter, nameFilter, tableNameFilter })
+
+      const { data, error } = await this.query(sql)
+
+      if (error) {
+        return { data: null, error }
+      }
+
+      const triggerRecord = data && data[0]
+
+      if (triggerRecord) {
+        return { data: triggerRecord, error: null }
+      }
+
+      return {
+        data: null,
+        error: {
+          message: `Cannot find a trigger with name ${name} on table "${schema}"."${table}"`,
+        },
+      }
+    }
+
+    return { data: null, error: { message: 'Invalid parameters on trigger retrieve' } }
+  }
+
+  /**
+   * Creates trigger
+   *
+   * @param {Object} obj - An object.
+   * @param {string} obj.name - Trigger name.
+   * @param {string} obj.schema - Name of schema that trigger is for.
+   * @param {string} obj.table - Unqualified table, view, or foreign table name that trigger is for.
+   * @param {string} obj.function_schema - Name of schema that function is for.
+   * @param {string} obj.function_name - Unqualified name of the function to execute.
+   * @param {('BEFORE'|'AFTER'|'INSTEAD OF')} obj.activation - Determines when function is called
+   * during event occurrence.
+   * @param {Array<string>} obj.events - Event(s) that will fire the trigger. Array of the following options: 'INSERT' | 'UPDATE' | 'UPDATE
+   * OF column_name1,column_name2' | 'DELETE' | 'TRUNCATE'.
+   * @param {('ROW'|'STATEMENT')} obj.orientation - Trigger function for every row affected by event or
+   * once per statement. Defaults to 'STATEMENT'.
+   * @param {string} obj.condition - Boolean expression that will trigger function.
+   * For example: 'old.* IS DISTINCT FROM new.*'
+   * @param {Array<string>} obj.function_args - array of arguments to be passed to function when trigger is fired.
+   * For example: ['arg1', 'arg2']
+   */
+  async create({
+    name,
+    schema = 'public',
+    table,
+    function_schema = 'public',
+    function_name,
+    function_args,
+    activation,
+    events,
+    orientation,
+    condition,
+  }: {
+    name: string
+    table: string
+    function_name: string
+    activation: string
+    events: string[]
+    function_schema?: string
+    schema?: string
+    orientation?: string
+    condition?: string
+    function_args?: string[]
+  }): Promise<PostgresMetaResult<PostgresTrigger>> {
+    const qualifiedTableName = `${ident(schema)}.${ident(table)}`
+    const qualifiedFunctionName = `${ident(function_schema)}.${ident(function_name)}`
+    const triggerEvents = events.join(' OR ')
+    const triggerOrientation = orientation ? `FOR EACH ${orientation}` : ''
+    const triggerCondition = condition ? `WHEN (${condition})` : ''
+    const functionArgs = `${function_args?.map(literal).join(',') ?? ''}`
+
+    const sql = `CREATE TRIGGER ${ident(
+      name
+    )} ${activation} ${triggerEvents} ON ${qualifiedTableName} ${triggerOrientation} ${triggerCondition} EXECUTE FUNCTION ${qualifiedFunctionName}(${functionArgs});`
+
+    const { error } = await this.query(sql)
+
+    if (error) {
+      return { data: null, error }
+    }
+    return await this.retrieve({
+      name,
+      table,
+      schema,
+    })
+  }
+
+  async update(
+    id: number,
+    {
+      name,
+      enabled_mode,
+    }: {
+      name?: string
+      enabled_mode?: 'ORIGIN' | 'REPLICA' | 'ALWAYS' | 'DISABLED'
+    }
+  ): Promise<PostgresMetaResult<PostgresTrigger>> {
+    const { data: old, error } = await this.retrieve({ id })
+    if (error) {
+      return { data: null, error }
+    }
+
+    let enabledModeSql = ''
+    switch (enabled_mode) {
+      case 'ORIGIN':
+        enabledModeSql = `ALTER TABLE ${ident(old!.schema)}.${ident(
+          old!.table
+        )} ENABLE TRIGGER ${ident(old!.name)};`
+        break
+      case 'DISABLED':
+        enabledModeSql = `ALTER TABLE ${ident(old!.schema)}.${ident(
+          old!.table
+        )} DISABLE TRIGGER ${ident(old!.name)};`
+        break
+      case 'REPLICA':
+      case 'ALWAYS':
+        enabledModeSql = `ALTER TABLE ${ident(old!.schema)}.${ident(
+          old!.table
+        )} ENABLE ${enabled_mode} TRIGGER ${ident(old!.name)};`
+        break
+      default:
+        break
+    }
+    const nameSql =
+      name && name !== old!.name
+        ? `ALTER TRIGGER ${ident(old!.name)} ON ${ident(old!.schema)}.${ident(
+            old!.table
+          )} RENAME TO ${ident(name)};`
+        : ''
+
+    // updateNameSql must be last
+    const sql = `BEGIN; ${enabledModeSql}; ${nameSql}; COMMIT;`
+    {
+      const { error } = await this.query(sql)
+
+      if (error) {
+        return { data: null, error }
+      }
+    }
+    return await this.retrieve({ id })
+  }
+
+  async remove(id: number, { cascade = false } = {}): Promise<PostgresMetaResult<PostgresTrigger>> {
+    const { data: triggerRecord, error } = await this.retrieve({ id })
+
+    if (error) {
+      return { data: null, error }
+    }
+
+    const { name, schema, table } = triggerRecord!
+    const sql = `DROP TRIGGER ${ident(name)} ON ${ident(schema)}.${ident(table)} ${
+      cascade ? 'CASCADE' : ''
+    };`
+
+    {
+      const { error } = await this.query(sql)
+
+      if (error) {
+        return { data: null, error }
+      }
+    }
+
+    return { data: triggerRecord!, error: null }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTypes.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTypes.ts
@@ -1,0 +1,45 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { filterByList } from './helpers.js'
+import { PostgresMetaResult, PostgresType } from './types.js'
+import { TYPES_SQL } from './sql/types.sql.js'
+
+export default class PostgresMetaTypes {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeTableTypes = false,
+    includeArrayTypes = false,
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+  }: {
+    includeTableTypes?: boolean
+    includeArrayTypes?: boolean
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+  } = {}): Promise<PostgresMetaResult<PostgresType[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = TYPES_SQL({ schemaFilter, limit, offset, includeTableTypes, includeArrayTypes })
+    return await this.query(sql)
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTypes.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaTypes.ts
@@ -7,7 +7,7 @@
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { filterByList } from './helpers.js'
-import { PostgresMetaResult, PostgresType } from './types.js'
+import type { PostgresMetaResult, PostgresType } from './types.js'
 import { TYPES_SQL } from './sql/types.sql.js'
 
 export default class PostgresMetaTypes {

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaVersion.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaVersion.ts
@@ -6,7 +6,7 @@
 //   none
 
 import { VERSION_SQL } from './sql/version.sql.js'
-import { PostgresMetaResult, PostgresVersion } from './types.js'
+import type { PostgresMetaResult, PostgresVersion } from './types.js'
 
 export default class PostgresMetaVersion {
   query: (sql: string) => Promise<PostgresMetaResult<any>>

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaVersion.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaVersion.ts
@@ -1,0 +1,25 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { VERSION_SQL } from './sql/version.sql.js'
+import { PostgresMetaResult, PostgresVersion } from './types.js'
+
+export default class PostgresMetaVersion {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async retrieve(): Promise<PostgresMetaResult<PostgresVersion>> {
+    const { data, error } = await this.query(VERSION_SQL())
+    if (error) {
+      return { data, error }
+    }
+    return { data: data[0], error }
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaViews.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaViews.ts
@@ -1,0 +1,119 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
+import { coalesceRowsToArray, filterByList, filterByValue } from './helpers.js'
+import { PostgresMetaResult, PostgresView } from './types.js'
+import { VIEWS_SQL } from './sql/views.sql.js'
+import { COLUMNS_SQL } from './sql/columns.sql.js'
+
+export default class PostgresMetaViews {
+  query: (sql: string) => Promise<PostgresMetaResult<any>>
+
+  constructor(query: (sql: string) => Promise<PostgresMetaResult<any>>) {
+    this.query = query
+  }
+
+  async list({
+    includeSystemSchemas = false,
+    includedSchemas,
+    excludedSchemas,
+    limit,
+    offset,
+    includeColumns = true,
+  }: {
+    includeSystemSchemas?: boolean
+    includedSchemas?: string[]
+    excludedSchemas?: string[]
+    limit?: number
+    offset?: number
+    includeColumns?: boolean
+  } = {}): Promise<PostgresMetaResult<PostgresView[]>> {
+    const schemaFilter = filterByList(
+      includedSchemas,
+      excludedSchemas,
+      !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
+    )
+    const sql = generateEnrichedViewsSql({ includeColumns, schemaFilter, limit, offset })
+    return await this.query(sql)
+  }
+
+  async retrieve({ id }: { id: number }): Promise<PostgresMetaResult<PostgresView>>
+  async retrieve({
+    name,
+    schema,
+  }: {
+    name: string
+    schema: string
+  }): Promise<PostgresMetaResult<PostgresView>>
+  async retrieve({
+    id,
+    name,
+    schema = 'public',
+  }: {
+    id?: number
+    name?: string
+    schema?: string
+  }): Promise<PostgresMetaResult<PostgresView>> {
+    if (id) {
+      const idsFilter = filterByValue([id])
+      const sql = generateEnrichedViewsSql({
+        includeColumns: true,
+        idsFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return { data: null, error: { message: `Cannot find a view with ID ${id}` } }
+      } else {
+        return { data: data[0], error }
+      }
+    } else if (name) {
+      const viewIdentifierFilter = filterByValue([`${schema}.${name}`])
+      const sql = generateEnrichedViewsSql({
+        includeColumns: true,
+        viewIdentifierFilter,
+      })
+      const { data, error } = await this.query(sql)
+      if (error) {
+        return { data, error }
+      } else if (data.length === 0) {
+        return {
+          data: null,
+          error: { message: `Cannot find a view named ${name} in schema ${schema}` },
+        }
+      } else {
+        return { data: data[0], error }
+      }
+    } else {
+      return { data: null, error: { message: 'Invalid parameters on view retrieve' } }
+    }
+  }
+}
+
+const generateEnrichedViewsSql = ({
+  includeColumns,
+  schemaFilter,
+  idsFilter,
+  viewIdentifierFilter,
+  limit,
+  offset,
+}: {
+  includeColumns: boolean
+  schemaFilter?: string
+  idsFilter?: string
+  viewIdentifierFilter?: string
+  limit?: number
+  offset?: number
+}) => `
+with views as (${VIEWS_SQL({ schemaFilter, limit, offset, viewIdentifierFilter, idsFilter })})
+  ${includeColumns ? `, columns as (${COLUMNS_SQL({ schemaFilter, tableIdentifierFilter: viewIdentifierFilter, tableIdFilter: idsFilter })})` : ''}
+select
+  *
+  ${includeColumns ? `, ${coalesceRowsToArray('columns', 'columns.table_id = views.id')}` : ''}
+from views`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaViews.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/PostgresMetaViews.ts
@@ -7,7 +7,7 @@
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants.js'
 import { coalesceRowsToArray, filterByList, filterByValue } from './helpers.js'
-import { PostgresMetaResult, PostgresView } from './types.js'
+import type { PostgresMetaResult, PostgresView } from './types.js'
 import { VIEWS_SQL } from './sql/views.sql.js'
 import { COLUMNS_SQL } from './sql/columns.sql.js'
 

--- a/packages/neon-js/src/vendor/postgres-meta/lib/constants.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/constants.ts
@@ -1,0 +1,8 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+export const DEFAULT_SYSTEM_SCHEMAS = ['information_schema', 'pg_catalog', 'pg_toast']

--- a/packages/neon-js/src/vendor/postgres-meta/lib/db.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/db.ts
@@ -3,10 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) Supabase Inc. — see ../LICENSE
 // Modified by Neon for vendoring purposes, 2026-04-30:
-//   none
+//   - removed `@sentry/node` import + every `Sentry.startSpan(...)` wrapper
+//     (the CLI does not init a Sentry SDK, so the wrappers were no-ops)
+//   - dropped the `RESULT_SIZE_EXCEEDED` branch (specific to the
+//     `npm:@supabase/pg@0.0.3` fork; we use upstream `pg@^8`)
+//   - swapped fork-specific `pg` usage for upstream `pg@^8`
 
 import pg from 'pg'
-import * as Sentry from '@sentry/node'
 import { parse as parseArray } from 'postgres-array'
 import { PostgresMetaResult, PoolConfig } from './types.js'
 
@@ -35,41 +38,37 @@ const poolerQueryHandleError = (
   sql: string,
   parameters?: unknown[]
 ): Promise<pg.QueryResult<any>> => {
-  return Sentry.startSpan(
-    { op: 'db', name: 'poolerQuery' },
-    () =>
-      new Promise((resolve, reject) => {
-        let rejected = false
-        const connectionErrorHandler = (err: any) => {
-          // If the error hasn't already be propagated to the catch
-          if (!rejected) {
-            // This is a trick to wait for the next tick, leaving a chance for handled errors such as
-            // RESULT_SIZE_LIMIT to take over other stream errors such as `unexpected commandComplete message`
-            setTimeout(() => {
-              rejected = true
-              return reject(err)
-            })
-          }
+  return new Promise((resolve, reject) => {
+    let rejected = false
+    const connectionErrorHandler = (err: any) => {
+      // If the error hasn't already be propagated to the catch
+      if (!rejected) {
+        // Wait for the next tick so handled errors take over other stream errors
+        // such as `unexpected commandComplete message`
+        setTimeout(() => {
+          rejected = true
+          return reject(err)
+        })
+      }
+    }
+    // This listener avoids uncaught exceptions for errors happening at connection level
+    // within the stream (e.g. parse errors); handle the error gracefully by bubbling it up.
+    pgpool.once('error', connectionErrorHandler)
+    pgpool
+      .query(sql, parameters)
+      .then((results: pg.QueryResult<any>) => {
+        if (!rejected) {
+          return resolve(results)
         }
-        // This listened avoid getting uncaught exceptions for errors happening at connection level within the stream
-        // such as parse or RESULT_SIZE_EXCEEDED errors instead, handle the error gracefully by bubbling in up to the caller
-        pgpool.once('error', connectionErrorHandler)
-        pgpool
-          .query(sql, parameters)
-          .then((results: pg.QueryResult<any>) => {
-            if (!rejected) {
-              return resolve(results)
-            }
-          })
-          .catch((err: any) => {
-            // If the error hasn't already be handled within the error listener
-            if (!rejected) {
-              rejected = true
-              return reject(err)
-            }
-          })
       })
-  )
+      .catch((err: any) => {
+        // If the error hasn't already be handled within the error listener
+        if (!rejected) {
+          rejected = true
+          return reject(err)
+        }
+      })
+  })
 }
 
 export const init: (config: PoolConfig) => {
@@ -79,195 +78,165 @@ export const init: (config: PoolConfig) => {
   ) => Promise<PostgresMetaResult<any>>
   end: () => Promise<void>
 } = (config) => {
-  return Sentry.startSpan({ op: 'db', name: 'db.init' }, () => {
-    // node-postgres ignores config.ssl if any of sslmode, sslca, sslkey, sslcert,
-    // sslrootcert are in the connection string. Here we allow setting sslmode in
-    // the connection string while setting the rest in config.ssl.
-    if (config.connectionString) {
-      const u = new URL(config.connectionString)
-      const sslmode = u.searchParams.get('sslmode')
-      u.searchParams.delete('sslmode')
-      // For now, we don't support setting these from the connection string.
-      u.searchParams.delete('sslca')
-      u.searchParams.delete('sslkey')
-      u.searchParams.delete('sslcert')
-      u.searchParams.delete('sslrootcert')
-      config.connectionString = u.toString()
+  // node-postgres ignores config.ssl if any of sslmode, sslca, sslkey, sslcert,
+  // sslrootcert are in the connection string. Here we allow setting sslmode in
+  // the connection string while setting the rest in config.ssl.
+  if (config.connectionString) {
+    const u = new URL(config.connectionString)
+    const sslmode = u.searchParams.get('sslmode')
+    u.searchParams.delete('sslmode')
+    // For now, we don't support setting these from the connection string.
+    u.searchParams.delete('sslca')
+    u.searchParams.delete('sslkey')
+    u.searchParams.delete('sslcert')
+    u.searchParams.delete('sslrootcert')
+    config.connectionString = u.toString()
 
-      // sslmode:    null, 'disable', 'prefer', 'require', 'verify-ca', 'verify-full', 'no-verify'
-      // config.ssl: true, false, {}
-      if (sslmode === null) {
-        // skip
-      } else if (sslmode === 'disable') {
-        config.ssl = false
-      } else {
-        if (typeof config.ssl !== 'object') {
-          config.ssl = {}
-        }
-        config.ssl.rejectUnauthorized = sslmode === 'verify-full'
+    // sslmode:    null, 'disable', 'prefer', 'require', 'verify-ca', 'verify-full', 'no-verify'
+    // config.ssl: true, false, {}
+    if (sslmode === null) {
+      // skip
+    } else if (sslmode === 'disable') {
+      config.ssl = false
+    } else {
+      if (typeof config.ssl !== 'object') {
+        config.ssl = {}
       }
+      config.ssl.rejectUnauthorized = sslmode === 'verify-full'
     }
+  }
 
-    // NOTE: Race condition could happen here: one async task may be doing
-    // `pool.end()` which invalidates the pool and subsequently all existing
-    // handles to `query`. Normally you might only deal with one DB so you don't
-    // need to call `pool.end()`, but since the server needs this, we make a
-    // compromise: if we run `query` after `pool.end()` is called (i.e. pool is
-    // `null`), we temporarily create a pool and close it right after.
-    let pool: pg.Pool | null = new pg.Pool(config)
+  // NOTE: Race condition could happen here: one async task may be doing
+  // `pool.end()` which invalidates the pool and subsequently all existing
+  // handles to `query`. Normally you might only deal with one DB so you don't
+  // need to call `pool.end()`, but since the server needs this, we make a
+  // compromise: if we run `query` after `pool.end()` is called (i.e. pool is
+  // `null`), we temporarily create a pool and close it right after.
+  let pool: pg.Pool | null = new pg.Pool(config)
 
-    return {
-      async query(
-        sql,
-        { statementQueryTimeout, trackQueryInSentry, parameters } = { trackQueryInSentry: true }
-      ) {
-        return Sentry.startSpan(
-          // For metrics purposes, log the query that will be run if it's not an user provided query (with possibly sentitives infos)
+  return {
+    async query(sql, { statementQueryTimeout, parameters } = {}) {
+      // Use statement_timeout AND idle_session_timeout to ensure the connection will be killed even if idle after
+      // timeout time.
+      const statementTimeoutQueryPrefix = statementQueryTimeout
+        ? `SET statement_timeout='${statementQueryTimeout}s'; SET idle_session_timeout='${statementQueryTimeout}s';`
+        : ''
+      // node-postgres need a statement_timeout to kill the connection when timeout is reached
+      // otherwise the query will keep running on the database even if query timeout was reached
+      // This need to be added at query and not connection level because poolers (pgbouncer) doesn't
+      // allow to set this parameter at connection time
+      const sqlWithStatementTimeout = `${statementTimeoutQueryPrefix}${sql}`
+      try {
+        if (!pool) {
+          const transientPool = new pg.Pool(config)
+          let res = await poolerQueryHandleError(transientPool, sqlWithStatementTimeout, parameters)
+          if (Array.isArray(res)) {
+            res = res.reverse().find((x) => x.rows.length !== 0) ?? { rows: [] }
+          }
+          await transientPool.end()
+          return { data: res.rows, error: null }
+        }
+
+        let res = await poolerQueryHandleError(pool, sqlWithStatementTimeout, parameters)
+        if (Array.isArray(res)) {
+          res = res.reverse().find((x) => x.rows.length !== 0) ?? { rows: [] }
+        }
+        return { data: res.rows, error: null }
+      } catch (error: any) {
+        if (error.constructor.name === 'DatabaseError') {
+          // Roughly based on:
+          // - https://github.com/postgres/postgres/blob/fc4089f3c65a5f1b413a3299ba02b66a8e5e37d0/src/interfaces/libpq/fe-protocol3.c#L1018
+          // - https://github.com/brianc/node-postgres/blob/b1a8947738ce0af004cb926f79829bb2abc64aa6/packages/pg/lib/native/query.js#L33
+          let formattedError = ''
           {
-            op: 'db',
-            name: 'init.query',
-            attributes: { sql: trackQueryInSentry ? sql : 'custom' },
-          },
-          async () => {
-            // Use statement_timeout AND idle_session_timeout to ensure the connection will be killed even if idle after
-            // timeout time.
-            const statementTimeoutQueryPrefix = statementQueryTimeout
-              ? `SET statement_timeout='${statementQueryTimeout}s'; SET idle_session_timeout='${statementQueryTimeout}s';`
-              : ''
-            // node-postgres need a statement_timeout to kill the connection when timeout is reached
-            // otherwise the query will keep running on the database even if query timeout was reached
-            // This need to be added at query and not connection level because poolers (pgbouncer) doesn't
-            // allow to set this parameter at connection time
-            const sqlWithStatementTimeout = `${statementTimeoutQueryPrefix}${sql}`
-            try {
-              if (!pool) {
-                const pool = new pg.Pool(config)
-                let res = await poolerQueryHandleError(pool, sqlWithStatementTimeout, parameters)
-                if (Array.isArray(res)) {
-                  res = res.reverse().find((x) => x.rows.length !== 0) ?? { rows: [] }
-                }
-                await pool.end()
-                return { data: res.rows, error: null }
-              }
+            if (error.severity) {
+              formattedError += `${error.severity}:  `
+            }
+            if (error.code) {
+              formattedError += `${error.code}: `
+            }
+            if (error.message) {
+              formattedError += error.message
+            }
+            formattedError += '\n'
+            if (error.position) {
+              // error.position is 1-based
+              // we also remove our `SET statement_timeout = 'XXs';\n` from the position
+              const position = Number(error.position) - 1 - statementTimeoutQueryPrefix.length
+              // we set the new error position
+              error.position = `${position + 1}`
 
-              let res = await poolerQueryHandleError(pool, sqlWithStatementTimeout, parameters)
-              if (Array.isArray(res)) {
-                res = res.reverse().find((x) => x.rows.length !== 0) ?? { rows: [] }
-              }
-              return { data: res.rows, error: null }
-            } catch (error: any) {
-              if (error.constructor.name === 'DatabaseError') {
-                // Roughly based on:
-                // - https://github.com/postgres/postgres/blob/fc4089f3c65a5f1b413a3299ba02b66a8e5e37d0/src/interfaces/libpq/fe-protocol3.c#L1018
-                // - https://github.com/brianc/node-postgres/blob/b1a8947738ce0af004cb926f79829bb2abc64aa6/packages/pg/lib/native/query.js#L33
-                let formattedError = ''
-                {
-                  if (error.severity) {
-                    formattedError += `${error.severity}:  `
-                  }
-                  if (error.code) {
-                    formattedError += `${error.code}: `
-                  }
-                  if (error.message) {
-                    formattedError += error.message
-                  }
-                  formattedError += '\n'
-                  if (error.position) {
-                    // error.position is 1-based
-                    // we also remove our `SET statement_timeout = 'XXs';\n` from the position
-                    const position = Number(error.position) - 1 - statementTimeoutQueryPrefix.length
-                    // we set the new error position
-                    error.position = `${position + 1}`
+              let line = ''
+              let lineNumber = 0
+              let lineOffset = 0
 
-                    let line = ''
-                    let lineNumber = 0
-                    let lineOffset = 0
-
-                    const lines = sql.split('\n')
-                    let currentOffset = 0
-                    for (let i = 0; i < lines.length; i++) {
-                      if (currentOffset + lines[i].length > position) {
-                        line = lines[i]
-                        lineNumber = i + 1 // 1-based
-                        lineOffset = position - currentOffset
-                        break
-                      }
-                      currentOffset += lines[i].length + 1 // 1 extra offset for newline
-                    }
-                    formattedError += `LINE ${lineNumber}: ${line}\n${' '.repeat(5 + lineNumber.toString().length + 2 + lineOffset)}^\n`
-                  }
-                  if (error.detail) {
-                    formattedError += `DETAIL:  ${error.detail}\n`
-                  }
-                  if (error.hint) {
-                    formattedError += `HINT:  ${error.hint}\n`
-                  }
-                  if (error.internalQuery) {
-                    formattedError += `QUERY:  ${error.internalQuery}\n`
-                  }
-                  if (error.where) {
-                    formattedError += `CONTEXT:  ${error.where}\n`
-                  }
+              const lines = sql.split('\n')
+              let currentOffset = 0
+              for (let i = 0; i < lines.length; i++) {
+                if (currentOffset + lines[i].length > position) {
+                  line = lines[i]
+                  lineNumber = i + 1 // 1-based
+                  lineOffset = position - currentOffset
+                  break
                 }
-
-                return {
-                  data: null,
-                  error: {
-                    ...error,
-                    // error.message is non-enumerable
-                    message: error.message,
-                    formattedError,
-                  },
-                }
+                currentOffset += lines[i].length + 1 // 1 extra offset for newline
               }
-              try {
-                // Handle stream errors and result size exceeded errors
-                if (error.code === 'RESULT_SIZE_EXCEEDED') {
-                  // Force kill the connection without waiting for graceful shutdown
-                  return {
-                    data: null,
-                    error: {
-                      message: `Query result size (${error.resultSize} bytes) exceeded the configured limit (${error.maxResultSize} bytes)`,
-                      code: error.code,
-                      resultSize: error.resultSize,
-                      maxResultSize: error.maxResultSize,
-                    },
-                  }
-                }
-                return { data: null, error: { code: error.code, message: error.message } }
-              } finally {
-                try {
-                  // If the error isn't a "DatabaseError" assume it's a connection related we kill the connection
-                  // To attempt a clean reconnect on next try
-                  await this.end.bind(this)
-                } catch (error) {
-                  console.error('Failed to end the connection on error: ', {
-                    this: this,
-                    end: this.end,
-                  })
-                }
-              }
+              formattedError += `LINE ${lineNumber}: ${line}\n${' '.repeat(5 + lineNumber.toString().length + 2 + lineOffset)}^\n`
+            }
+            if (error.detail) {
+              formattedError += `DETAIL:  ${error.detail}\n`
+            }
+            if (error.hint) {
+              formattedError += `HINT:  ${error.hint}\n`
+            }
+            if (error.internalQuery) {
+              formattedError += `QUERY:  ${error.internalQuery}\n`
+            }
+            if (error.where) {
+              formattedError += `CONTEXT:  ${error.where}\n`
             }
           }
-        )
-      },
 
-      async end() {
-        Sentry.startSpan({ op: 'db', name: 'init.end' }, async () => {
+          return {
+            data: null,
+            error: {
+              ...error,
+              // error.message is non-enumerable
+              message: error.message,
+              formattedError,
+            },
+          }
+        }
+        try {
+          return { data: null, error: { code: error.code, message: error.message } }
+        } finally {
           try {
-            const _pool = pool
-            pool = null
-            // Gracefully wait for active connections to be idle, then close all
-            // connections in the pool.
-            if (_pool) {
-              await _pool.end()
-            }
-          } catch (endError) {
-            // Ignore any errors during cleanup just log them
-            console.error('Failed ending connection pool', endError)
+            // If the error isn't a "DatabaseError" assume it's a connection related we kill the connection
+            // To attempt a clean reconnect on next try
+            await this.end.bind(this)
+          } catch (_endError) {
+            console.error('Failed to end the connection on error: ', {
+              this: this,
+              end: this.end,
+            })
           }
-        })
-      },
-    }
-  })
+        }
+      }
+    },
+
+    async end() {
+      try {
+        const _pool = pool
+        pool = null
+        // Gracefully wait for active connections to be idle, then close all
+        // connections in the pool.
+        if (_pool) {
+          await _pool.end()
+        }
+      } catch (endError) {
+        // Ignore any errors during cleanup just log them
+        console.error('Failed ending connection pool', endError)
+      }
+    },
+  }
 }

--- a/packages/neon-js/src/vendor/postgres-meta/lib/db.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/db.ts
@@ -8,10 +8,14 @@
 //   - dropped the `RESULT_SIZE_EXCEEDED` branch (specific to the
 //     `npm:@supabase/pg@0.0.3` fork; we use upstream `pg@^8`)
 //   - swapped fork-specific `pg` usage for upstream `pg@^8`
+//   - added `as any` casts for the raw-OID `setTypeParser` calls so they
+//     compile under upstream `pg@^8`'s stricter `TypeId` overload typings
+//   - converted type-only imports to `import type` for the package's
+//     `verbatimModuleSyntax: true` tsconfig
 
 import pg from 'pg'
 import { parse as parseArray } from 'postgres-array'
-import { PostgresMetaResult, PoolConfig } from './types.js'
+import type { PostgresMetaResult, PoolConfig } from './types.js'
 
 pg.types.setTypeParser(pg.types.builtins.INT8, (x) => {
   const asNumber = Number(x)
@@ -25,11 +29,15 @@ pg.types.setTypeParser(pg.types.builtins.DATE, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.INTERVAL, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (x) => x)
 pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (x) => x)
-pg.types.setTypeParser(1115, parseArray) // _timestamp
-pg.types.setTypeParser(1182, parseArray) // _date
-pg.types.setTypeParser(1185, parseArray) // _timestamptz
-pg.types.setTypeParser(600, (x) => x) // point
-pg.types.setTypeParser(1017, (x) => x) // _point
+// `pg`'s `setTypeParser` overload signature accepts only a `TypeId` enum value
+// for the strongly-typed form. We pass raw OIDs for the non-builtin array
+// types, so cast to `any` to bypass the overload check. Behaviour at runtime
+// is identical to the upstream call.
+pg.types.setTypeParser(1115 as any, parseArray) // _timestamp
+pg.types.setTypeParser(1182 as any, parseArray) // _date
+pg.types.setTypeParser(1185 as any, parseArray) // _timestamptz
+pg.types.setTypeParser(600 as any, (x) => x) // point
+pg.types.setTypeParser(1017 as any, (x) => x) // _point
 
 // Ensure any query will have an appropriate error handler on the pool to prevent connections errors
 // to bubble up all the stack eventually killing the server

--- a/packages/neon-js/src/vendor/postgres-meta/lib/db.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/db.ts
@@ -1,0 +1,273 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import pg from 'pg'
+import * as Sentry from '@sentry/node'
+import { parse as parseArray } from 'postgres-array'
+import { PostgresMetaResult, PoolConfig } from './types.js'
+
+pg.types.setTypeParser(pg.types.builtins.INT8, (x) => {
+  const asNumber = Number(x)
+  if (Number.isSafeInteger(asNumber)) {
+    return asNumber
+  } else {
+    return x
+  }
+})
+pg.types.setTypeParser(pg.types.builtins.DATE, (x) => x)
+pg.types.setTypeParser(pg.types.builtins.INTERVAL, (x) => x)
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (x) => x)
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, (x) => x)
+pg.types.setTypeParser(1115, parseArray) // _timestamp
+pg.types.setTypeParser(1182, parseArray) // _date
+pg.types.setTypeParser(1185, parseArray) // _timestamptz
+pg.types.setTypeParser(600, (x) => x) // point
+pg.types.setTypeParser(1017, (x) => x) // _point
+
+// Ensure any query will have an appropriate error handler on the pool to prevent connections errors
+// to bubble up all the stack eventually killing the server
+const poolerQueryHandleError = (
+  pgpool: pg.Pool,
+  sql: string,
+  parameters?: unknown[]
+): Promise<pg.QueryResult<any>> => {
+  return Sentry.startSpan(
+    { op: 'db', name: 'poolerQuery' },
+    () =>
+      new Promise((resolve, reject) => {
+        let rejected = false
+        const connectionErrorHandler = (err: any) => {
+          // If the error hasn't already be propagated to the catch
+          if (!rejected) {
+            // This is a trick to wait for the next tick, leaving a chance for handled errors such as
+            // RESULT_SIZE_LIMIT to take over other stream errors such as `unexpected commandComplete message`
+            setTimeout(() => {
+              rejected = true
+              return reject(err)
+            })
+          }
+        }
+        // This listened avoid getting uncaught exceptions for errors happening at connection level within the stream
+        // such as parse or RESULT_SIZE_EXCEEDED errors instead, handle the error gracefully by bubbling in up to the caller
+        pgpool.once('error', connectionErrorHandler)
+        pgpool
+          .query(sql, parameters)
+          .then((results: pg.QueryResult<any>) => {
+            if (!rejected) {
+              return resolve(results)
+            }
+          })
+          .catch((err: any) => {
+            // If the error hasn't already be handled within the error listener
+            if (!rejected) {
+              rejected = true
+              return reject(err)
+            }
+          })
+      })
+  )
+}
+
+export const init: (config: PoolConfig) => {
+  query: (
+    sql: string,
+    opts?: { statementQueryTimeout?: number; trackQueryInSentry?: boolean; parameters?: unknown[] }
+  ) => Promise<PostgresMetaResult<any>>
+  end: () => Promise<void>
+} = (config) => {
+  return Sentry.startSpan({ op: 'db', name: 'db.init' }, () => {
+    // node-postgres ignores config.ssl if any of sslmode, sslca, sslkey, sslcert,
+    // sslrootcert are in the connection string. Here we allow setting sslmode in
+    // the connection string while setting the rest in config.ssl.
+    if (config.connectionString) {
+      const u = new URL(config.connectionString)
+      const sslmode = u.searchParams.get('sslmode')
+      u.searchParams.delete('sslmode')
+      // For now, we don't support setting these from the connection string.
+      u.searchParams.delete('sslca')
+      u.searchParams.delete('sslkey')
+      u.searchParams.delete('sslcert')
+      u.searchParams.delete('sslrootcert')
+      config.connectionString = u.toString()
+
+      // sslmode:    null, 'disable', 'prefer', 'require', 'verify-ca', 'verify-full', 'no-verify'
+      // config.ssl: true, false, {}
+      if (sslmode === null) {
+        // skip
+      } else if (sslmode === 'disable') {
+        config.ssl = false
+      } else {
+        if (typeof config.ssl !== 'object') {
+          config.ssl = {}
+        }
+        config.ssl.rejectUnauthorized = sslmode === 'verify-full'
+      }
+    }
+
+    // NOTE: Race condition could happen here: one async task may be doing
+    // `pool.end()` which invalidates the pool and subsequently all existing
+    // handles to `query`. Normally you might only deal with one DB so you don't
+    // need to call `pool.end()`, but since the server needs this, we make a
+    // compromise: if we run `query` after `pool.end()` is called (i.e. pool is
+    // `null`), we temporarily create a pool and close it right after.
+    let pool: pg.Pool | null = new pg.Pool(config)
+
+    return {
+      async query(
+        sql,
+        { statementQueryTimeout, trackQueryInSentry, parameters } = { trackQueryInSentry: true }
+      ) {
+        return Sentry.startSpan(
+          // For metrics purposes, log the query that will be run if it's not an user provided query (with possibly sentitives infos)
+          {
+            op: 'db',
+            name: 'init.query',
+            attributes: { sql: trackQueryInSentry ? sql : 'custom' },
+          },
+          async () => {
+            // Use statement_timeout AND idle_session_timeout to ensure the connection will be killed even if idle after
+            // timeout time.
+            const statementTimeoutQueryPrefix = statementQueryTimeout
+              ? `SET statement_timeout='${statementQueryTimeout}s'; SET idle_session_timeout='${statementQueryTimeout}s';`
+              : ''
+            // node-postgres need a statement_timeout to kill the connection when timeout is reached
+            // otherwise the query will keep running on the database even if query timeout was reached
+            // This need to be added at query and not connection level because poolers (pgbouncer) doesn't
+            // allow to set this parameter at connection time
+            const sqlWithStatementTimeout = `${statementTimeoutQueryPrefix}${sql}`
+            try {
+              if (!pool) {
+                const pool = new pg.Pool(config)
+                let res = await poolerQueryHandleError(pool, sqlWithStatementTimeout, parameters)
+                if (Array.isArray(res)) {
+                  res = res.reverse().find((x) => x.rows.length !== 0) ?? { rows: [] }
+                }
+                await pool.end()
+                return { data: res.rows, error: null }
+              }
+
+              let res = await poolerQueryHandleError(pool, sqlWithStatementTimeout, parameters)
+              if (Array.isArray(res)) {
+                res = res.reverse().find((x) => x.rows.length !== 0) ?? { rows: [] }
+              }
+              return { data: res.rows, error: null }
+            } catch (error: any) {
+              if (error.constructor.name === 'DatabaseError') {
+                // Roughly based on:
+                // - https://github.com/postgres/postgres/blob/fc4089f3c65a5f1b413a3299ba02b66a8e5e37d0/src/interfaces/libpq/fe-protocol3.c#L1018
+                // - https://github.com/brianc/node-postgres/blob/b1a8947738ce0af004cb926f79829bb2abc64aa6/packages/pg/lib/native/query.js#L33
+                let formattedError = ''
+                {
+                  if (error.severity) {
+                    formattedError += `${error.severity}:  `
+                  }
+                  if (error.code) {
+                    formattedError += `${error.code}: `
+                  }
+                  if (error.message) {
+                    formattedError += error.message
+                  }
+                  formattedError += '\n'
+                  if (error.position) {
+                    // error.position is 1-based
+                    // we also remove our `SET statement_timeout = 'XXs';\n` from the position
+                    const position = Number(error.position) - 1 - statementTimeoutQueryPrefix.length
+                    // we set the new error position
+                    error.position = `${position + 1}`
+
+                    let line = ''
+                    let lineNumber = 0
+                    let lineOffset = 0
+
+                    const lines = sql.split('\n')
+                    let currentOffset = 0
+                    for (let i = 0; i < lines.length; i++) {
+                      if (currentOffset + lines[i].length > position) {
+                        line = lines[i]
+                        lineNumber = i + 1 // 1-based
+                        lineOffset = position - currentOffset
+                        break
+                      }
+                      currentOffset += lines[i].length + 1 // 1 extra offset for newline
+                    }
+                    formattedError += `LINE ${lineNumber}: ${line}\n${' '.repeat(5 + lineNumber.toString().length + 2 + lineOffset)}^\n`
+                  }
+                  if (error.detail) {
+                    formattedError += `DETAIL:  ${error.detail}\n`
+                  }
+                  if (error.hint) {
+                    formattedError += `HINT:  ${error.hint}\n`
+                  }
+                  if (error.internalQuery) {
+                    formattedError += `QUERY:  ${error.internalQuery}\n`
+                  }
+                  if (error.where) {
+                    formattedError += `CONTEXT:  ${error.where}\n`
+                  }
+                }
+
+                return {
+                  data: null,
+                  error: {
+                    ...error,
+                    // error.message is non-enumerable
+                    message: error.message,
+                    formattedError,
+                  },
+                }
+              }
+              try {
+                // Handle stream errors and result size exceeded errors
+                if (error.code === 'RESULT_SIZE_EXCEEDED') {
+                  // Force kill the connection without waiting for graceful shutdown
+                  return {
+                    data: null,
+                    error: {
+                      message: `Query result size (${error.resultSize} bytes) exceeded the configured limit (${error.maxResultSize} bytes)`,
+                      code: error.code,
+                      resultSize: error.resultSize,
+                      maxResultSize: error.maxResultSize,
+                    },
+                  }
+                }
+                return { data: null, error: { code: error.code, message: error.message } }
+              } finally {
+                try {
+                  // If the error isn't a "DatabaseError" assume it's a connection related we kill the connection
+                  // To attempt a clean reconnect on next try
+                  await this.end.bind(this)
+                } catch (error) {
+                  console.error('Failed to end the connection on error: ', {
+                    this: this,
+                    end: this.end,
+                  })
+                }
+              }
+            }
+          }
+        )
+      },
+
+      async end() {
+        Sentry.startSpan({ op: 'db', name: 'init.end' }, async () => {
+          try {
+            const _pool = pool
+            pool = null
+            // Gracefully wait for active connections to be idle, then close all
+            // connections in the pool.
+            if (_pool) {
+              await _pool.end()
+            }
+          } catch (endError) {
+            // Ignore any errors during cleanup just log them
+            console.error('Failed ending connection pool', endError)
+          }
+        })
+      },
+    }
+  })
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/generators.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/generators.ts
@@ -6,7 +6,7 @@
 //   none
 
 import PostgresMeta from './PostgresMeta.js'
-import {
+import type {
   PostgresColumn,
   PostgresForeignTable,
   PostgresFunction,

--- a/packages/neon-js/src/vendor/postgres-meta/lib/generators.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/generators.ts
@@ -1,0 +1,148 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import PostgresMeta from './PostgresMeta.js'
+import {
+  PostgresColumn,
+  PostgresForeignTable,
+  PostgresFunction,
+  PostgresMaterializedView,
+  PostgresMetaResult,
+  PostgresRelationship,
+  PostgresSchema,
+  PostgresTable,
+  PostgresType,
+  PostgresView,
+} from './types.js'
+
+export type GeneratorMetadata = {
+  schemas: PostgresSchema[]
+  tables: Omit<PostgresTable, 'columns'>[]
+  foreignTables: Omit<PostgresForeignTable, 'columns'>[]
+  views: Omit<PostgresView, 'columns'>[]
+  materializedViews: Omit<PostgresMaterializedView, 'columns'>[]
+  columns: PostgresColumn[]
+  relationships: PostgresRelationship[]
+  functions: PostgresFunction[]
+  types: PostgresType[]
+}
+
+export async function getGeneratorMetadata(
+  pgMeta: PostgresMeta,
+  filters: { includedSchemas?: string[]; excludedSchemas?: string[] } = {
+    includedSchemas: [],
+    excludedSchemas: [],
+  }
+): Promise<PostgresMetaResult<GeneratorMetadata>> {
+  const includedSchemas = filters.includedSchemas ?? []
+  const excludedSchemas = filters.excludedSchemas ?? []
+
+  const { data: schemas, error: schemasError } = await pgMeta.schemas.list({
+    includeSystemSchemas: false,
+    includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+    excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+  })
+  if (schemasError) {
+    return { data: null, error: schemasError }
+  }
+
+  const { data: tables, error: tablesError } = await pgMeta.tables.list({
+    includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+    excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+    includeColumns: false,
+  })
+  if (tablesError) {
+    return { data: null, error: tablesError }
+  }
+
+  const { data: foreignTables, error: foreignTablesError } = await pgMeta.foreignTables.list({
+    includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+    excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+    includeColumns: false,
+  })
+  if (foreignTablesError) {
+    return { data: null, error: foreignTablesError }
+  }
+
+  const { data: views, error: viewsError } = await pgMeta.views.list({
+    includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+    excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+    includeColumns: false,
+  })
+  if (viewsError) {
+    return { data: null, error: viewsError }
+  }
+
+  const { data: materializedViews, error: materializedViewsError } =
+    await pgMeta.materializedViews.list({
+      includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+      excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+      includeColumns: false,
+    })
+  if (materializedViewsError) {
+    return { data: null, error: materializedViewsError }
+  }
+
+  const { data: columns, error: columnsError } = await pgMeta.columns.list({
+    includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+    excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+    includeSystemSchemas: false,
+  })
+  if (columnsError) {
+    return { data: null, error: columnsError }
+  }
+
+  const { data: relationships, error: relationshipsError } = await pgMeta.relationships.list({
+    includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+    excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+    includeSystemSchemas: false,
+  })
+  if (relationshipsError) {
+    return { data: null, error: relationshipsError }
+  }
+
+  const { data: functions, error: functionsError } = await pgMeta.functions.list({
+    includedSchemas: includedSchemas.length > 0 ? includedSchemas : undefined,
+    excludedSchemas: excludedSchemas.length > 0 ? excludedSchemas : undefined,
+    includeSystemSchemas: false,
+  })
+  if (functionsError) {
+    return { data: null, error: functionsError }
+  }
+
+  const { data: types, error: typesError } = await pgMeta.types.list({
+    includeTableTypes: true,
+    includeArrayTypes: true,
+    includeSystemSchemas: true,
+  })
+  if (typesError) {
+    return { data: null, error: typesError }
+  }
+
+  await pgMeta.end()
+
+  return {
+    data: {
+      schemas: schemas.filter(
+        ({ name }) =>
+          !excludedSchemas.includes(name) &&
+          (includedSchemas.length === 0 || includedSchemas.includes(name))
+      ),
+      tables,
+      foreignTables,
+      views,
+      materializedViews,
+      columns,
+      relationships,
+      functions: functions.filter(
+        ({ return_type }) => !['trigger', 'event_trigger'].includes(return_type)
+      ),
+      types,
+    },
+    error: null,
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/helpers.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/helpers.ts
@@ -1,0 +1,44 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { literal } from 'pg-format'
+
+export const coalesceRowsToArray = (source: string, filter: string) => {
+  return `
+COALESCE(
+  (
+    SELECT
+      array_agg(row_to_json(${source})) FILTER (WHERE ${filter})
+    FROM
+      ${source}
+  ),
+  '{}'
+) AS ${source}`
+}
+
+export const filterByList = (
+  include?: (string | number)[],
+  exclude?: (string | number)[],
+  defaultExclude?: (string | number)[]
+) => {
+  if (defaultExclude) {
+    exclude = defaultExclude.concat(exclude ?? [])
+  }
+  if (include?.length) {
+    return `IN (${include.map(literal).join(',')})`
+  } else if (exclude?.length) {
+    return `NOT IN (${exclude.map(literal).join(',')})`
+  }
+  return ''
+}
+
+export const filterByValue = (ids?: (string | number)[]) => {
+  if (ids?.length) {
+    return `IN (${ids.map(literal).join(',')})`
+  }
+  return ''
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/index.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/index.ts
@@ -1,0 +1,27 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   - Slimmer re-export than upstream `src/lib/index.ts`. Exposes only the
+//     types that `templates/typescript.ts` and `cli/commands/generate-types.ts`
+//     consume. `PostgresMeta` itself is imported directly from
+//     `./PostgresMeta.js` by callers that need it.
+
+export type {
+  PostgresColumn,
+  PostgresFunction,
+  PostgresSchema,
+  PostgresTable,
+  PostgresType,
+  PostgresView,
+  PostgresMaterializedView,
+  PostgresForeignTable,
+  PostgresRelationship,
+  PostgresMetaResult,
+  PostgresMetaOk,
+  PostgresMetaErr,
+  PoolConfig,
+} from './types.js'
+
+export { default as PostgresMeta } from './PostgresMeta.js'

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/column_privileges.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/column_privileges.sql.ts
@@ -1,0 +1,164 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilter } from './common.js'
+
+export const COLUMN_PRIVILEGES_SQL = (
+  props: SQLQueryPropsWithSchemaFilter & {
+    columnIdsFilter?: string
+  }
+) => /* SQL */ `
+-- Lists each column's privileges in the form of:
+--
+-- [
+--   {
+--     "column_id": "12345.1",
+--     "relation_schema": "public",
+--     "relation_name": "mytable",
+--     "column_name": "mycolumn",
+--     "privileges": [
+--       {
+--         "grantor": "postgres",
+--         "grantee": "myrole",
+--         "privilege_type": "SELECT",
+--         "is_grantable": false
+--       },
+--       ...
+--     ]
+--   },
+--   ...
+-- ]
+--
+-- Modified from information_schema.column_privileges. We try to be as close as
+-- possible to the view definition, obtained from:
+--
+-- select pg_get_viewdef('information_schema.column_privileges');
+--
+-- The main differences are:
+-- - we include column privileges for materialized views
+--   (reason for exclusion in information_schema.column_privileges:
+--    https://www.postgresql.org/message-id/9136.1502740844%40sss.pgh.pa.us)
+-- - we query a.attrelid and a.attnum to generate \`column_id\`
+-- - \`table_catalog\` is omitted
+-- - table_schema -> relation_schema, table_name -> relation_name
+--
+-- Column privileges are intertwined with table privileges in that table
+-- privileges override column privileges. E.g. if we do:
+--
+-- grant all on mytable to myrole;
+--
+-- Then \`myrole\` is granted privileges for ALL columns. Likewise, if we do:
+--
+-- grant all (id) on mytable to myrole;
+-- revoke all on mytable from myrole;
+--
+-- Then the grant on the \`id\` column is revoked.
+--
+-- This is unlike how grants for schemas and tables interact, where you need
+-- privileges for BOTH the schema the table is in AND the table itself in order
+-- to access the table.
+
+select (x.attrelid || '.' || x.attnum) as column_id,
+       nc.nspname as relation_schema,
+       x.relname as relation_name,
+       x.attname as column_name,
+       coalesce(
+         jsonb_agg(
+           jsonb_build_object(
+             'grantor', u_grantor.rolname,
+             'grantee', grantee.rolname,
+             'privilege_type', x.prtype,
+             'is_grantable', x.grantable
+           )
+         ),
+         '[]'
+       ) as privileges
+from
+  (select pr_c.grantor,
+          pr_c.grantee,
+          a.attrelid,
+          a.attnum,
+          a.attname,
+          pr_c.relname,
+          pr_c.relnamespace,
+          pr_c.prtype,
+          pr_c.grantable,
+          pr_c.relowner
+   from
+     (select pg_class.oid,
+             pg_class.relname,
+             pg_class.relnamespace,
+             pg_class.relowner,
+             (aclexplode(coalesce(pg_class.relacl, acldefault('r', pg_class.relowner)))).grantor as grantor,
+             (aclexplode(coalesce(pg_class.relacl, acldefault('r', pg_class.relowner)))).grantee as grantee,
+             (aclexplode(coalesce(pg_class.relacl, acldefault('r', pg_class.relowner)))).privilege_type as privilege_type,
+             (aclexplode(coalesce(pg_class.relacl, acldefault('r', pg_class.relowner)))).is_grantable as is_grantable
+      from pg_class
+      where (pg_class.relkind = any (array['r',
+                                           'v',
+                                           'm',
+                                           'f',
+                                           'p'])) ) pr_c(oid, relname, relnamespace, relowner, grantor, grantee, prtype, grantable),
+                                                    pg_attribute a
+   where ((a.attrelid = pr_c.oid)
+          and (a.attnum > 0)
+          and (not a.attisdropped))
+   union select pr_a.grantor,
+                pr_a.grantee,
+                pr_a.attrelid,
+                pr_a.attnum,
+                pr_a.attname,
+                c.relname,
+                c.relnamespace,
+                pr_a.prtype,
+                pr_a.grantable,
+                c.relowner
+   from
+     (select a.attrelid,
+             a.attnum,
+             a.attname,
+             (aclexplode(coalesce(a.attacl, acldefault('c', cc.relowner)))).grantor as grantor,
+             (aclexplode(coalesce(a.attacl, acldefault('c', cc.relowner)))).grantee as grantee,
+             (aclexplode(coalesce(a.attacl, acldefault('c', cc.relowner)))).privilege_type as privilege_type,
+             (aclexplode(coalesce(a.attacl, acldefault('c', cc.relowner)))).is_grantable as is_grantable
+      from (pg_attribute a
+            join pg_class cc on ((a.attrelid = cc.oid)))
+      where ((a.attnum > 0)
+             and (not a.attisdropped))) pr_a(attrelid, attnum, attname, grantor, grantee, prtype, grantable),
+                                        pg_class c
+   where ((pr_a.attrelid = c.oid)
+          and (c.relkind = any (ARRAY['r',
+                                      'v',
+                                      'm',
+                                      'f',
+                                      'p'])))) x,
+     pg_namespace nc,
+     pg_authid u_grantor,
+  (select pg_authid.oid,
+          pg_authid.rolname
+   from pg_authid
+   union all select (0)::oid as oid,
+                    'PUBLIC') grantee(oid, rolname)
+where ((x.relnamespace = nc.oid)
+       ${props.schemaFilter ? `and nc.nspname ${props.schemaFilter}` : ''}
+       ${props.columnIdsFilter ? `and (x.attrelid || '.' || x.attnum) ${props.columnIdsFilter}` : ''}
+       and (x.grantee = grantee.oid)
+       and (x.grantor = u_grantor.oid)
+       and (x.prtype = any (ARRAY['INSERT',
+                                  'SELECT',
+                                  'UPDATE',
+                                  'REFERENCES']))
+       and (pg_has_role(u_grantor.oid, 'USAGE')
+            or pg_has_role(grantee.oid, 'USAGE')
+            or (grantee.rolname = 'PUBLIC')))
+group by column_id,
+         nc.nspname,
+         x.relname,
+         x.attname
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/columns.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/columns.sql.ts
@@ -1,0 +1,136 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilter } from './common.js'
+
+export const COLUMNS_SQL = (
+  props: SQLQueryPropsWithSchemaFilter & {
+    tableIdFilter?: string
+    tableIdentifierFilter?: string
+    columnNameFilter?: string
+    idsFilter?: string
+  }
+) => /* SQL */ `
+-- Adapted from information_schema.columns
+
+SELECT
+  c.oid :: int8 AS table_id,
+  nc.nspname AS schema,
+  c.relname AS table,
+  (c.oid || '.' || a.attnum) AS id,
+  a.attnum AS ordinal_position,
+  a.attname AS name,
+  CASE
+    WHEN a.atthasdef THEN pg_get_expr(ad.adbin, ad.adrelid)
+    ELSE NULL
+  END AS default_value,
+  CASE
+    WHEN t.typtype = 'd' THEN CASE
+      WHEN bt.typelem <> 0 :: oid
+      AND bt.typlen = -1 THEN 'ARRAY'
+      WHEN nbt.nspname = 'pg_catalog' THEN format_type(t.typbasetype, NULL)
+      ELSE 'USER-DEFINED'
+    END
+    ELSE CASE
+      WHEN t.typelem <> 0 :: oid
+      AND t.typlen = -1 THEN 'ARRAY'
+      WHEN nt.nspname = 'pg_catalog' THEN format_type(a.atttypid, NULL)
+      ELSE 'USER-DEFINED'
+    END
+  END AS data_type,
+  COALESCE(bt.typname, t.typname) AS format,
+  a.attidentity IN ('a', 'd') AS is_identity,
+  CASE
+    a.attidentity
+    WHEN 'a' THEN 'ALWAYS'
+    WHEN 'd' THEN 'BY DEFAULT'
+    ELSE NULL
+  END AS identity_generation,
+  a.attgenerated IN ('s') AS is_generated,
+  NOT (
+    a.attnotnull
+    OR t.typtype = 'd' AND t.typnotnull
+  ) AS is_nullable,
+  (
+    c.relkind IN ('r', 'p')
+    OR c.relkind IN ('v', 'f') AND pg_column_is_updatable(c.oid, a.attnum, FALSE)
+  ) AS is_updatable,
+  uniques.table_id IS NOT NULL AS is_unique,
+  check_constraints.definition AS "check",
+  array_to_json(
+    array(
+      SELECT
+        enumlabel
+      FROM
+        pg_catalog.pg_enum enums
+      WHERE
+        enums.enumtypid = coalesce(bt.oid, t.oid)
+        OR enums.enumtypid = coalesce(bt.typelem, t.typelem)
+      ORDER BY
+        enums.enumsortorder
+    )
+  ) AS enums,
+  col_description(c.oid, a.attnum) AS comment
+FROM
+  pg_attribute a
+  LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid
+  AND a.attnum = ad.adnum
+  JOIN (
+    pg_class c
+    JOIN pg_namespace nc ON c.relnamespace = nc.oid
+  ) ON a.attrelid = c.oid
+  JOIN (
+    pg_type t
+    JOIN pg_namespace nt ON t.typnamespace = nt.oid
+  ) ON a.atttypid = t.oid
+  LEFT JOIN (
+    pg_type bt
+    JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid
+  ) ON t.typtype = 'd'
+  AND t.typbasetype = bt.oid
+  LEFT JOIN (
+    SELECT DISTINCT ON (table_id, ordinal_position)
+      conrelid AS table_id,
+      conkey[1] AS ordinal_position
+    FROM pg_catalog.pg_constraint
+    WHERE contype = 'u' AND cardinality(conkey) = 1
+  ) AS uniques ON uniques.table_id = c.oid AND uniques.ordinal_position = a.attnum
+  LEFT JOIN (
+    -- We only select the first column check
+    SELECT DISTINCT ON (table_id, ordinal_position)
+      conrelid AS table_id,
+      conkey[1] AS ordinal_position,
+      substring(
+        pg_get_constraintdef(pg_constraint.oid, true),
+        8,
+        length(pg_get_constraintdef(pg_constraint.oid, true)) - 8
+      ) AS "definition"
+    FROM pg_constraint
+    WHERE contype = 'c' AND cardinality(conkey) = 1
+    ORDER BY table_id, ordinal_position, oid asc
+  ) AS check_constraints ON check_constraints.table_id = c.oid AND check_constraints.ordinal_position = a.attnum
+WHERE
+  ${props.schemaFilter ? `nc.nspname ${props.schemaFilter} AND` : ''}
+  ${props.idsFilter ? `(c.oid || '.' || a.attnum) ${props.idsFilter} AND` : ''}
+  ${props.columnNameFilter ? `(c.relname || '.' || a.attname) ${props.columnNameFilter} AND` : ''}
+  ${props.tableIdFilter ? `c.oid ${props.tableIdFilter} AND` : ''}
+  ${props.tableIdentifierFilter ? `nc.nspname || '.' || c.relname ${props.tableIdentifierFilter} AND` : ''}
+  NOT pg_is_other_temp_schema(nc.oid)
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+  AND (c.relkind IN ('r', 'v', 'm', 'f', 'p'))
+  AND (
+    pg_has_role(c.relowner, 'USAGE')
+    OR has_column_privilege(
+      c.oid,
+      a.attnum,
+      'SELECT, INSERT, UPDATE, REFERENCES'
+    )
+  )
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/common.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/common.ts
@@ -1,0 +1,24 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+export type SQLQueryProps = {
+  limit?: number
+  offset?: number
+}
+
+export type SQLQueryPropsWithSchemaFilter = SQLQueryProps & {
+  schemaFilter?: string
+}
+
+export type SQLQueryPropsWithIdsFilter = SQLQueryProps & {
+  idsFilter?: string
+}
+
+export type SQLQueryPropsWithSchemaFilterAndIdsFilter = SQLQueryProps & {
+  schemaFilter?: string
+  idsFilter?: string
+}

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/config.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/config.sql.ts
@@ -1,0 +1,38 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const CONFIG_SQL = (props: SQLQueryPropsWithSchemaFilterAndIdsFilter) => /* SQL */ `
+SELECT
+  name,
+  setting,
+  category,
+  TRIM(split_part(category, '/', 1)) AS group,
+  TRIM(split_part(category, '/', 2)) AS subgroup,
+  unit,
+  short_desc,
+  extra_desc,
+  context,
+  vartype,
+  source,
+  min_val,
+  max_val,
+  enumvals,
+  boot_val,
+  reset_val,
+  sourcefile,
+  sourceline,
+  pending_restart
+FROM
+  pg_settings
+ORDER BY
+  category,
+  name
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/extensions.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/extensions.sql.ts
@@ -1,0 +1,26 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryProps } from './common.js'
+
+export const EXTENSIONS_SQL = (props: SQLQueryProps & { nameFilter?: string }) => /* SQL */ `
+SELECT
+  e.name,
+  n.nspname AS schema,
+  e.default_version,
+  x.extversion AS installed_version,
+  e.comment
+FROM
+  pg_available_extensions() e(name, default_version, comment)
+  LEFT JOIN pg_extension x ON e.name = x.extname
+  LEFT JOIN pg_namespace n ON x.extnamespace = n.oid
+WHERE
+  true
+  ${props.nameFilter ? `AND e.name ${props.nameFilter}` : ''}
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/foreign_tables.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/foreign_tables.sql.ts
@@ -1,0 +1,32 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryProps } from './common.js'
+
+export const FOREIGN_TABLES_SQL = (
+  props: SQLQueryProps & {
+    schemaFilter?: string
+    idsFilter?: string
+    tableIdentifierFilter?: string
+  }
+) => /* SQL */ `
+SELECT
+  c.oid :: int8 AS id,
+  n.nspname AS schema,
+  c.relname AS name,
+  obj_description(c.oid) AS comment
+FROM
+  pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE
+  ${props.schemaFilter ? `n.nspname ${props.schemaFilter} AND` : ''}
+  ${props.idsFilter ? `c.oid ${props.idsFilter} AND` : ''}
+  ${props.tableIdentifierFilter ? `(n.nspname || '.' || c.relname) ${props.tableIdentifierFilter} AND` : ''}
+  c.relkind = 'f'
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/functions.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/functions.sql.ts
@@ -1,0 +1,162 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const FUNCTIONS_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & {
+    nameFilter?: string
+    args?: string[]
+  }
+) => /* SQL */ `
+-- CTE with sane arg_modes, arg_names, and arg_types.
+-- All three are always of the same length.
+-- All three include all args, including OUT and TABLE args.
+with functions as (
+  select
+    p.*,
+    -- proargmodes is null when all arg modes are IN
+    coalesce(
+      p.proargmodes,
+      array_fill('i'::text, array[cardinality(coalesce(p.proallargtypes, p.proargtypes))])
+    ) as arg_modes,
+    -- proargnames is null when all args are unnamed
+    coalesce(
+      p.proargnames,
+      array_fill(''::text, array[cardinality(coalesce(p.proallargtypes, p.proargtypes))])
+    ) as arg_names,
+    -- proallargtypes is null when all arg modes are IN
+    coalesce(p.proallargtypes, p.proargtypes) as arg_types,
+    array_cat(
+      array_fill(false, array[pronargs - pronargdefaults]),
+      array_fill(true, array[pronargdefaults])) as arg_has_defaults
+  from
+    pg_proc as p
+    ${props.schemaFilter ? `join pg_namespace n on p.pronamespace = n.oid` : ''}
+  where
+    ${props.schemaFilter ? `n.nspname ${props.schemaFilter} AND` : ''}
+    ${props.idsFilter ? `p.oid ${props.idsFilter} AND` : ''}
+    ${props.nameFilter ? `p.proname ${props.nameFilter} AND` : ''}
+    ${
+      props.args === undefined
+        ? ''
+        : props.args.length > 0
+          ? `p.proargtypes::text = ${
+              props.args.length
+                ? `(
+          SELECT STRING_AGG(type_oid::text, ' ') FROM (
+            SELECT (
+              split_args.arr[
+                array_length(
+                  split_args.arr,
+                  1
+                )
+              ]::regtype::oid
+            ) AS type_oid FROM (
+              SELECT STRING_TO_ARRAY(
+                UNNEST(
+                  ARRAY[${props.args}]
+                ),
+                ' '
+              ) AS arr
+            ) AS split_args
+          ) args
+    )`
+                : "''"
+            } AND`
+          : ''
+    }
+    p.prokind = 'f'
+)
+select
+  f.oid::int8 as id,
+  n.nspname as schema,
+  f.proname as name,
+  l.lanname as language,
+  case
+    when l.lanname = 'internal' then ''
+    else f.prosrc
+  end as definition,
+  case
+    when l.lanname = 'internal' then f.prosrc
+    else pg_get_functiondef(f.oid)
+  end as complete_statement,
+  coalesce(f_args.args, '[]') as args,
+  pg_get_function_arguments(f.oid) as argument_types,
+  pg_get_function_identity_arguments(f.oid) as identity_argument_types,
+  f.prorettype::int8 as return_type_id,
+  pg_get_function_result(f.oid) as return_type,
+  nullif(rt.typrelid::int8, 0) as return_type_relation_id,
+  f.proretset as is_set_returning_function,
+  case
+    when f.proretset then nullif(f.prorows, 0)
+    else null
+  end as prorows,
+  case
+    when f.provolatile = 'i' then 'IMMUTABLE'
+    when f.provolatile = 's' then 'STABLE'
+    when f.provolatile = 'v' then 'VOLATILE'
+  end as behavior,
+  f.prosecdef as security_definer,
+  f_config.config_params as config_params
+from
+  functions f
+  left join pg_namespace n on f.pronamespace = n.oid
+  left join pg_language l on f.prolang = l.oid
+  left join pg_type rt on rt.oid = f.prorettype
+  left join (
+    select
+      oid,
+      jsonb_object_agg(param, value) filter (where param is not null) as config_params
+    from
+      (
+        select
+          oid,
+          (string_to_array(unnest(proconfig), '='))[1] as param,
+          (string_to_array(unnest(proconfig), '='))[2] as value
+        from
+          functions
+      ) as t
+    group by
+      oid
+  ) f_config on f_config.oid = f.oid
+  left join (
+    select
+      oid,
+      jsonb_agg(jsonb_build_object(
+        'mode', t2.mode,
+        'name', name,
+        'type_id', type_id,
+        'has_default', has_default
+      )) as args
+    from
+      (
+        select
+          oid,
+          unnest(arg_modes) as mode,
+          unnest(arg_names) as name,
+          unnest(arg_types)::int8 as type_id,
+          unnest(arg_has_defaults) as has_default
+        from
+          functions
+      ) as t1,
+      lateral (
+        select
+          case
+            when t1.mode = 'i' then 'in'
+            when t1.mode = 'o' then 'out'
+            when t1.mode = 'b' then 'inout'
+            when t1.mode = 'v' then 'variadic'
+            else 'table'
+          end as mode
+      ) as t2
+    group by
+      t1.oid
+  ) f_args on f_args.oid = f.oid
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/indexes.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/indexes.sql.ts
@@ -1,0 +1,57 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const INDEXES_SQL = (props: SQLQueryPropsWithSchemaFilterAndIdsFilter) => /* SQL */ `
+SELECT
+    idx.indexrelid::int8 AS id,
+    idx.indrelid::int8 AS table_id,
+    n.nspname AS schema,
+    idx.indnatts AS number_of_attributes,
+    idx.indnkeyatts AS number_of_key_attributes,
+    idx.indisunique AS is_unique,
+    idx.indisprimary AS is_primary,
+    idx.indisexclusion AS is_exclusion,
+    idx.indimmediate AS is_immediate,
+    idx.indisclustered AS is_clustered,
+    idx.indisvalid AS is_valid,
+    idx.indcheckxmin AS check_xmin,
+    idx.indisready AS is_ready,
+    idx.indislive AS is_live,
+    idx.indisreplident AS is_replica_identity,
+    idx.indkey::smallint[] AS key_attributes,
+    idx.indcollation::integer[] AS collation,
+    idx.indclass::integer[] AS class,
+    idx.indoption::smallint[] AS options,
+    idx.indpred AS index_predicate,
+    obj_description(idx.indexrelid, 'pg_class') AS comment,
+    ix.indexdef as index_definition,
+    am.amname AS access_method,
+    jsonb_agg(
+      jsonb_build_object(
+        'attribute_number', a.attnum,
+        'attribute_name', a.attname,
+        'data_type', format_type(a.atttypid, a.atttypmod)
+      )
+      ORDER BY a.attnum
+    ) AS index_attributes
+  FROM
+    pg_index idx
+    JOIN pg_class c ON c.oid = idx.indexrelid
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    JOIN pg_am am ON c.relam = am.oid
+    JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(idx.indkey)
+    JOIN pg_indexes ix ON c.relname = ix.indexname
+  WHERE
+    ${props.schemaFilter ? `n.nspname ${props.schemaFilter}` : 'true'}
+    ${props.idsFilter ? `AND idx.indexrelid ${props.idsFilter}` : ''}
+  GROUP BY
+    idx.indexrelid, idx.indrelid, n.nspname, idx.indnatts, idx.indnkeyatts, idx.indisunique, idx.indisprimary, idx.indisexclusion, idx.indimmediate, idx.indisclustered, idx.indisvalid, idx.indcheckxmin, idx.indisready, idx.indislive, idx.indisreplident, idx.indkey, idx.indcollation, idx.indclass, idx.indoption, idx.indexprs, idx.indpred, ix.indexdef, am.amname
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/materialized_views.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/materialized_views.sql.ts
@@ -1,0 +1,31 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const MATERIALIZED_VIEWS_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & {
+    materializedViewIdentifierFilter?: string
+  }
+) => /* SQL */ `
+select
+  c.oid::int8 as id,
+  n.nspname as schema,
+  c.relname as name,
+  c.relispopulated as is_populated,
+  obj_description(c.oid) as comment
+from
+  pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+where
+  ${props.schemaFilter ? `n.nspname ${props.schemaFilter} AND` : ''}
+  ${props.idsFilter ? `c.oid ${props.idsFilter} AND` : ''}
+  ${props.materializedViewIdentifierFilter ? `(n.nspname || '.' || c.relname) ${props.materializedViewIdentifierFilter} AND` : ''}
+  c.relkind = 'm'
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/policies.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/policies.sql.ts
@@ -1,0 +1,61 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const POLICIES_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & { functionNameIdentifierFilter?: string }
+) => /* SQL */ `
+SELECT
+  pol.oid :: int8 AS id,
+  n.nspname AS schema,
+  c.relname AS table,
+  c.oid :: int8 AS table_id,
+  pol.polname AS name,
+  CASE
+    WHEN pol.polpermissive THEN 'PERMISSIVE' :: text
+    ELSE 'RESTRICTIVE' :: text
+  END AS action,
+  CASE
+    WHEN pol.polroles = '{0}' :: oid [] THEN array_to_json(
+      string_to_array('public' :: text, '' :: text) :: name []
+    )
+    ELSE array_to_json(
+      ARRAY(
+        SELECT
+          pg_roles.rolname
+        FROM
+          pg_roles
+        WHERE
+          pg_roles.oid = ANY (pol.polroles)
+        ORDER BY
+          pg_roles.rolname
+      )
+    )
+  END AS roles,
+  CASE
+    pol.polcmd
+    WHEN 'r' :: "char" THEN 'SELECT' :: text
+    WHEN 'a' :: "char" THEN 'INSERT' :: text
+    WHEN 'w' :: "char" THEN 'UPDATE' :: text
+    WHEN 'd' :: "char" THEN 'DELETE' :: text
+    WHEN '*' :: "char" THEN 'ALL' :: text
+    ELSE NULL :: text
+  END AS command,
+  pg_get_expr(pol.polqual, pol.polrelid) AS definition,
+  pg_get_expr(pol.polwithcheck, pol.polrelid) AS check
+FROM
+  pg_policy pol
+  JOIN pg_class c ON c.oid = pol.polrelid
+  LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE
+  ${props.schemaFilter ? `n.nspname ${props.schemaFilter}` : 'true'}
+  ${props.idsFilter ? `AND pol.oid ${props.idsFilter}` : ''}
+  ${props.functionNameIdentifierFilter ? `AND (c.relname || '.' || pol.polname) ${props.functionNameIdentifierFilter}` : ''}
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/publications.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/publications.sql.ts
@@ -1,0 +1,54 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithIdsFilter } from './common.js'
+
+export const PUBLICATIONS_SQL = (
+  props: SQLQueryPropsWithIdsFilter & { nameFilter?: string }
+) => /* SQL */ `
+SELECT
+  p.oid :: int8 AS id,
+  p.pubname AS name,
+  p.pubowner::regrole::text AS owner,
+  p.pubinsert AS publish_insert,
+  p.pubupdate AS publish_update,
+  p.pubdelete AS publish_delete,
+  p.pubtruncate AS publish_truncate,
+  CASE
+    WHEN p.puballtables THEN NULL
+    ELSE pr.tables
+  END AS tables
+FROM
+  pg_catalog.pg_publication AS p
+  LEFT JOIN LATERAL (
+    SELECT
+      COALESCE(
+        array_agg(
+          json_build_object(
+            'id',
+            c.oid :: int8,
+            'name',
+            c.relname,
+            'schema',
+            nc.nspname
+          )
+        ),
+        '{}'
+      ) AS tables
+    FROM
+      pg_catalog.pg_publication_rel AS pr
+      JOIN pg_class AS c ON pr.prrelid = c.oid
+      join pg_namespace as nc on c.relnamespace = nc.oid
+    WHERE
+      pr.prpubid = p.oid
+  ) AS pr ON 1 = 1
+WHERE
+  ${props.idsFilter ? `p.oid ${props.idsFilter}` : 'true'}
+  ${props.nameFilter ? `AND p.pubname ${props.nameFilter}` : ''}
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/roles.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/roles.sql.ts
@@ -1,0 +1,51 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithIdsFilter } from './common.js'
+
+export const ROLES_SQL = (
+  props: SQLQueryPropsWithIdsFilter & {
+    includeDefaultRoles?: boolean
+    nameFilter?: string
+  }
+) => /* SQL */ `
+-- TODO: Consider using pg_authid vs. pg_roles for unencrypted password field
+SELECT
+  oid :: int8 AS id,
+  rolname AS name,
+  rolsuper AS is_superuser,
+  rolcreatedb AS can_create_db,
+  rolcreaterole AS can_create_role,
+  rolinherit AS inherit_role,
+  rolcanlogin AS can_login,
+  rolreplication AS is_replication_role,
+  rolbypassrls AS can_bypass_rls,
+  (
+    SELECT
+      COUNT(*)
+    FROM
+      pg_stat_activity
+    WHERE
+      pg_roles.rolname = pg_stat_activity.usename
+  ) AS active_connections,
+  CASE WHEN rolconnlimit = -1 THEN current_setting('max_connections') :: int8
+       ELSE rolconnlimit
+  END AS connection_limit,
+  rolpassword AS password,
+  rolvaliduntil AS valid_until,
+  rolconfig AS config
+FROM
+  pg_roles
+WHERE
+  ${props.idsFilter ? `oid ${props.idsFilter}` : 'true'}
+  -- All default/predefined roles start with pg_: https://www.postgresql.org/docs/15/predefined-roles.html
+  -- The pg_ prefix is also reserved.
+  ${!props.includeDefaultRoles ? `AND NOT pg_catalog.starts_with(rolname, 'pg_')` : ''}
+  ${props.nameFilter ? `AND rolname ${props.nameFilter}` : ''}
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/schemas.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/schemas.sql.ts
@@ -1,0 +1,34 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryProps } from './common.js'
+
+export const SCHEMAS_SQL = (
+  props: SQLQueryProps & { nameFilter?: string; idsFilter?: string; includeSystemSchemas?: boolean }
+) => /* SQL */ `
+-- Adapted from information_schema.schemata
+select
+  n.oid::int8 as id,
+  n.nspname as name,
+  u.rolname as owner
+from
+  pg_namespace n,
+  pg_roles u
+where
+  n.nspowner = u.oid
+  ${props.idsFilter ? `and n.oid ${props.idsFilter}` : ''}
+  ${props.nameFilter ? `and n.nspname ${props.nameFilter}` : ''}
+  ${!props.includeSystemSchemas ? `and not pg_catalog.starts_with(n.nspname, 'pg_')` : ''}
+  and (
+    pg_has_role(n.nspowner, 'USAGE')
+    or has_schema_privilege(n.oid, 'CREATE, USAGE')
+  )
+  and not pg_catalog.starts_with(n.nspname, 'pg_temp_')
+  and not pg_catalog.starts_with(n.nspname, 'pg_toast_temp_')
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/table.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/table.sql.ts
@@ -1,0 +1,117 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const TABLES_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & { tableIdentifierFilter?: string }
+) => /* SQL */ `
+SELECT
+  c.oid :: int8 AS id,
+  nc.nspname AS schema,
+  c.relname AS name,
+  c.relrowsecurity AS rls_enabled,
+  c.relforcerowsecurity AS rls_forced,
+  CASE
+    WHEN c.relreplident = 'd' THEN 'DEFAULT'
+    WHEN c.relreplident = 'i' THEN 'INDEX'
+    WHEN c.relreplident = 'f' THEN 'FULL'
+    ELSE 'NOTHING'
+  END AS replica_identity,
+  pg_total_relation_size(format('%I.%I', nc.nspname, c.relname)) :: int8 AS bytes,
+  pg_size_pretty(
+    pg_total_relation_size(format('%I.%I', nc.nspname, c.relname))
+  ) AS size,
+  pg_stat_get_live_tuples(c.oid) AS live_rows_estimate,
+  pg_stat_get_dead_tuples(c.oid) AS dead_rows_estimate,
+  obj_description(c.oid) AS comment,
+  coalesce(pk.primary_keys, '[]') as primary_keys,
+  coalesce(
+    jsonb_agg(relationships) filter (where relationships is not null),
+    '[]'
+  ) as relationships
+FROM
+  pg_namespace nc
+  JOIN pg_class c ON nc.oid = c.relnamespace
+  left join (
+    select
+      c.oid::int8 as table_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'table_id', c.oid::int8,
+          'schema', n.nspname,
+          'table_name', c.relname,
+          'name', a.attname
+        )
+        order by array_position(i.indkey, a.attnum)
+      ) as primary_keys
+    from
+      pg_index i
+      join pg_class c on i.indrelid = c.oid
+      join pg_namespace n on c.relnamespace = n.oid
+      join pg_attribute a on a.attrelid = c.oid and a.attnum = any(i.indkey)
+    where
+      ${props.schemaFilter ? `n.nspname ${props.schemaFilter} AND` : ''}
+      ${props.tableIdentifierFilter ? `n.nspname || '.' || c.relname ${props.tableIdentifierFilter} AND` : ''}
+      i.indisprimary
+    group by c.oid
+  ) as pk
+  on pk.table_id = c.oid
+  left join (
+    select
+      c.oid :: int8 as id,
+      c.conname as constraint_name,
+      nsa.nspname as source_schema,
+      csa.relname as source_table_name,
+      sa.attname as source_column_name,
+      nta.nspname as target_table_schema,
+      cta.relname as target_table_name,
+      ta.attname as target_column_name
+    from
+      pg_constraint c
+    join (
+      pg_attribute sa
+      join pg_class csa on sa.attrelid = csa.oid
+      join pg_namespace nsa on csa.relnamespace = nsa.oid
+    ) on sa.attrelid = c.conrelid and sa.attnum = any (c.conkey)
+    join (
+      pg_attribute ta
+      join pg_class cta on ta.attrelid = cta.oid
+      join pg_namespace nta on cta.relnamespace = nta.oid
+    ) on ta.attrelid = c.confrelid and ta.attnum = any (c.confkey)
+    where
+      ${props.schemaFilter ? `nsa.nspname ${props.schemaFilter} OR nta.nspname ${props.schemaFilter} AND` : ''}
+      ${props.tableIdentifierFilter ? `(nsa.nspname || '.' || csa.relname) ${props.tableIdentifierFilter} OR (nta.nspname || '.' || cta.relname) ${props.tableIdentifierFilter} AND` : ''}
+      c.contype = 'f'
+  ) as relationships
+  on (relationships.source_schema = nc.nspname and relationships.source_table_name = c.relname)
+  or (relationships.target_table_schema = nc.nspname and relationships.target_table_name = c.relname)
+WHERE
+  ${props.schemaFilter ? `nc.nspname ${props.schemaFilter} AND` : ''}
+  ${props.idsFilter ? `c.oid ${props.idsFilter} AND` : ''}
+  ${props.tableIdentifierFilter ? `nc.nspname || '.' || c.relname ${props.tableIdentifierFilter} AND` : ''}
+  c.relkind IN ('r', 'p')
+  AND NOT pg_is_other_temp_schema(nc.oid)
+  AND (
+    pg_has_role(c.relowner, 'USAGE')
+    OR has_table_privilege(
+      c.oid,
+      'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER'
+    )
+    OR has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
+  )
+group by
+  c.oid,
+  c.relname,
+  c.relrowsecurity,
+  c.relforcerowsecurity,
+  c.relreplident,
+  nc.nspname,
+  pk.primary_keys
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/table_privileges.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/table_privileges.sql.ts
@@ -1,0 +1,95 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const TABLE_PRIVILEGES_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & {
+    nameIdentifierFilter?: string
+  }
+) => /* SQL */ `
+-- Despite the name \`table_privileges\`, this includes other kinds of relations:
+-- views, matviews, etc. "Relation privileges" just doesn't roll off the tongue.
+--
+-- For each relation, get its relacl in a jsonb format,
+-- e.g.
+--
+-- '{postgres=arwdDxt/postgres}'
+--
+-- becomes
+--
+-- [
+--   {
+--     "grantee": "postgres",
+--     "grantor": "postgres",
+--     "is_grantable": false,
+--     "privilege_type": "INSERT"
+--   },
+--   ...
+-- ]
+select
+  c.oid as relation_id,
+  nc.nspname as schema,
+  c.relname as name,
+  case
+    when c.relkind = 'r' then 'table'
+    when c.relkind = 'v' then 'view'
+    when c.relkind = 'm' then 'materialized_view'
+    when c.relkind = 'f' then 'foreign_table'
+    when c.relkind = 'p' then 'partitioned_table'
+  end as kind,
+  coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'grantor', grantor.rolname,
+        'grantee', grantee.rolname,
+        'privilege_type', _priv.privilege_type,
+        'is_grantable', _priv.is_grantable
+      )
+    ) filter (where _priv is not null),
+    '[]'
+  ) as privileges
+from pg_class c
+join pg_namespace as nc
+  on nc.oid = c.relnamespace
+left join lateral (
+  select grantor, grantee, privilege_type, is_grantable
+  from aclexplode(coalesce(c.relacl, acldefault('r', c.relowner)))
+) as _priv on true
+left join pg_roles as grantor
+  on grantor.oid = _priv.grantor
+left join (
+  select
+    pg_roles.oid,
+    pg_roles.rolname
+  from pg_roles
+  union all
+  select
+    (0)::oid as oid, 'PUBLIC'
+) as grantee (oid, rolname)
+  on grantee.oid = _priv.grantee
+where c.relkind in ('r', 'v', 'm', 'f', 'p')
+  ${props.schemaFilter ? `and nc.nspname ${props.schemaFilter}` : ''}
+  ${props.idsFilter ? `and c.oid ${props.idsFilter}` : ''}
+  ${props.nameIdentifierFilter ? `and (nc.nspname || '.' || c.relname) ${props.nameIdentifierFilter}` : ''}
+  and not pg_is_other_temp_schema(c.relnamespace)
+  and (
+    pg_has_role(c.relowner, 'USAGE')
+    or has_table_privilege(
+      c.oid,
+      'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER, MAINTAIN'
+    )
+    or has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
+  )
+group by
+  c.oid,
+  nc.nspname,
+  c.relname,
+  c.relkind
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/table_relationships.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/table_relationships.sql.ts
@@ -1,0 +1,58 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilter } from './common.js'
+
+export const TABLE_RELATIONSHIPS_SQL = (props: SQLQueryPropsWithSchemaFilter) => /* SQL */ `
+-- Adapted from
+-- https://github.com/PostgREST/postgrest/blob/f9f0f79fa914ac00c11fbf7f4c558e14821e67e2/src/PostgREST/SchemaCache.hs#L722
+WITH
+pks_uniques_cols AS (
+  SELECT
+    connamespace,
+    conrelid,
+    jsonb_agg(column_info.cols) as cols
+  FROM pg_constraint
+  JOIN lateral (
+    SELECT array_agg(cols.attname order by cols.attnum) as cols
+    FROM ( select unnest(conkey) as col) _
+    JOIN pg_attribute cols on cols.attrelid = conrelid and cols.attnum = col
+  ) column_info ON TRUE
+  WHERE
+    contype IN ('p', 'u') and
+    connamespace::regnamespace::text <> 'pg_catalog'
+    ${props.schemaFilter ? `and connamespace::regnamespace::text ${props.schemaFilter}` : ''}
+  GROUP BY connamespace, conrelid
+)
+SELECT
+  traint.conname AS foreign_key_name,
+  ns1.nspname AS schema,
+  tab.relname AS relation,
+  column_info.cols AS columns,
+  ns2.nspname AS referenced_schema,
+  other.relname AS referenced_relation,
+  column_info.refs AS referenced_columns,
+  (column_info.cols IN (SELECT * FROM jsonb_array_elements(pks_uqs.cols))) AS is_one_to_one
+FROM pg_constraint traint
+JOIN LATERAL (
+  SELECT
+    jsonb_agg(cols.attname order by ord) AS cols,
+    jsonb_agg(refs.attname order by ord) AS refs
+  FROM unnest(traint.conkey, traint.confkey) WITH ORDINALITY AS _(col, ref, ord)
+  JOIN pg_attribute cols ON cols.attrelid = traint.conrelid AND cols.attnum = col
+  JOIN pg_attribute refs ON refs.attrelid = traint.confrelid AND refs.attnum = ref
+  WHERE ${props.schemaFilter ? `traint.connamespace::regnamespace::text ${props.schemaFilter}` : 'true'}
+) AS column_info ON TRUE
+JOIN pg_namespace ns1 ON ns1.oid = traint.connamespace
+JOIN pg_class tab ON tab.oid = traint.conrelid
+JOIN pg_class other ON other.oid = traint.confrelid
+JOIN pg_namespace ns2 ON ns2.oid = other.relnamespace
+LEFT JOIN pks_uniques_cols pks_uqs ON pks_uqs.connamespace = traint.connamespace AND pks_uqs.conrelid = traint.conrelid
+WHERE traint.contype = 'f'
+AND traint.conparentid = 0
+${props.schemaFilter ? `and ns1.nspname ${props.schemaFilter}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/triggers.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/triggers.sql.ts
@@ -1,0 +1,75 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const TRIGGERS_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & {
+    tableNameFilter?: string
+    nameFilter?: string
+  }
+) => /* SQL */ `
+SELECT
+  pg_t.oid AS id,
+  pg_t.tgrelid AS table_id,
+  CASE
+    WHEN pg_t.tgenabled = 'D' THEN 'DISABLED'
+    WHEN pg_t.tgenabled = 'O' THEN 'ORIGIN'
+    WHEN pg_t.tgenabled = 'R' THEN 'REPLICA'
+    WHEN pg_t.tgenabled = 'A' THEN 'ALWAYS'
+    END AS enabled_mode,
+  (
+    STRING_TO_ARRAY(
+      ENCODE(pg_t.tgargs, 'escape'), '\\000'
+    )
+  )[:pg_t.tgnargs] AS function_args,
+  is_t.trigger_name AS name,
+  is_t.event_object_table AS table,
+  is_t.event_object_schema AS schema,
+  is_t.action_condition AS condition,
+  is_t.action_orientation AS orientation,
+  is_t.action_timing AS activation,
+  ARRAY_AGG(is_t.event_manipulation)::text[] AS events,
+  pg_p.proname AS function_name,
+  pg_n.nspname AS function_schema
+FROM
+  pg_trigger AS pg_t
+JOIN
+  pg_class AS pg_c
+ON pg_t.tgrelid = pg_c.oid
+JOIN pg_namespace AS table_ns
+ON pg_c.relnamespace = table_ns.oid
+JOIN information_schema.triggers AS is_t
+ON is_t.trigger_name = pg_t.tgname
+AND pg_c.relname = is_t.event_object_table
+AND pg_c.relnamespace = (quote_ident(is_t.event_object_schema))::regnamespace
+JOIN pg_proc AS pg_p
+ON pg_t.tgfoid = pg_p.oid
+JOIN pg_namespace AS pg_n
+ON pg_p.pronamespace = pg_n.oid
+WHERE
+  ${props.schemaFilter ? `table_ns.nspname ${props.schemaFilter}` : 'true'}
+  ${props.tableNameFilter ? `AND pg_c.relname ${props.tableNameFilter}` : ''}
+  ${props.nameFilter ? `AND is_t.trigger_name ${props.nameFilter}` : ''}
+  ${props.idsFilter ? `AND pg_t.oid ${props.idsFilter}` : ''}
+GROUP BY
+  pg_t.oid,
+  pg_t.tgrelid,
+  pg_t.tgenabled,
+  pg_t.tgargs,
+  pg_t.tgnargs,
+  is_t.trigger_name,
+  is_t.event_object_table,
+  is_t.event_object_schema,
+  is_t.action_condition,
+  is_t.action_orientation,
+  is_t.action_timing,
+  pg_p.proname,
+  pg_n.nspname
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/types.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/types.sql.ts
@@ -1,0 +1,80 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const TYPES_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & {
+    includeTableTypes?: boolean
+    includeArrayTypes?: boolean
+  }
+) => /* SQL */ `
+select
+  t.oid::int8 as id,
+  t.typname as name,
+  n.nspname as schema,
+  format_type (t.oid, null) as format,
+  coalesce(t_enums.enums, '[]') as enums,
+  coalesce(t_attributes.attributes, '[]') as attributes,
+  obj_description (t.oid, 'pg_type') as comment,
+  nullif(t.typrelid::int8, 0) as type_relation_id
+from
+  pg_type t
+  left join pg_namespace n on n.oid = t.typnamespace
+  left join (
+    select
+      enumtypid,
+      jsonb_agg(enumlabel order by enumsortorder) as enums
+    from
+      pg_enum
+    group by
+      enumtypid
+  ) as t_enums on t_enums.enumtypid = t.oid
+  left join (
+    select
+      oid,
+      jsonb_agg(
+        jsonb_build_object('name', a.attname, 'type_id', a.atttypid::int8)
+        order by a.attnum asc
+      ) as attributes
+    from
+      pg_class c
+      join pg_attribute a on a.attrelid = c.oid
+    where
+      c.relkind = 'c' and not a.attisdropped
+    group by
+      c.oid
+  ) as t_attributes on t_attributes.oid = t.typrelid
+  where
+      (
+        t.typrelid = 0
+        or (
+          select
+            c.relkind ${props.includeTableTypes ? `in ('c', 'r', 'v', 'm', 'p')` : `= 'c'`}
+          from
+            pg_class c
+          where
+            c.oid = t.typrelid
+        )
+      )
+      ${
+        !props.includeArrayTypes
+          ? `and not exists (
+                 select
+                 from
+                   pg_type el
+                 where
+                   el.oid = t.typelem
+                   and el.typarray = t.oid
+               )`
+          : ''
+      }
+      ${props.schemaFilter ? `and n.nspname ${props.schemaFilter}` : ''}
+      ${props.idsFilter ? `and t.oid ${props.idsFilter}` : ''}
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/version.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/version.sql.ts
@@ -1,0 +1,19 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+export const VERSION_SQL = () => /* SQL */ `
+SELECT
+  version(),
+  current_setting('server_version_num') :: int8 AS version_number,
+  (
+    SELECT
+      COUNT(*) AS active_connections
+    FROM
+      pg_stat_activity
+  ) AS active_connections,
+  current_setting('max_connections') :: int8 AS max_connections
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/views.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/views.sql.ts
@@ -1,0 +1,32 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilterAndIdsFilter } from './common.js'
+
+export const VIEWS_SQL = (
+  props: SQLQueryPropsWithSchemaFilterAndIdsFilter & {
+    viewIdentifierFilter?: string
+  }
+) => /* SQL */ `
+SELECT
+  c.oid :: int8 AS id,
+  n.nspname AS schema,
+  c.relname AS name,
+  -- See definition of information_schema.views
+  (pg_relation_is_updatable(c.oid, false) & 20) = 20 AS is_updatable,
+  obj_description(c.oid) AS comment
+FROM
+  pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE
+  ${props.schemaFilter ? `n.nspname ${props.schemaFilter} AND` : ''}
+  ${props.idsFilter ? `c.oid ${props.idsFilter} AND` : ''}
+  ${props.viewIdentifierFilter ? `(n.nspname || '.' || c.relname) ${props.viewIdentifierFilter} AND` : ''}
+  c.relkind = 'v'
+${props.limit ? `limit ${props.limit}` : ''}
+${props.offset ? `offset ${props.offset}` : ''}
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/sql/views_key_dependencies.sql.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/sql/views_key_dependencies.sql.ts
@@ -1,0 +1,204 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import type { SQLQueryPropsWithSchemaFilter } from './common.js'
+
+export const VIEWS_KEY_DEPENDENCIES_SQL = (props: SQLQueryPropsWithSchemaFilter) => /* SQL */ `
+-- Adapted from
+-- https://github.com/PostgREST/postgrest/blob/f9f0f79fa914ac00c11fbf7f4c558e14821e67e2/src/PostgREST/SchemaCache.hs#L820
+with recursive
+pks_fks as (
+  -- pk + fk referencing col
+  select
+    contype::text as contype,
+    conname,
+    array_length(conkey, 1) as ncol,
+    conrelid as resorigtbl,
+    col as resorigcol,
+    ord
+  from pg_constraint
+  left join lateral unnest(conkey) with ordinality as _(col, ord) on true
+  where contype IN ('p', 'f')
+  union
+  -- fk referenced col
+  select
+    concat(contype, '_ref') as contype,
+    conname,
+    array_length(confkey, 1) as ncol,
+    confrelid,
+    col,
+    ord
+  from pg_constraint
+  left join lateral unnest(confkey) with ordinality as _(col, ord) on true
+  where contype='f'
+  ${props.schemaFilter ? `and connamespace::regnamespace::text ${props.schemaFilter}` : ''}
+),
+views as (
+  select
+    c.oid       as view_id,
+    n.nspname   as view_schema,
+    c.relname   as view_name,
+    r.ev_action as view_definition
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  join pg_rewrite r on r.ev_class = c.oid
+  where c.relkind in ('v', 'm') 
+    ${props.schemaFilter ? `and n.nspname ${props.schemaFilter}` : ''}
+),
+transform_json as (
+  select
+    view_id, view_schema, view_name,
+    -- the following formatting is without indentation on purpose
+    -- to allow simple diffs, with less whitespace noise
+    replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      regexp_replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+      replace(
+        view_definition::text,
+      -- This conversion to json is heavily optimized for performance.
+      -- The general idea is to use as few regexp_replace() calls as possible.
+      -- Simple replace() is a lot faster, so we jump through some hoops
+      -- to be able to use regexp_replace() only once.
+      -- This has been tested against a huge schema with 250+ different views.
+      -- The unit tests do NOT reflect all possible inputs. Be careful when changing this!
+      -- -----------------------------------------------
+      -- pattern           | replacement         | flags
+      -- -----------------------------------------------
+      -- <> in pg_node_tree is the same as null in JSON, but due to very poor performance of json_typeof
+      -- we need to make this an empty array here to prevent json_array_elements from throwing an error
+      -- when the targetList is null.
+      -- We'll need to put it first, to make the node protection below work for node lists that start with
+      -- null: (<> ..., too. This is the case for coldefexprs, when the first column does not have a default value.
+         '<>'              , '()'
+      -- , is not part of the pg_node_tree format, but used in the regex.
+      -- This removes all , that might be part of column names.
+      ), ','               , ''
+      -- The same applies for { and }, although those are used a lot in pg_node_tree.
+      -- We remove the escaped ones, which might be part of column names again.
+      ), E'\\\\{'            , ''
+      ), E'\\\\}'            , ''
+      -- The fields we need are formatted as json manually to protect them from the regex.
+      ), ' :targetList '   , ',"targetList":'
+      ), ' :resno '        , ',"resno":'
+      ), ' :resorigtbl '   , ',"resorigtbl":'
+      ), ' :resorigcol '   , ',"resorigcol":'
+      -- Make the regex also match the node type, e.g. \`{QUERY ...\`, to remove it in one pass.
+      ), '{'               , '{ :'
+      -- Protect node lists, which start with \`({\` or \`((\` from the greedy regex.
+      -- The extra \`{\` is removed again later.
+      ), '(('              , '{(('
+      ), '({'              , '{({'
+      -- This regex removes all unused fields to avoid the need to format all of them correctly.
+      -- This leads to a smaller json result as well.
+      -- Removal stops at \`,\` for used fields (see above) and \`}\` for the end of the current node.
+      -- Nesting can't be parsed correctly with a regex, so we stop at \`{\` as well and
+      -- add an empty key for the followig node.
+      ), ' :[^}{,]+'       , ',"":'              , 'g'
+      -- For performance, the regex also added those empty keys when hitting a \`,\` or \`}\`.
+      -- Those are removed next.
+      ), ',"":}'           , '}'
+      ), ',"":,'           , ','
+      -- This reverses the "node list protection" from above.
+      ), '{('              , '('
+      -- Every key above has been added with a \`,\` so far. The first key in an object doesn't need it.
+      ), '{,'              , '{'
+      -- pg_node_tree has \`()\` around lists, but JSON uses \`[]\`
+      ), '('               , '['
+      ), ')'               , ']'
+      -- pg_node_tree has \` \` between list items, but JSON uses \`,\`
+      ), ' '             , ','
+    )::json as view_definition
+  from views
+),
+target_entries as(
+  select
+    view_id, view_schema, view_name,
+    json_array_elements(view_definition->0->'targetList') as entry
+  from transform_json
+),
+results as(
+  select
+    view_id, view_schema, view_name,
+    (entry->>'resno')::int as view_column,
+    (entry->>'resorigtbl')::oid as resorigtbl,
+    (entry->>'resorigcol')::int as resorigcol
+  from target_entries
+),
+-- CYCLE detection according to PG docs: https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CYCLE
+-- Can be replaced with CYCLE clause once PG v13 is EOL.
+recursion(view_id, view_schema, view_name, view_column, resorigtbl, resorigcol, is_cycle, path) as(
+  select
+    r.*,
+    false,
+    ARRAY[resorigtbl]
+  from results r
+  where ${props.schemaFilter ? `view_schema ${props.schemaFilter}` : 'true'}
+  union all
+  select
+    view.view_id,
+    view.view_schema,
+    view.view_name,
+    view.view_column,
+    tab.resorigtbl,
+    tab.resorigcol,
+    tab.resorigtbl = ANY(path),
+    path || tab.resorigtbl
+  from recursion view
+  join results tab on view.resorigtbl=tab.view_id and view.resorigcol=tab.view_column
+  where not is_cycle
+),
+repeated_references as(
+  select
+    view_id,
+    view_schema,
+    view_name,
+    resorigtbl,
+    resorigcol,
+    array_agg(attname) as view_columns
+  from recursion
+  join pg_attribute vcol on vcol.attrelid = view_id and vcol.attnum = view_column
+  group by
+    view_id,
+    view_schema,
+    view_name,
+    resorigtbl,
+    resorigcol
+)
+select
+  sch.nspname as table_schema,
+  tbl.relname as table_name,
+  rep.view_schema,
+  rep.view_name,
+  pks_fks.conname as constraint_name,
+  pks_fks.contype as constraint_type,
+  jsonb_agg(
+    jsonb_build_object('table_column', col.attname, 'view_columns', view_columns) order by pks_fks.ord
+  ) as column_dependencies
+from repeated_references rep
+join pks_fks using (resorigtbl, resorigcol)
+join pg_class tbl on tbl.oid = rep.resorigtbl
+join pg_attribute col on col.attrelid = tbl.oid and col.attnum = rep.resorigcol
+join pg_namespace sch on sch.oid = tbl.relnamespace
+group by sch.nspname, tbl.relname,  rep.view_schema, rep.view_name, pks_fks.conname, pks_fks.contype, pks_fks.ncol
+-- make sure we only return key for which all columns are referenced in the view - no partial PKs or FKs
+having ncol = array_length(array_agg(row(col.attname, view_columns) order by pks_fks.ord), 1)
+`

--- a/packages/neon-js/src/vendor/postgres-meta/lib/types.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/types.ts
@@ -3,12 +3,41 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) Supabase Inc. — see ../LICENSE
 // Modified by Neon for vendoring purposes, 2026-04-30:
-//   none
+//   - rewrote every `Type.Object(...) + Static<typeof ...>` pair as a plain
+//     TypeScript `interface` / discriminated union. This drops the
+//     `@sinclair/typebox` runtime dependency. The schema constants
+//     (`postgresColumnSchema`, etc.) were never imported by anything we
+//     vendor — they only existed to feed Fastify route validators in the
+//     upstream HTTP server, which we do not vendor.
+//   - replaced the `pg-protocol` `DatabaseError` type import with a minimal
+//     structural alias that captures the fields the rest of the vendored
+//     code reads. `pg-protocol` is bundled with `pg`, but we keep the
+//     direct dependency surface to upstream `pg@^8` only.
 
-import { Static, Type } from '@sinclair/typebox'
-import { DatabaseError } from 'pg-protocol'
 import type { Options as PrettierOptions } from 'prettier'
-import { PoolConfig as PgPoolConfig } from 'pg'
+import type { PoolConfig as PgPoolConfig } from 'pg'
+
+// Structural shape of `pg-protocol`'s `DatabaseError`. We only need the
+// fields the rest of the vendored code touches.
+interface PgDatabaseError extends Error {
+  length?: number
+  severity?: string
+  code?: string
+  detail?: string
+  hint?: string
+  position?: string
+  internalPosition?: string
+  internalQuery?: string
+  where?: string
+  schema?: string
+  table?: string
+  column?: string
+  dataType?: string
+  constraint?: string
+  file?: string
+  line?: string
+  routine?: string
+}
 
 export interface FormatterOptions extends PrettierOptions {}
 
@@ -19,582 +48,461 @@ export interface PostgresMetaOk<T> {
 
 export interface PostgresMetaErr {
   data: null
-  error: Partial<DatabaseError> & { message: string; formattedError?: string }
+  error: Partial<PgDatabaseError> & { message: string; formattedError?: string }
 }
 
 export type PostgresMetaResult<T> = PostgresMetaOk<T> | PostgresMetaErr
 
-export const postgresColumnSchema = Type.Object({
-  table_id: Type.Integer(),
-  schema: Type.String(),
-  table: Type.String(),
-  id: Type.RegExp(/^(\d+)\.(\d+)$/),
-  ordinal_position: Type.Integer(),
-  name: Type.String(),
-  default_value: Type.Unknown(),
-  data_type: Type.String(),
-  format: Type.String(),
-  is_identity: Type.Boolean(),
-  identity_generation: Type.Union([
-    Type.Literal('ALWAYS'),
-    Type.Literal('BY DEFAULT'),
-    Type.Null(),
-  ]),
-  is_generated: Type.Boolean(),
-  is_nullable: Type.Boolean(),
-  is_updatable: Type.Boolean(),
-  is_unique: Type.Boolean(),
-  enums: Type.Array(Type.String()),
-  check: Type.Union([Type.String(), Type.Null()]),
-  comment: Type.Union([Type.String(), Type.Null()]),
-})
-export type PostgresColumn = Static<typeof postgresColumnSchema>
+export interface PostgresColumn {
+  table_id: number
+  schema: string
+  table: string
+  /** Matches `^(\d+)\.(\d+)$` */
+  id: string
+  ordinal_position: number
+  name: string
+  default_value: unknown
+  data_type: string
+  format: string
+  is_identity: boolean
+  identity_generation: 'ALWAYS' | 'BY DEFAULT' | null
+  is_generated: boolean
+  is_nullable: boolean
+  is_updatable: boolean
+  is_unique: boolean
+  enums: string[]
+  check: string | null
+  comment: string | null
+}
 
-export const postgresColumnCreateSchema = Type.Object({
-  table_id: Type.Integer(),
-  name: Type.String(),
-  type: Type.String(),
-  default_value: Type.Optional(Type.Unknown()),
-  default_value_format: Type.Optional(
-    Type.Union([Type.Literal('expression'), Type.Literal('literal')])
-  ),
-  is_identity: Type.Optional(Type.Boolean()),
-  identity_generation: Type.Optional(
-    Type.Union([Type.Literal('BY DEFAULT'), Type.Literal('ALWAYS')])
-  ),
-  is_nullable: Type.Optional(Type.Boolean()),
-  is_primary_key: Type.Optional(Type.Boolean()),
-  is_unique: Type.Optional(Type.Boolean()),
-  comment: Type.Optional(Type.String()),
-  check: Type.Optional(Type.String()),
-})
-export type PostgresColumnCreate = Static<typeof postgresColumnCreateSchema>
+export interface PostgresColumnCreate {
+  table_id: number
+  name: string
+  type: string
+  default_value?: unknown
+  default_value_format?: 'expression' | 'literal'
+  is_identity?: boolean
+  identity_generation?: 'BY DEFAULT' | 'ALWAYS'
+  is_nullable?: boolean
+  is_primary_key?: boolean
+  is_unique?: boolean
+  comment?: string
+  check?: string
+}
 
-export const postgresColumnUpdateSchema = Type.Object({
-  name: Type.Optional(Type.String()),
-  type: Type.Optional(Type.String()),
-  drop_default: Type.Optional(Type.Boolean()),
-  default_value: Type.Optional(Type.Unknown()),
-  default_value_format: Type.Optional(
-    Type.Union([Type.Literal('expression'), Type.Literal('literal')])
-  ),
-  is_identity: Type.Optional(Type.Boolean()),
-  identity_generation: Type.Optional(
-    Type.Union([Type.Literal('BY DEFAULT'), Type.Literal('ALWAYS')])
-  ),
-  is_nullable: Type.Optional(Type.Boolean()),
-  is_unique: Type.Optional(Type.Boolean()),
-  comment: Type.Optional(Type.String()),
-  check: Type.Optional(
-    Type.Union(
-      // Type.Null() must go first: https://github.com/sinclairzx81/typebox/issues/546
-      [Type.Null(), Type.String()]
-    )
-  ),
-})
-export type PostgresColumnUpdate = Static<typeof postgresColumnUpdateSchema>
+export interface PostgresColumnUpdate {
+  name?: string
+  type?: string
+  drop_default?: boolean
+  default_value?: unknown
+  default_value_format?: 'expression' | 'literal'
+  is_identity?: boolean
+  identity_generation?: 'BY DEFAULT' | 'ALWAYS'
+  is_nullable?: boolean
+  is_unique?: boolean
+  comment?: string
+  check?: string | null
+}
 
 // TODO Rethink config.sql
-export const postgresConfigSchema = Type.Object({
-  name: Type.Unknown(),
-  setting: Type.Unknown(),
-  category: Type.Unknown(),
-  group: Type.Unknown(),
-  subgroup: Type.Unknown(),
-  unit: Type.Unknown(),
-  short_desc: Type.Unknown(),
-  extra_desc: Type.Unknown(),
-  context: Type.Unknown(),
-  vartype: Type.Unknown(),
-  source: Type.Unknown(),
-  min_val: Type.Unknown(),
-  max_val: Type.Unknown(),
-  enumvals: Type.Unknown(),
-  boot_val: Type.Unknown(),
-  reset_val: Type.Unknown(),
-  sourcefile: Type.Unknown(),
-  sourceline: Type.Unknown(),
-  pending_restart: Type.Unknown(),
-})
-export type PostgresConfig = Static<typeof postgresConfigSchema>
+export interface PostgresConfig {
+  name: unknown
+  setting: unknown
+  category: unknown
+  group: unknown
+  subgroup: unknown
+  unit: unknown
+  short_desc: unknown
+  extra_desc: unknown
+  context: unknown
+  vartype: unknown
+  source: unknown
+  min_val: unknown
+  max_val: unknown
+  enumvals: unknown
+  boot_val: unknown
+  reset_val: unknown
+  sourcefile: unknown
+  sourceline: unknown
+  pending_restart: unknown
+}
 
-export const postgresExtensionSchema = Type.Object({
-  name: Type.String(),
-  schema: Type.Union([Type.String(), Type.Null()]),
-  default_version: Type.String(),
-  installed_version: Type.Union([Type.String(), Type.Null()]),
-  comment: Type.Union([Type.String(), Type.Null()]),
-})
-export type PostgresExtension = Static<typeof postgresExtensionSchema>
+export interface PostgresExtension {
+  name: string
+  schema: string | null
+  default_version: string
+  installed_version: string | null
+  comment: string | null
+}
 
-export const postgresForeignTableSchema = Type.Object({
-  id: Type.Integer(),
-  schema: Type.String(),
-  name: Type.String(),
-  comment: Type.Union([Type.String(), Type.Null()]),
-  columns: Type.Optional(Type.Array(postgresColumnSchema)),
-})
-export type PostgresForeignTable = Static<typeof postgresForeignTableSchema>
+export interface PostgresForeignTable {
+  id: number
+  schema: string
+  name: string
+  comment: string | null
+  columns?: PostgresColumn[]
+}
 
-const postgresFunctionSchema = Type.Object({
-  id: Type.Integer(),
-  schema: Type.String(),
-  name: Type.String(),
-  language: Type.String(),
-  definition: Type.String(),
-  complete_statement: Type.String(),
-  args: Type.Array(
-    Type.Object({
-      mode: Type.Union([
-        Type.Literal('in'),
-        Type.Literal('out'),
-        Type.Literal('inout'),
-        Type.Literal('variadic'),
-        Type.Literal('table'),
-      ]),
-      name: Type.String(),
-      type_id: Type.Number(),
-      has_default: Type.Boolean(),
-    })
-  ),
-  argument_types: Type.String(),
-  identity_argument_types: Type.String(),
-  return_type_id: Type.Integer(),
-  return_type: Type.String(),
-  return_type_relation_id: Type.Union([Type.Integer(), Type.Null()]),
-  is_set_returning_function: Type.Boolean(),
-  prorows: Type.Union([Type.Number(), Type.Null()]),
-  behavior: Type.Union([
-    Type.Literal('IMMUTABLE'),
-    Type.Literal('STABLE'),
-    Type.Literal('VOLATILE'),
-  ]),
-  security_definer: Type.Boolean(),
-  config_params: Type.Union([Type.Record(Type.String(), Type.String()), Type.Null()]),
-})
-export type PostgresFunction = Static<typeof postgresFunctionSchema>
+export interface PostgresFunction {
+  id: number
+  schema: string
+  name: string
+  language: string
+  definition: string
+  complete_statement: string
+  args: {
+    mode: 'in' | 'out' | 'inout' | 'variadic' | 'table'
+    name: string
+    type_id: number
+    has_default: boolean
+  }[]
+  argument_types: string
+  identity_argument_types: string
+  return_type_id: number
+  return_type: string
+  return_type_relation_id: number | null
+  is_set_returning_function: boolean
+  prorows: number | null
+  behavior: 'IMMUTABLE' | 'STABLE' | 'VOLATILE'
+  security_definer: boolean
+  config_params: Record<string, string> | null
+}
 
-export const postgresFunctionCreateFunction = Type.Object({
-  name: Type.String(),
-  definition: Type.String(),
-  args: Type.Optional(Type.Array(Type.String())),
-  behavior: Type.Optional(
-    Type.Union([Type.Literal('IMMUTABLE'), Type.Literal('STABLE'), Type.Literal('VOLATILE')])
-  ),
-  config_params: Type.Optional(Type.Record(Type.String(), Type.String())),
-  schema: Type.Optional(Type.String()),
-  language: Type.Optional(Type.String()),
-  return_type: Type.Optional(Type.String()),
-  security_definer: Type.Optional(Type.Boolean()),
-})
-export type PostgresFunctionCreate = Static<typeof postgresFunctionCreateFunction>
+export interface PostgresFunctionCreate {
+  name: string
+  definition: string
+  args?: string[]
+  behavior?: 'IMMUTABLE' | 'STABLE' | 'VOLATILE'
+  config_params?: Record<string, string>
+  schema?: string
+  language?: string
+  return_type?: string
+  security_definer?: boolean
+}
 
-const postgresIndexSchema = Type.Object({
-  id: Type.Integer(),
-  table_id: Type.Integer(),
-  schema: Type.String(),
-  number_of_attributes: Type.Integer(),
-  number_of_key_attributes: Type.Integer(),
-  is_unique: Type.Boolean(),
-  is_primary: Type.Boolean(),
-  is_exclusion: Type.Boolean(),
-  is_immediate: Type.Boolean(),
-  is_clustered: Type.Boolean(),
-  is_valid: Type.Boolean(),
-  check_xmin: Type.Boolean(),
-  is_ready: Type.Boolean(),
-  is_live: Type.Boolean(),
-  is_replica_identity: Type.Boolean(),
-  key_attributes: Type.Array(Type.Number()),
-  collation: Type.Array(Type.Number()),
-  class: Type.Array(Type.Number()),
-  options: Type.Array(Type.Number()),
-  index_predicate: Type.Union([Type.String(), Type.Null()]),
-  comment: Type.Union([Type.String(), Type.Null()]),
-  index_definition: Type.String(),
-  access_method: Type.String(),
-  index_attributes: Type.Array(
-    Type.Object({
-      attribute_number: Type.Number(),
-      attribute_name: Type.String(),
-      data_type: Type.String(),
-    })
-  ),
-})
-export type PostgresIndex = Static<typeof postgresIndexSchema>
+export interface PostgresIndex {
+  id: number
+  table_id: number
+  schema: string
+  number_of_attributes: number
+  number_of_key_attributes: number
+  is_unique: boolean
+  is_primary: boolean
+  is_exclusion: boolean
+  is_immediate: boolean
+  is_clustered: boolean
+  is_valid: boolean
+  check_xmin: boolean
+  is_ready: boolean
+  is_live: boolean
+  is_replica_identity: boolean
+  key_attributes: number[]
+  collation: number[]
+  class: number[]
+  options: number[]
+  index_predicate: string | null
+  comment: string | null
+  index_definition: string
+  access_method: string
+  index_attributes: {
+    attribute_number: number
+    attribute_name: string
+    data_type: string
+  }[]
+}
 
-export const postgresPolicySchema = Type.Object({
-  id: Type.Integer(),
-  schema: Type.String(),
-  table: Type.String(),
-  table_id: Type.Integer(),
-  name: Type.String(),
-  action: Type.Union([Type.Literal('PERMISSIVE'), Type.Literal('RESTRICTIVE')]),
-  roles: Type.Array(Type.String()),
-  command: Type.Union([
-    Type.Literal('SELECT'),
-    Type.Literal('INSERT'),
-    Type.Literal('UPDATE'),
-    Type.Literal('DELETE'),
-    Type.Literal('ALL'),
-  ]),
-  definition: Type.Union([Type.String(), Type.Null()]),
-  check: Type.Union([Type.String(), Type.Null()]),
-})
-export type PostgresPolicy = Static<typeof postgresPolicySchema>
+export interface PostgresPolicy {
+  id: number
+  schema: string
+  table: string
+  table_id: number
+  name: string
+  action: 'PERMISSIVE' | 'RESTRICTIVE'
+  roles: string[]
+  command: 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'ALL'
+  definition: string | null
+  check: string | null
+}
 
-export const postgresPrimaryKeySchema = Type.Object({
-  schema: Type.String(),
-  table_name: Type.String(),
-  name: Type.String(),
-  table_id: Type.Integer(),
-})
-export type PostgresPrimaryKey = Static<typeof postgresPrimaryKeySchema>
+export interface PostgresPrimaryKey {
+  schema: string
+  table_name: string
+  name: string
+  table_id: number
+}
 
-export const postgresPublicationSchema = Type.Object({
-  id: Type.Integer(),
-  name: Type.String(),
-  owner: Type.String(),
-  publish_insert: Type.Boolean(),
-  publish_update: Type.Boolean(),
-  publish_delete: Type.Boolean(),
-  publish_truncate: Type.Boolean(),
-  tables: Type.Union([
-    Type.Array(Type.Object({ id: Type.Integer(), name: Type.String(), schema: Type.String() })),
-    Type.Null(),
-  ]),
-})
-export type PostgresPublication = Static<typeof postgresPublicationSchema>
+export interface PostgresPublication {
+  id: number
+  name: string
+  owner: string
+  publish_insert: boolean
+  publish_update: boolean
+  publish_delete: boolean
+  publish_truncate: boolean
+  tables: { id: number; name: string; schema: string }[] | null
+}
 
-export const postgresRelationshipOldSchema = Type.Object({
-  id: Type.Integer(),
-  constraint_name: Type.String(),
-  source_schema: Type.String(),
-  source_table_name: Type.String(),
-  source_column_name: Type.String(),
-  target_table_schema: Type.String(),
-  target_table_name: Type.String(),
-  target_column_name: Type.String(),
-})
-export const postgresRelationshipSchema = Type.Object({
-  foreign_key_name: Type.String(),
-  schema: Type.String(),
-  relation: Type.String(),
-  columns: Type.Array(Type.String()),
-  is_one_to_one: Type.Boolean(),
-  referenced_schema: Type.String(),
-  referenced_relation: Type.String(),
-  referenced_columns: Type.Array(Type.String()),
-})
-export type PostgresRelationship = Static<typeof postgresRelationshipSchema>
+/** Older shape returned by the `relationships` SQL; kept for compatibility. */
+export interface PostgresRelationshipOld {
+  id: number
+  constraint_name: string
+  source_schema: string
+  source_table_name: string
+  source_column_name: string
+  target_table_schema: string
+  target_table_name: string
+  target_column_name: string
+}
 
-export const PostgresMetaRoleConfigSchema = Type.Object({
-  op: Type.Union([Type.Literal('remove'), Type.Literal('add'), Type.Literal('replace')]),
-  path: Type.String(),
-  value: Type.Optional(Type.String()),
-})
-export type PostgresMetaRoleConfig = Static<typeof PostgresMetaRoleConfigSchema>
+export interface PostgresRelationship {
+  foreign_key_name: string
+  schema: string
+  relation: string
+  columns: string[]
+  is_one_to_one: boolean
+  referenced_schema: string
+  referenced_relation: string
+  referenced_columns: string[]
+}
 
-export const postgresRoleSchema = Type.Object({
-  id: Type.Integer(),
-  name: Type.String(),
-  is_superuser: Type.Boolean(),
-  can_create_db: Type.Boolean(),
-  can_create_role: Type.Boolean(),
-  inherit_role: Type.Boolean(),
-  can_login: Type.Boolean(),
-  is_replication_role: Type.Boolean(),
-  can_bypass_rls: Type.Boolean(),
-  active_connections: Type.Integer(),
-  connection_limit: Type.Integer(),
-  password: Type.String(),
-  valid_until: Type.Union([Type.String(), Type.Null()]),
-  config: Type.Union([Type.String(), Type.Null(), Type.Record(Type.String(), Type.String())]),
-})
-export type PostgresRole = Static<typeof postgresRoleSchema>
+export interface PostgresMetaRoleConfig {
+  op: 'remove' | 'add' | 'replace'
+  path: string
+  value?: string
+}
 
-export const postgresRoleCreateSchema = Type.Object({
-  name: Type.String(),
-  password: Type.Optional(Type.String()),
-  inherit_role: Type.Optional(Type.Boolean()),
-  can_login: Type.Optional(Type.Boolean()),
-  is_superuser: Type.Optional(Type.Boolean()),
-  can_create_db: Type.Optional(Type.Boolean()),
-  can_create_role: Type.Optional(Type.Boolean()),
-  is_replication_role: Type.Optional(Type.Boolean()),
-  can_bypass_rls: Type.Optional(Type.Boolean()),
-  connection_limit: Type.Optional(Type.Integer()),
-  member_of: Type.Optional(Type.Array(Type.String())),
-  members: Type.Optional(Type.Array(Type.String())),
-  admins: Type.Optional(Type.Array(Type.String())),
-  valid_until: Type.Optional(Type.String()),
-  config: Type.Optional(Type.Record(Type.String(), Type.String())),
-})
-export type PostgresRoleCreate = Static<typeof postgresRoleCreateSchema>
+export interface PostgresRole {
+  id: number
+  name: string
+  is_superuser: boolean
+  can_create_db: boolean
+  can_create_role: boolean
+  inherit_role: boolean
+  can_login: boolean
+  is_replication_role: boolean
+  can_bypass_rls: boolean
+  active_connections: number
+  connection_limit: number
+  password: string
+  valid_until: string | null
+  config: string | null | Record<string, string>
+}
 
-export const postgresRoleUpdateSchema = Type.Object({
-  name: Type.Optional(Type.String()),
-  password: Type.Optional(Type.String()),
-  inherit_role: Type.Optional(Type.Boolean()),
-  can_login: Type.Optional(Type.Boolean()),
-  is_superuser: Type.Optional(Type.Boolean()),
-  can_create_db: Type.Optional(Type.Boolean()),
-  can_create_role: Type.Optional(Type.Boolean()),
-  is_replication_role: Type.Optional(Type.Boolean()),
-  can_bypass_rls: Type.Optional(Type.Boolean()),
-  connection_limit: Type.Optional(Type.Integer()),
-  valid_until: Type.Optional(Type.String()),
-  config: Type.Optional(Type.Array(PostgresMetaRoleConfigSchema)),
-})
-export type PostgresRoleUpdate = Static<typeof postgresRoleUpdateSchema>
+export interface PostgresRoleCreate {
+  name: string
+  password?: string
+  inherit_role?: boolean
+  can_login?: boolean
+  is_superuser?: boolean
+  can_create_db?: boolean
+  can_create_role?: boolean
+  is_replication_role?: boolean
+  can_bypass_rls?: boolean
+  connection_limit?: number
+  member_of?: string[]
+  members?: string[]
+  admins?: string[]
+  valid_until?: string
+  config?: Record<string, string>
+}
 
-export const postgresSchemaSchema = Type.Object({
-  id: Type.Integer(),
-  name: Type.String(),
-  owner: Type.String(),
-})
-export type PostgresSchema = Static<typeof postgresSchemaSchema>
+export interface PostgresRoleUpdate {
+  name?: string
+  password?: string
+  inherit_role?: boolean
+  can_login?: boolean
+  is_superuser?: boolean
+  can_create_db?: boolean
+  can_create_role?: boolean
+  is_replication_role?: boolean
+  can_bypass_rls?: boolean
+  connection_limit?: number
+  valid_until?: string
+  config?: PostgresMetaRoleConfig[]
+}
 
-export const postgresSchemaCreateSchema = Type.Object({
-  name: Type.String(),
-  owner: Type.Optional(Type.String()),
-})
-export type PostgresSchemaCreate = Static<typeof postgresSchemaCreateSchema>
+export interface PostgresSchema {
+  id: number
+  name: string
+  owner: string
+}
 
-export const postgresSchemaUpdateSchema = Type.Object({
-  name: Type.Optional(Type.String()),
-  owner: Type.Optional(Type.String()),
-})
-export type PostgresSchemaUpdate = Static<typeof postgresSchemaUpdateSchema>
+export interface PostgresSchemaCreate {
+  name: string
+  owner?: string
+}
 
-export const postgresTableSchema = Type.Object({
-  id: Type.Integer(),
-  schema: Type.String(),
-  name: Type.String(),
-  rls_enabled: Type.Boolean(),
-  rls_forced: Type.Boolean(),
-  replica_identity: Type.Union([
-    Type.Literal('DEFAULT'),
-    Type.Literal('INDEX'),
-    Type.Literal('FULL'),
-    Type.Literal('NOTHING'),
-  ]),
-  bytes: Type.Integer(),
-  size: Type.String(),
-  live_rows_estimate: Type.Integer(),
-  dead_rows_estimate: Type.Integer(),
-  comment: Type.Union([Type.String(), Type.Null()]),
-  columns: Type.Optional(Type.Array(postgresColumnSchema)),
-  primary_keys: Type.Array(postgresPrimaryKeySchema),
-  relationships: Type.Array(postgresRelationshipOldSchema),
-})
-export type PostgresTable = Static<typeof postgresTableSchema>
+export interface PostgresSchemaUpdate {
+  name?: string
+  owner?: string
+}
 
-export const postgresTableCreateSchema = Type.Object({
-  name: Type.String(),
-  schema: Type.Optional(Type.String()),
-  comment: Type.Optional(Type.String()),
-})
-export type PostgresTableCreate = Static<typeof postgresTableCreateSchema>
+export interface PostgresTable {
+  id: number
+  schema: string
+  name: string
+  rls_enabled: boolean
+  rls_forced: boolean
+  replica_identity: 'DEFAULT' | 'INDEX' | 'FULL' | 'NOTHING'
+  bytes: number
+  size: string
+  live_rows_estimate: number
+  dead_rows_estimate: number
+  comment: string | null
+  columns?: PostgresColumn[]
+  primary_keys: PostgresPrimaryKey[]
+  relationships: PostgresRelationshipOld[]
+}
 
-export const postgresTableUpdateSchema = Type.Object({
-  name: Type.Optional(Type.String()),
-  schema: Type.Optional(Type.String()),
-  rls_enabled: Type.Optional(Type.Boolean()),
-  rls_forced: Type.Optional(Type.Boolean()),
-  replica_identity: Type.Optional(
-    Type.Union([
-      Type.Literal('DEFAULT'),
-      Type.Literal('INDEX'),
-      Type.Literal('FULL'),
-      Type.Literal('NOTHING'),
-    ])
-  ),
-  replica_identity_index: Type.Optional(Type.String()),
-  primary_keys: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
-  comment: Type.Optional(Type.String()),
-})
-export type PostgresTableUpdate = Static<typeof postgresTableUpdateSchema>
+export interface PostgresTableCreate {
+  name: string
+  schema?: string
+  comment?: string
+}
 
-export const postgresTriggerSchema = Type.Object({
-  id: Type.Integer(),
-  table_id: Type.Integer(),
-  enabled_mode: Type.Union([
-    Type.Literal('ORIGIN'),
-    Type.Literal('REPLICA'),
-    Type.Literal('ALWAYS'),
-    Type.Literal('DISABLED'),
-  ]),
-  name: Type.String(),
-  table: Type.String(),
-  schema: Type.String(),
-  condition: Type.Union([Type.String(), Type.Null()]),
-  orientation: Type.Union([Type.Literal('ROW'), Type.Literal('STATEMENT')]),
-  activation: Type.Union([
-    Type.Literal('BEFORE'),
-    Type.Literal('AFTER'),
-    Type.Literal('INSTEAD OF'),
-  ]),
-  events: Type.Array(Type.String()),
-  function_schema: Type.String(),
-  function_name: Type.String(),
-  function_args: Type.Array(Type.String()),
-})
-export type PostgresTrigger = Static<typeof postgresTriggerSchema>
+export interface PostgresTableUpdate {
+  name?: string
+  schema?: string
+  rls_enabled?: boolean
+  rls_forced?: boolean
+  replica_identity?: 'DEFAULT' | 'INDEX' | 'FULL' | 'NOTHING'
+  replica_identity_index?: string
+  primary_keys?: { name: string }[]
+  comment?: string
+}
 
-export const postgresTypeSchema = Type.Object({
-  id: Type.Integer(),
-  name: Type.String(),
-  schema: Type.String(),
-  format: Type.String(),
-  enums: Type.Array(Type.String()),
-  attributes: Type.Array(Type.Object({ name: Type.String(), type_id: Type.Integer() })),
-  comment: Type.Union([Type.String(), Type.Null()]),
-  type_relation_id: Type.Union([Type.Integer(), Type.Null()]),
-})
-export type PostgresType = Static<typeof postgresTypeSchema>
+export interface PostgresTrigger {
+  id: number
+  table_id: number
+  enabled_mode: 'ORIGIN' | 'REPLICA' | 'ALWAYS' | 'DISABLED'
+  name: string
+  table: string
+  schema: string
+  condition: string | null
+  orientation: 'ROW' | 'STATEMENT'
+  activation: 'BEFORE' | 'AFTER' | 'INSTEAD OF'
+  events: string[]
+  function_schema: string
+  function_name: string
+  function_args: string[]
+}
 
-export const postgresVersionSchema = Type.Object({
-  version: Type.String(),
-  version_number: Type.Integer(),
-  active_connections: Type.Integer(),
-  max_connections: Type.Integer(),
-})
-export type PostgresVersion = Static<typeof postgresVersionSchema>
+export interface PostgresType {
+  id: number
+  name: string
+  schema: string
+  format: string
+  enums: string[]
+  attributes: { name: string; type_id: number }[]
+  comment: string | null
+  type_relation_id: number | null
+}
 
-export const postgresViewSchema = Type.Object({
-  id: Type.Integer(),
-  schema: Type.String(),
-  name: Type.String(),
-  is_updatable: Type.Boolean(),
-  comment: Type.Union([Type.String(), Type.Null()]),
-  columns: Type.Optional(Type.Array(postgresColumnSchema)),
-})
-export type PostgresView = Static<typeof postgresViewSchema>
+export interface PostgresVersion {
+  version: string
+  version_number: number
+  active_connections: number
+  max_connections: number
+}
 
-export const postgresMaterializedViewSchema = Type.Object({
-  id: Type.Integer(),
-  schema: Type.String(),
-  name: Type.String(),
-  is_populated: Type.Boolean(),
-  comment: Type.Union([Type.String(), Type.Null()]),
-  columns: Type.Optional(Type.Array(postgresColumnSchema)),
-})
-export type PostgresMaterializedView = Static<typeof postgresMaterializedViewSchema>
+export interface PostgresView {
+  id: number
+  schema: string
+  name: string
+  is_updatable: boolean
+  comment: string | null
+  columns?: PostgresColumn[]
+}
 
-export const postgresTablePrivilegesSchema = Type.Object({
-  relation_id: Type.Integer(),
-  schema: Type.String(),
-  name: Type.String(),
-  kind: Type.Union([
-    Type.Literal('table'),
-    Type.Literal('view'),
-    Type.Literal('materialized_view'),
-    Type.Literal('foreign_table'),
-    Type.Literal('partitioned_table'),
-  ]),
-  privileges: Type.Array(
-    Type.Object({
-      grantor: Type.String(),
-      grantee: Type.String(),
-      privilege_type: Type.Union([
-        Type.Literal('SELECT'),
-        Type.Literal('INSERT'),
-        Type.Literal('UPDATE'),
-        Type.Literal('DELETE'),
-        Type.Literal('TRUNCATE'),
-        Type.Literal('REFERENCES'),
-        Type.Literal('TRIGGER'),
-        Type.Literal('MAINTAIN'),
-      ]),
-      is_grantable: Type.Boolean(),
-    })
-  ),
-})
-export type PostgresTablePrivileges = Static<typeof postgresTablePrivilegesSchema>
+export interface PostgresMaterializedView {
+  id: number
+  schema: string
+  name: string
+  is_populated: boolean
+  comment: string | null
+  columns?: PostgresColumn[]
+}
 
-export const postgresTablePrivilegesGrantSchema = Type.Object({
-  relation_id: Type.Integer(),
-  grantee: Type.String(),
-  privilege_type: Type.Union([
-    Type.Literal('ALL'),
-    Type.Literal('SELECT'),
-    Type.Literal('INSERT'),
-    Type.Literal('UPDATE'),
-    Type.Literal('DELETE'),
-    Type.Literal('TRUNCATE'),
-    Type.Literal('REFERENCES'),
-    Type.Literal('TRIGGER'),
-    Type.Literal('MAINTAIN'),
-  ]),
-  is_grantable: Type.Optional(Type.Boolean()),
-})
-export type PostgresTablePrivilegesGrant = Static<typeof postgresTablePrivilegesGrantSchema>
+export interface PostgresTablePrivileges {
+  relation_id: number
+  schema: string
+  name: string
+  kind: 'table' | 'view' | 'materialized_view' | 'foreign_table' | 'partitioned_table'
+  privileges: {
+    grantor: string
+    grantee: string
+    privilege_type:
+      | 'SELECT'
+      | 'INSERT'
+      | 'UPDATE'
+      | 'DELETE'
+      | 'TRUNCATE'
+      | 'REFERENCES'
+      | 'TRIGGER'
+      | 'MAINTAIN'
+    is_grantable: boolean
+  }[]
+}
 
-export const postgresTablePrivilegesRevokeSchema = Type.Object({
-  relation_id: Type.Integer(),
-  grantee: Type.String(),
-  privilege_type: Type.Union([
-    Type.Literal('ALL'),
-    Type.Literal('SELECT'),
-    Type.Literal('INSERT'),
-    Type.Literal('UPDATE'),
-    Type.Literal('DELETE'),
-    Type.Literal('TRUNCATE'),
-    Type.Literal('REFERENCES'),
-    Type.Literal('TRIGGER'),
-    Type.Literal('MAINTAIN'),
-  ]),
-})
-export type PostgresTablePrivilegesRevoke = Static<typeof postgresTablePrivilegesRevokeSchema>
+export interface PostgresTablePrivilegesGrant {
+  relation_id: number
+  grantee: string
+  privilege_type:
+    | 'ALL'
+    | 'SELECT'
+    | 'INSERT'
+    | 'UPDATE'
+    | 'DELETE'
+    | 'TRUNCATE'
+    | 'REFERENCES'
+    | 'TRIGGER'
+    | 'MAINTAIN'
+  is_grantable?: boolean
+}
 
-export const postgresColumnPrivilegesSchema = Type.Object({
-  column_id: Type.RegExp(/^(\d+)\.(\d+)$/),
-  relation_schema: Type.String(),
-  relation_name: Type.String(),
-  column_name: Type.String(),
-  privileges: Type.Array(
-    Type.Object({
-      grantor: Type.String(),
-      grantee: Type.String(),
-      privilege_type: Type.Union([
-        Type.Literal('SELECT'),
-        Type.Literal('INSERT'),
-        Type.Literal('UPDATE'),
-        Type.Literal('REFERENCES'),
-      ]),
-      is_grantable: Type.Boolean(),
-    })
-  ),
-})
-export type PostgresColumnPrivileges = Static<typeof postgresColumnPrivilegesSchema>
+export interface PostgresTablePrivilegesRevoke {
+  relation_id: number
+  grantee: string
+  privilege_type:
+    | 'ALL'
+    | 'SELECT'
+    | 'INSERT'
+    | 'UPDATE'
+    | 'DELETE'
+    | 'TRUNCATE'
+    | 'REFERENCES'
+    | 'TRIGGER'
+    | 'MAINTAIN'
+}
 
-export const postgresColumnPrivilegesGrantSchema = Type.Object({
-  column_id: Type.RegExp(/^(\d+)\.(\d+)$/),
-  grantee: Type.String(),
-  privilege_type: Type.Union([
-    Type.Literal('ALL'),
-    Type.Literal('SELECT'),
-    Type.Literal('INSERT'),
-    Type.Literal('UPDATE'),
-    Type.Literal('REFERENCES'),
-  ]),
-  is_grantable: Type.Optional(Type.Boolean()),
-})
-export type PostgresColumnPrivilegesGrant = Static<typeof postgresColumnPrivilegesGrantSchema>
+export interface PostgresColumnPrivileges {
+  /** Matches `^(\d+)\.(\d+)$` */
+  column_id: string
+  relation_schema: string
+  relation_name: string
+  column_name: string
+  privileges: {
+    grantor: string
+    grantee: string
+    privilege_type: 'SELECT' | 'INSERT' | 'UPDATE' | 'REFERENCES'
+    is_grantable: boolean
+  }[]
+}
 
-export const postgresColumnPrivilegesRevokeSchema = Type.Object({
-  column_id: Type.RegExp(/^(\d+)\.(\d+)$/),
-  grantee: Type.String(),
-  privilege_type: Type.Union([
-    Type.Literal('ALL'),
-    Type.Literal('SELECT'),
-    Type.Literal('INSERT'),
-    Type.Literal('UPDATE'),
-    Type.Literal('REFERENCES'),
-  ]),
-})
-export type PostgresColumnPrivilegesRevoke = Static<typeof postgresColumnPrivilegesRevokeSchema>
+export interface PostgresColumnPrivilegesGrant {
+  /** Matches `^(\d+)\.(\d+)$` */
+  column_id: string
+  grantee: string
+  privilege_type: 'ALL' | 'SELECT' | 'INSERT' | 'UPDATE' | 'REFERENCES'
+  is_grantable?: boolean
+}
+
+export interface PostgresColumnPrivilegesRevoke {
+  /** Matches `^(\d+)\.(\d+)$` */
+  column_id: string
+  grantee: string
+  privilege_type: 'ALL' | 'SELECT' | 'INSERT' | 'UPDATE' | 'REFERENCES'
+}
 
 export interface PoolConfig extends PgPoolConfig {
   maxResultSize?: number

--- a/packages/neon-js/src/vendor/postgres-meta/lib/types.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/lib/types.ts
@@ -1,0 +1,601 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import { Static, Type } from '@sinclair/typebox'
+import { DatabaseError } from 'pg-protocol'
+import type { Options as PrettierOptions } from 'prettier'
+import { PoolConfig as PgPoolConfig } from 'pg'
+
+export interface FormatterOptions extends PrettierOptions {}
+
+export interface PostgresMetaOk<T> {
+  data: T
+  error: null
+}
+
+export interface PostgresMetaErr {
+  data: null
+  error: Partial<DatabaseError> & { message: string; formattedError?: string }
+}
+
+export type PostgresMetaResult<T> = PostgresMetaOk<T> | PostgresMetaErr
+
+export const postgresColumnSchema = Type.Object({
+  table_id: Type.Integer(),
+  schema: Type.String(),
+  table: Type.String(),
+  id: Type.RegExp(/^(\d+)\.(\d+)$/),
+  ordinal_position: Type.Integer(),
+  name: Type.String(),
+  default_value: Type.Unknown(),
+  data_type: Type.String(),
+  format: Type.String(),
+  is_identity: Type.Boolean(),
+  identity_generation: Type.Union([
+    Type.Literal('ALWAYS'),
+    Type.Literal('BY DEFAULT'),
+    Type.Null(),
+  ]),
+  is_generated: Type.Boolean(),
+  is_nullable: Type.Boolean(),
+  is_updatable: Type.Boolean(),
+  is_unique: Type.Boolean(),
+  enums: Type.Array(Type.String()),
+  check: Type.Union([Type.String(), Type.Null()]),
+  comment: Type.Union([Type.String(), Type.Null()]),
+})
+export type PostgresColumn = Static<typeof postgresColumnSchema>
+
+export const postgresColumnCreateSchema = Type.Object({
+  table_id: Type.Integer(),
+  name: Type.String(),
+  type: Type.String(),
+  default_value: Type.Optional(Type.Unknown()),
+  default_value_format: Type.Optional(
+    Type.Union([Type.Literal('expression'), Type.Literal('literal')])
+  ),
+  is_identity: Type.Optional(Type.Boolean()),
+  identity_generation: Type.Optional(
+    Type.Union([Type.Literal('BY DEFAULT'), Type.Literal('ALWAYS')])
+  ),
+  is_nullable: Type.Optional(Type.Boolean()),
+  is_primary_key: Type.Optional(Type.Boolean()),
+  is_unique: Type.Optional(Type.Boolean()),
+  comment: Type.Optional(Type.String()),
+  check: Type.Optional(Type.String()),
+})
+export type PostgresColumnCreate = Static<typeof postgresColumnCreateSchema>
+
+export const postgresColumnUpdateSchema = Type.Object({
+  name: Type.Optional(Type.String()),
+  type: Type.Optional(Type.String()),
+  drop_default: Type.Optional(Type.Boolean()),
+  default_value: Type.Optional(Type.Unknown()),
+  default_value_format: Type.Optional(
+    Type.Union([Type.Literal('expression'), Type.Literal('literal')])
+  ),
+  is_identity: Type.Optional(Type.Boolean()),
+  identity_generation: Type.Optional(
+    Type.Union([Type.Literal('BY DEFAULT'), Type.Literal('ALWAYS')])
+  ),
+  is_nullable: Type.Optional(Type.Boolean()),
+  is_unique: Type.Optional(Type.Boolean()),
+  comment: Type.Optional(Type.String()),
+  check: Type.Optional(
+    Type.Union(
+      // Type.Null() must go first: https://github.com/sinclairzx81/typebox/issues/546
+      [Type.Null(), Type.String()]
+    )
+  ),
+})
+export type PostgresColumnUpdate = Static<typeof postgresColumnUpdateSchema>
+
+// TODO Rethink config.sql
+export const postgresConfigSchema = Type.Object({
+  name: Type.Unknown(),
+  setting: Type.Unknown(),
+  category: Type.Unknown(),
+  group: Type.Unknown(),
+  subgroup: Type.Unknown(),
+  unit: Type.Unknown(),
+  short_desc: Type.Unknown(),
+  extra_desc: Type.Unknown(),
+  context: Type.Unknown(),
+  vartype: Type.Unknown(),
+  source: Type.Unknown(),
+  min_val: Type.Unknown(),
+  max_val: Type.Unknown(),
+  enumvals: Type.Unknown(),
+  boot_val: Type.Unknown(),
+  reset_val: Type.Unknown(),
+  sourcefile: Type.Unknown(),
+  sourceline: Type.Unknown(),
+  pending_restart: Type.Unknown(),
+})
+export type PostgresConfig = Static<typeof postgresConfigSchema>
+
+export const postgresExtensionSchema = Type.Object({
+  name: Type.String(),
+  schema: Type.Union([Type.String(), Type.Null()]),
+  default_version: Type.String(),
+  installed_version: Type.Union([Type.String(), Type.Null()]),
+  comment: Type.Union([Type.String(), Type.Null()]),
+})
+export type PostgresExtension = Static<typeof postgresExtensionSchema>
+
+export const postgresForeignTableSchema = Type.Object({
+  id: Type.Integer(),
+  schema: Type.String(),
+  name: Type.String(),
+  comment: Type.Union([Type.String(), Type.Null()]),
+  columns: Type.Optional(Type.Array(postgresColumnSchema)),
+})
+export type PostgresForeignTable = Static<typeof postgresForeignTableSchema>
+
+const postgresFunctionSchema = Type.Object({
+  id: Type.Integer(),
+  schema: Type.String(),
+  name: Type.String(),
+  language: Type.String(),
+  definition: Type.String(),
+  complete_statement: Type.String(),
+  args: Type.Array(
+    Type.Object({
+      mode: Type.Union([
+        Type.Literal('in'),
+        Type.Literal('out'),
+        Type.Literal('inout'),
+        Type.Literal('variadic'),
+        Type.Literal('table'),
+      ]),
+      name: Type.String(),
+      type_id: Type.Number(),
+      has_default: Type.Boolean(),
+    })
+  ),
+  argument_types: Type.String(),
+  identity_argument_types: Type.String(),
+  return_type_id: Type.Integer(),
+  return_type: Type.String(),
+  return_type_relation_id: Type.Union([Type.Integer(), Type.Null()]),
+  is_set_returning_function: Type.Boolean(),
+  prorows: Type.Union([Type.Number(), Type.Null()]),
+  behavior: Type.Union([
+    Type.Literal('IMMUTABLE'),
+    Type.Literal('STABLE'),
+    Type.Literal('VOLATILE'),
+  ]),
+  security_definer: Type.Boolean(),
+  config_params: Type.Union([Type.Record(Type.String(), Type.String()), Type.Null()]),
+})
+export type PostgresFunction = Static<typeof postgresFunctionSchema>
+
+export const postgresFunctionCreateFunction = Type.Object({
+  name: Type.String(),
+  definition: Type.String(),
+  args: Type.Optional(Type.Array(Type.String())),
+  behavior: Type.Optional(
+    Type.Union([Type.Literal('IMMUTABLE'), Type.Literal('STABLE'), Type.Literal('VOLATILE')])
+  ),
+  config_params: Type.Optional(Type.Record(Type.String(), Type.String())),
+  schema: Type.Optional(Type.String()),
+  language: Type.Optional(Type.String()),
+  return_type: Type.Optional(Type.String()),
+  security_definer: Type.Optional(Type.Boolean()),
+})
+export type PostgresFunctionCreate = Static<typeof postgresFunctionCreateFunction>
+
+const postgresIndexSchema = Type.Object({
+  id: Type.Integer(),
+  table_id: Type.Integer(),
+  schema: Type.String(),
+  number_of_attributes: Type.Integer(),
+  number_of_key_attributes: Type.Integer(),
+  is_unique: Type.Boolean(),
+  is_primary: Type.Boolean(),
+  is_exclusion: Type.Boolean(),
+  is_immediate: Type.Boolean(),
+  is_clustered: Type.Boolean(),
+  is_valid: Type.Boolean(),
+  check_xmin: Type.Boolean(),
+  is_ready: Type.Boolean(),
+  is_live: Type.Boolean(),
+  is_replica_identity: Type.Boolean(),
+  key_attributes: Type.Array(Type.Number()),
+  collation: Type.Array(Type.Number()),
+  class: Type.Array(Type.Number()),
+  options: Type.Array(Type.Number()),
+  index_predicate: Type.Union([Type.String(), Type.Null()]),
+  comment: Type.Union([Type.String(), Type.Null()]),
+  index_definition: Type.String(),
+  access_method: Type.String(),
+  index_attributes: Type.Array(
+    Type.Object({
+      attribute_number: Type.Number(),
+      attribute_name: Type.String(),
+      data_type: Type.String(),
+    })
+  ),
+})
+export type PostgresIndex = Static<typeof postgresIndexSchema>
+
+export const postgresPolicySchema = Type.Object({
+  id: Type.Integer(),
+  schema: Type.String(),
+  table: Type.String(),
+  table_id: Type.Integer(),
+  name: Type.String(),
+  action: Type.Union([Type.Literal('PERMISSIVE'), Type.Literal('RESTRICTIVE')]),
+  roles: Type.Array(Type.String()),
+  command: Type.Union([
+    Type.Literal('SELECT'),
+    Type.Literal('INSERT'),
+    Type.Literal('UPDATE'),
+    Type.Literal('DELETE'),
+    Type.Literal('ALL'),
+  ]),
+  definition: Type.Union([Type.String(), Type.Null()]),
+  check: Type.Union([Type.String(), Type.Null()]),
+})
+export type PostgresPolicy = Static<typeof postgresPolicySchema>
+
+export const postgresPrimaryKeySchema = Type.Object({
+  schema: Type.String(),
+  table_name: Type.String(),
+  name: Type.String(),
+  table_id: Type.Integer(),
+})
+export type PostgresPrimaryKey = Static<typeof postgresPrimaryKeySchema>
+
+export const postgresPublicationSchema = Type.Object({
+  id: Type.Integer(),
+  name: Type.String(),
+  owner: Type.String(),
+  publish_insert: Type.Boolean(),
+  publish_update: Type.Boolean(),
+  publish_delete: Type.Boolean(),
+  publish_truncate: Type.Boolean(),
+  tables: Type.Union([
+    Type.Array(Type.Object({ id: Type.Integer(), name: Type.String(), schema: Type.String() })),
+    Type.Null(),
+  ]),
+})
+export type PostgresPublication = Static<typeof postgresPublicationSchema>
+
+export const postgresRelationshipOldSchema = Type.Object({
+  id: Type.Integer(),
+  constraint_name: Type.String(),
+  source_schema: Type.String(),
+  source_table_name: Type.String(),
+  source_column_name: Type.String(),
+  target_table_schema: Type.String(),
+  target_table_name: Type.String(),
+  target_column_name: Type.String(),
+})
+export const postgresRelationshipSchema = Type.Object({
+  foreign_key_name: Type.String(),
+  schema: Type.String(),
+  relation: Type.String(),
+  columns: Type.Array(Type.String()),
+  is_one_to_one: Type.Boolean(),
+  referenced_schema: Type.String(),
+  referenced_relation: Type.String(),
+  referenced_columns: Type.Array(Type.String()),
+})
+export type PostgresRelationship = Static<typeof postgresRelationshipSchema>
+
+export const PostgresMetaRoleConfigSchema = Type.Object({
+  op: Type.Union([Type.Literal('remove'), Type.Literal('add'), Type.Literal('replace')]),
+  path: Type.String(),
+  value: Type.Optional(Type.String()),
+})
+export type PostgresMetaRoleConfig = Static<typeof PostgresMetaRoleConfigSchema>
+
+export const postgresRoleSchema = Type.Object({
+  id: Type.Integer(),
+  name: Type.String(),
+  is_superuser: Type.Boolean(),
+  can_create_db: Type.Boolean(),
+  can_create_role: Type.Boolean(),
+  inherit_role: Type.Boolean(),
+  can_login: Type.Boolean(),
+  is_replication_role: Type.Boolean(),
+  can_bypass_rls: Type.Boolean(),
+  active_connections: Type.Integer(),
+  connection_limit: Type.Integer(),
+  password: Type.String(),
+  valid_until: Type.Union([Type.String(), Type.Null()]),
+  config: Type.Union([Type.String(), Type.Null(), Type.Record(Type.String(), Type.String())]),
+})
+export type PostgresRole = Static<typeof postgresRoleSchema>
+
+export const postgresRoleCreateSchema = Type.Object({
+  name: Type.String(),
+  password: Type.Optional(Type.String()),
+  inherit_role: Type.Optional(Type.Boolean()),
+  can_login: Type.Optional(Type.Boolean()),
+  is_superuser: Type.Optional(Type.Boolean()),
+  can_create_db: Type.Optional(Type.Boolean()),
+  can_create_role: Type.Optional(Type.Boolean()),
+  is_replication_role: Type.Optional(Type.Boolean()),
+  can_bypass_rls: Type.Optional(Type.Boolean()),
+  connection_limit: Type.Optional(Type.Integer()),
+  member_of: Type.Optional(Type.Array(Type.String())),
+  members: Type.Optional(Type.Array(Type.String())),
+  admins: Type.Optional(Type.Array(Type.String())),
+  valid_until: Type.Optional(Type.String()),
+  config: Type.Optional(Type.Record(Type.String(), Type.String())),
+})
+export type PostgresRoleCreate = Static<typeof postgresRoleCreateSchema>
+
+export const postgresRoleUpdateSchema = Type.Object({
+  name: Type.Optional(Type.String()),
+  password: Type.Optional(Type.String()),
+  inherit_role: Type.Optional(Type.Boolean()),
+  can_login: Type.Optional(Type.Boolean()),
+  is_superuser: Type.Optional(Type.Boolean()),
+  can_create_db: Type.Optional(Type.Boolean()),
+  can_create_role: Type.Optional(Type.Boolean()),
+  is_replication_role: Type.Optional(Type.Boolean()),
+  can_bypass_rls: Type.Optional(Type.Boolean()),
+  connection_limit: Type.Optional(Type.Integer()),
+  valid_until: Type.Optional(Type.String()),
+  config: Type.Optional(Type.Array(PostgresMetaRoleConfigSchema)),
+})
+export type PostgresRoleUpdate = Static<typeof postgresRoleUpdateSchema>
+
+export const postgresSchemaSchema = Type.Object({
+  id: Type.Integer(),
+  name: Type.String(),
+  owner: Type.String(),
+})
+export type PostgresSchema = Static<typeof postgresSchemaSchema>
+
+export const postgresSchemaCreateSchema = Type.Object({
+  name: Type.String(),
+  owner: Type.Optional(Type.String()),
+})
+export type PostgresSchemaCreate = Static<typeof postgresSchemaCreateSchema>
+
+export const postgresSchemaUpdateSchema = Type.Object({
+  name: Type.Optional(Type.String()),
+  owner: Type.Optional(Type.String()),
+})
+export type PostgresSchemaUpdate = Static<typeof postgresSchemaUpdateSchema>
+
+export const postgresTableSchema = Type.Object({
+  id: Type.Integer(),
+  schema: Type.String(),
+  name: Type.String(),
+  rls_enabled: Type.Boolean(),
+  rls_forced: Type.Boolean(),
+  replica_identity: Type.Union([
+    Type.Literal('DEFAULT'),
+    Type.Literal('INDEX'),
+    Type.Literal('FULL'),
+    Type.Literal('NOTHING'),
+  ]),
+  bytes: Type.Integer(),
+  size: Type.String(),
+  live_rows_estimate: Type.Integer(),
+  dead_rows_estimate: Type.Integer(),
+  comment: Type.Union([Type.String(), Type.Null()]),
+  columns: Type.Optional(Type.Array(postgresColumnSchema)),
+  primary_keys: Type.Array(postgresPrimaryKeySchema),
+  relationships: Type.Array(postgresRelationshipOldSchema),
+})
+export type PostgresTable = Static<typeof postgresTableSchema>
+
+export const postgresTableCreateSchema = Type.Object({
+  name: Type.String(),
+  schema: Type.Optional(Type.String()),
+  comment: Type.Optional(Type.String()),
+})
+export type PostgresTableCreate = Static<typeof postgresTableCreateSchema>
+
+export const postgresTableUpdateSchema = Type.Object({
+  name: Type.Optional(Type.String()),
+  schema: Type.Optional(Type.String()),
+  rls_enabled: Type.Optional(Type.Boolean()),
+  rls_forced: Type.Optional(Type.Boolean()),
+  replica_identity: Type.Optional(
+    Type.Union([
+      Type.Literal('DEFAULT'),
+      Type.Literal('INDEX'),
+      Type.Literal('FULL'),
+      Type.Literal('NOTHING'),
+    ])
+  ),
+  replica_identity_index: Type.Optional(Type.String()),
+  primary_keys: Type.Optional(Type.Array(Type.Object({ name: Type.String() }))),
+  comment: Type.Optional(Type.String()),
+})
+export type PostgresTableUpdate = Static<typeof postgresTableUpdateSchema>
+
+export const postgresTriggerSchema = Type.Object({
+  id: Type.Integer(),
+  table_id: Type.Integer(),
+  enabled_mode: Type.Union([
+    Type.Literal('ORIGIN'),
+    Type.Literal('REPLICA'),
+    Type.Literal('ALWAYS'),
+    Type.Literal('DISABLED'),
+  ]),
+  name: Type.String(),
+  table: Type.String(),
+  schema: Type.String(),
+  condition: Type.Union([Type.String(), Type.Null()]),
+  orientation: Type.Union([Type.Literal('ROW'), Type.Literal('STATEMENT')]),
+  activation: Type.Union([
+    Type.Literal('BEFORE'),
+    Type.Literal('AFTER'),
+    Type.Literal('INSTEAD OF'),
+  ]),
+  events: Type.Array(Type.String()),
+  function_schema: Type.String(),
+  function_name: Type.String(),
+  function_args: Type.Array(Type.String()),
+})
+export type PostgresTrigger = Static<typeof postgresTriggerSchema>
+
+export const postgresTypeSchema = Type.Object({
+  id: Type.Integer(),
+  name: Type.String(),
+  schema: Type.String(),
+  format: Type.String(),
+  enums: Type.Array(Type.String()),
+  attributes: Type.Array(Type.Object({ name: Type.String(), type_id: Type.Integer() })),
+  comment: Type.Union([Type.String(), Type.Null()]),
+  type_relation_id: Type.Union([Type.Integer(), Type.Null()]),
+})
+export type PostgresType = Static<typeof postgresTypeSchema>
+
+export const postgresVersionSchema = Type.Object({
+  version: Type.String(),
+  version_number: Type.Integer(),
+  active_connections: Type.Integer(),
+  max_connections: Type.Integer(),
+})
+export type PostgresVersion = Static<typeof postgresVersionSchema>
+
+export const postgresViewSchema = Type.Object({
+  id: Type.Integer(),
+  schema: Type.String(),
+  name: Type.String(),
+  is_updatable: Type.Boolean(),
+  comment: Type.Union([Type.String(), Type.Null()]),
+  columns: Type.Optional(Type.Array(postgresColumnSchema)),
+})
+export type PostgresView = Static<typeof postgresViewSchema>
+
+export const postgresMaterializedViewSchema = Type.Object({
+  id: Type.Integer(),
+  schema: Type.String(),
+  name: Type.String(),
+  is_populated: Type.Boolean(),
+  comment: Type.Union([Type.String(), Type.Null()]),
+  columns: Type.Optional(Type.Array(postgresColumnSchema)),
+})
+export type PostgresMaterializedView = Static<typeof postgresMaterializedViewSchema>
+
+export const postgresTablePrivilegesSchema = Type.Object({
+  relation_id: Type.Integer(),
+  schema: Type.String(),
+  name: Type.String(),
+  kind: Type.Union([
+    Type.Literal('table'),
+    Type.Literal('view'),
+    Type.Literal('materialized_view'),
+    Type.Literal('foreign_table'),
+    Type.Literal('partitioned_table'),
+  ]),
+  privileges: Type.Array(
+    Type.Object({
+      grantor: Type.String(),
+      grantee: Type.String(),
+      privilege_type: Type.Union([
+        Type.Literal('SELECT'),
+        Type.Literal('INSERT'),
+        Type.Literal('UPDATE'),
+        Type.Literal('DELETE'),
+        Type.Literal('TRUNCATE'),
+        Type.Literal('REFERENCES'),
+        Type.Literal('TRIGGER'),
+        Type.Literal('MAINTAIN'),
+      ]),
+      is_grantable: Type.Boolean(),
+    })
+  ),
+})
+export type PostgresTablePrivileges = Static<typeof postgresTablePrivilegesSchema>
+
+export const postgresTablePrivilegesGrantSchema = Type.Object({
+  relation_id: Type.Integer(),
+  grantee: Type.String(),
+  privilege_type: Type.Union([
+    Type.Literal('ALL'),
+    Type.Literal('SELECT'),
+    Type.Literal('INSERT'),
+    Type.Literal('UPDATE'),
+    Type.Literal('DELETE'),
+    Type.Literal('TRUNCATE'),
+    Type.Literal('REFERENCES'),
+    Type.Literal('TRIGGER'),
+    Type.Literal('MAINTAIN'),
+  ]),
+  is_grantable: Type.Optional(Type.Boolean()),
+})
+export type PostgresTablePrivilegesGrant = Static<typeof postgresTablePrivilegesGrantSchema>
+
+export const postgresTablePrivilegesRevokeSchema = Type.Object({
+  relation_id: Type.Integer(),
+  grantee: Type.String(),
+  privilege_type: Type.Union([
+    Type.Literal('ALL'),
+    Type.Literal('SELECT'),
+    Type.Literal('INSERT'),
+    Type.Literal('UPDATE'),
+    Type.Literal('DELETE'),
+    Type.Literal('TRUNCATE'),
+    Type.Literal('REFERENCES'),
+    Type.Literal('TRIGGER'),
+    Type.Literal('MAINTAIN'),
+  ]),
+})
+export type PostgresTablePrivilegesRevoke = Static<typeof postgresTablePrivilegesRevokeSchema>
+
+export const postgresColumnPrivilegesSchema = Type.Object({
+  column_id: Type.RegExp(/^(\d+)\.(\d+)$/),
+  relation_schema: Type.String(),
+  relation_name: Type.String(),
+  column_name: Type.String(),
+  privileges: Type.Array(
+    Type.Object({
+      grantor: Type.String(),
+      grantee: Type.String(),
+      privilege_type: Type.Union([
+        Type.Literal('SELECT'),
+        Type.Literal('INSERT'),
+        Type.Literal('UPDATE'),
+        Type.Literal('REFERENCES'),
+      ]),
+      is_grantable: Type.Boolean(),
+    })
+  ),
+})
+export type PostgresColumnPrivileges = Static<typeof postgresColumnPrivilegesSchema>
+
+export const postgresColumnPrivilegesGrantSchema = Type.Object({
+  column_id: Type.RegExp(/^(\d+)\.(\d+)$/),
+  grantee: Type.String(),
+  privilege_type: Type.Union([
+    Type.Literal('ALL'),
+    Type.Literal('SELECT'),
+    Type.Literal('INSERT'),
+    Type.Literal('UPDATE'),
+    Type.Literal('REFERENCES'),
+  ]),
+  is_grantable: Type.Optional(Type.Boolean()),
+})
+export type PostgresColumnPrivilegesGrant = Static<typeof postgresColumnPrivilegesGrantSchema>
+
+export const postgresColumnPrivilegesRevokeSchema = Type.Object({
+  column_id: Type.RegExp(/^(\d+)\.(\d+)$/),
+  grantee: Type.String(),
+  privilege_type: Type.Union([
+    Type.Literal('ALL'),
+    Type.Literal('SELECT'),
+    Type.Literal('INSERT'),
+    Type.Literal('UPDATE'),
+    Type.Literal('REFERENCES'),
+  ]),
+})
+export type PostgresColumnPrivilegesRevoke = Static<typeof postgresColumnPrivilegesRevokeSchema>
+
+export interface PoolConfig extends PgPoolConfig {
+  maxResultSize?: number
+}

--- a/packages/neon-js/src/vendor/postgres-meta/templates/typescript.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/templates/typescript.ts
@@ -1,0 +1,978 @@
+// Vendored from https://github.com/supabase/postgres-meta @ v0.93.1
+//   (commit dc50199ca163b32ba4bdfa601dd3a9076ed2b640)
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Supabase Inc. — see ../LICENSE
+// Modified by Neon for vendoring purposes, 2026-04-30:
+//   none
+
+import prettier from 'prettier'
+import type { GeneratorMetadata } from '../../lib/generators.js'
+import type {
+  PostgresColumn,
+  PostgresFunction,
+  PostgresSchema,
+  PostgresTable,
+  PostgresType,
+  PostgresView,
+} from '../../lib/index.js'
+import {
+  GENERATE_TYPES_DEFAULT_SCHEMA,
+  VALID_FUNCTION_ARGS_MODE,
+  VALID_UNNAMED_FUNCTION_ARG_TYPES,
+} from '../constants.js'
+
+type TsRelationship = Pick<
+  GeneratorMetadata['relationships'][number],
+  'foreign_key_name' | 'columns' | 'is_one_to_one' | 'referenced_relation' | 'referenced_columns'
+>
+
+export const apply = async ({
+  schemas,
+  tables,
+  foreignTables,
+  views,
+  materializedViews,
+  columns,
+  relationships,
+  functions,
+  types,
+  detectOneToOneRelationships,
+  postgrestVersion,
+}: GeneratorMetadata & {
+  detectOneToOneRelationships: boolean
+  postgrestVersion?: string
+}): Promise<string> => {
+  schemas.sort((a, b) => a.name.localeCompare(b.name))
+  relationships.sort(
+    (a, b) =>
+      a.foreign_key_name.localeCompare(b.foreign_key_name) ||
+      a.referenced_relation.localeCompare(b.referenced_relation) ||
+      JSON.stringify(a.referenced_columns).localeCompare(JSON.stringify(b.referenced_columns))
+  )
+  const introspectionBySchema = Object.fromEntries<{
+    tables: {
+      table: Pick<PostgresTable, 'id' | 'name' | 'schema' | 'columns'>
+      relationships: TsRelationship[]
+    }[]
+    views: {
+      view: PostgresView
+      relationships: TsRelationship[]
+    }[]
+    functions: { fn: PostgresFunction; inArgs: PostgresFunction['args'] }[]
+    enums: PostgresType[]
+    compositeTypes: PostgresType[]
+  }>(
+    schemas.map((s) => [
+      s.name,
+      { tables: [], views: [], functions: [], enums: [], compositeTypes: [] },
+    ])
+  )
+  const columnsByTableId: Record<number, PostgresColumn[]> = {}
+  const tablesNamesByTableId: Record<number, string> = {}
+  const relationTypeByIds = new Map<number, (typeof types)[number]>()
+  // group types by id for quicker lookup
+  const typesById = new Map<number, (typeof types)[number]>()
+  const tablesLike = [...tables, ...foreignTables, ...views, ...materializedViews]
+
+  for (const tableLike of tablesLike) {
+    columnsByTableId[tableLike.id] = []
+    tablesNamesByTableId[tableLike.id] = tableLike.name
+  }
+  for (const column of columns) {
+    if (column.table_id in columnsByTableId) {
+      columnsByTableId[column.table_id].push(column)
+    }
+  }
+  for (const tableId in columnsByTableId) {
+    columnsByTableId[tableId].sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  for (const type of types) {
+    typesById.set(type.id, type)
+    // Save all the types that are relation types for quicker lookup
+    if (type.type_relation_id) {
+      relationTypeByIds.set(type.id, type)
+    }
+    if (type.schema in introspectionBySchema) {
+      if (type.enums.length > 0) {
+        introspectionBySchema[type.schema].enums.push(type)
+      }
+      if (type.attributes.length > 0) {
+        introspectionBySchema[type.schema].compositeTypes.push(type)
+      }
+    }
+  }
+
+  function getRelationships(
+    object: { schema: string; name: string },
+    relationships: GeneratorMetadata['relationships']
+  ): Pick<
+    GeneratorMetadata['relationships'][number],
+    'foreign_key_name' | 'columns' | 'is_one_to_one' | 'referenced_relation' | 'referenced_columns'
+  >[] {
+    return relationships.filter(
+      (relationship) =>
+        relationship.schema === object.schema &&
+        relationship.referenced_schema === object.schema &&
+        relationship.relation === object.name
+    )
+  }
+
+  function generateRelationshiptTsDefinition(relationship: TsRelationship): string {
+    return `{
+      foreignKeyName: ${JSON.stringify(relationship.foreign_key_name)}
+      columns: ${JSON.stringify(relationship.columns)}${detectOneToOneRelationships ? `\nisOneToOne: ${relationship.is_one_to_one}` : ''}
+      referencedRelation: ${JSON.stringify(relationship.referenced_relation)}
+      referencedColumns: ${JSON.stringify(relationship.referenced_columns)}
+    }`
+  }
+
+  for (const table of tables) {
+    if (table.schema in introspectionBySchema) {
+      introspectionBySchema[table.schema].tables.push({
+        table,
+        relationships: getRelationships(table, relationships),
+      })
+    }
+  }
+  for (const table of foreignTables) {
+    if (table.schema in introspectionBySchema) {
+      introspectionBySchema[table.schema].tables.push({
+        table,
+        relationships: getRelationships(table, relationships),
+      })
+    }
+  }
+  for (const view of views) {
+    if (view.schema in introspectionBySchema) {
+      introspectionBySchema[view.schema].views.push({
+        view,
+        relationships: getRelationships(view, relationships),
+      })
+    }
+  }
+  for (const materializedView of materializedViews) {
+    if (materializedView.schema in introspectionBySchema) {
+      introspectionBySchema[materializedView.schema].views.push({
+        view: {
+          ...materializedView,
+          is_updatable: false,
+        },
+        relationships: getRelationships(materializedView, relationships),
+      })
+    }
+  }
+  // Helper function to get table/view name from relation id
+  const getTableNameFromRelationId = (
+    relationId: number | null,
+    returnTypeId: number | null
+  ): string | null => {
+    if (!relationId) return null
+
+    if (tablesNamesByTableId[relationId]) return tablesNamesByTableId[relationId]
+    // if it's a composite type we use the type name as relation name to allow sub-selecting fields of the composite type
+    const reltype = returnTypeId ? relationTypeByIds.get(returnTypeId) : null
+    return reltype ? reltype.name : null
+  }
+
+  for (const func of functions) {
+    if (func.schema in introspectionBySchema) {
+      func.args.sort((a, b) => a.name.localeCompare(b.name))
+      // Get all input args (in, inout, variadic modes)
+      const inArgs = func.args.filter(({ mode }) => VALID_FUNCTION_ARGS_MODE.has(mode))
+
+      if (
+        // Case 1: Function has no parameters
+        inArgs.length === 0 ||
+        // Case 2: All input args are named
+        !inArgs.some(({ name }) => name === '') ||
+        // Case 3: All unnamed args have default values AND are valid types
+        inArgs.every((arg) => {
+          if (arg.name === '') {
+            return arg.has_default && VALID_UNNAMED_FUNCTION_ARG_TYPES.has(arg.type_id)
+          }
+          return true
+        }) ||
+        // Case 4: Single unnamed parameter of valid type (json, jsonb, text)
+        // Exclude all functions definitions that have only one single argument unnamed argument that isn't
+        // a json/jsonb/text as it won't be considered by PostgREST
+        (inArgs.length === 1 &&
+          inArgs[0].name === '' &&
+          (VALID_UNNAMED_FUNCTION_ARG_TYPES.has(inArgs[0].type_id) ||
+            // OR if the function have a single unnamed args which is another table (embeded function)
+            (relationTypeByIds.get(inArgs[0].type_id) &&
+              getTableNameFromRelationId(func.return_type_relation_id, func.return_type_id)) ||
+            // OR if the function takes a table row but doesn't qualify as embedded (for error reporting)
+            (relationTypeByIds.get(inArgs[0].type_id) &&
+              !getTableNameFromRelationId(func.return_type_relation_id, func.return_type_id))))
+      ) {
+        introspectionBySchema[func.schema].functions.push({ fn: func, inArgs })
+      }
+    }
+  }
+  for (const schema in introspectionBySchema) {
+    introspectionBySchema[schema].tables.sort((a, b) => a.table.name.localeCompare(b.table.name))
+    introspectionBySchema[schema].views.sort((a, b) => a.view.name.localeCompare(b.view.name))
+    introspectionBySchema[schema].functions.sort((a, b) => a.fn.name.localeCompare(b.fn.name))
+    introspectionBySchema[schema].enums.sort((a, b) => a.name.localeCompare(b.name))
+    introspectionBySchema[schema].compositeTypes.sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  const getFunctionTsReturnType = (fn: PostgresFunction, returnType: string) => {
+    // Determine if this function should have SetofOptions
+    let setofOptionsInfo = ''
+
+    const returnTableName = getTableNameFromRelationId(
+      fn.return_type_relation_id,
+      fn.return_type_id
+    )
+    const returnsSetOfTable = fn.is_set_returning_function && fn.return_type_relation_id !== null
+    const returnsMultipleRows = fn.prorows !== null && fn.prorows > 1
+    // Case 1: if the function returns a table, we need to add SetofOptions to allow selecting sub fields of the table
+    // Those can be used in rpc to select sub fields of a table
+    if (returnTableName) {
+      setofOptionsInfo = `SetofOptions: {
+        from: "*"
+        to: ${JSON.stringify(returnTableName)}
+        isOneToOne: ${Boolean(!returnsMultipleRows)}
+        isSetofReturn: ${fn.is_set_returning_function}
+      }`
+    }
+    // Case 2: if the function has a single table argument, we need to add SetofOptions to allow selecting sub fields of the table
+    // and set the right "from" and "to" values to allow selecting from a table row
+    if (fn.args.length === 1) {
+      const relationType = relationTypeByIds.get(fn.args[0].type_id)
+
+      // Only add SetofOptions for functions with table arguments (embedded functions)
+      // or specific functions that RETURNS table-name
+      if (relationType) {
+        const sourceTable = relationType.format
+        // Case 1: Standard embedded function with proper setof detection
+        if (returnsSetOfTable && returnTableName) {
+          setofOptionsInfo = `SetofOptions: {
+          from: ${JSON.stringify(sourceTable)}
+          to: ${JSON.stringify(returnTableName)}
+          isOneToOne: ${Boolean(!returnsMultipleRows)}
+          isSetofReturn: true
+        }`
+        }
+        // Case 2: Handle RETURNS table-name those are always a one to one relationship
+        else if (returnTableName && !returnsSetOfTable) {
+          const targetTable = returnTableName
+          setofOptionsInfo = `SetofOptions: {
+            from: ${JSON.stringify(sourceTable)}
+            to: ${JSON.stringify(targetTable)}
+            isOneToOne: true
+            isSetofReturn: false
+          }`
+        }
+      }
+    }
+
+    return `${returnType}${fn.is_set_returning_function && returnsMultipleRows ? '[]' : ''}
+                          ${setofOptionsInfo ? `${setofOptionsInfo}` : ''}`
+  }
+
+  const getFunctionReturnType = (schema: PostgresSchema, fn: PostgresFunction): string => {
+    // Case 1: `returns table`.
+    const tableArgs = fn.args.filter(({ mode }) => mode === 'table')
+    if (tableArgs.length > 0) {
+      const argsNameAndType = tableArgs.map(({ name, type_id }) => {
+        const type = typesById.get(type_id)
+        let tsType = 'unknown'
+        if (type) {
+          tsType = pgTypeToTsType(schema, type.name, {
+            types,
+            schemas,
+            tables,
+            views,
+          })
+        }
+        return { name, type: tsType }
+      })
+
+      return `{
+              ${argsNameAndType.map(({ name, type }) => `${JSON.stringify(name)}: ${type}`)}
+            }`
+    }
+
+    // Case 2: returns a relation's row type.
+    const relation =
+      introspectionBySchema[schema.name]?.tables.find(
+        ({ table: { id } }) => id === fn.return_type_relation_id
+      )?.table ||
+      introspectionBySchema[schema.name]?.views.find(
+        ({ view: { id } }) => id === fn.return_type_relation_id
+      )?.view
+    if (relation) {
+      return `{
+              ${columnsByTableId[relation.id]
+                .map((column) =>
+                  generateColumnTsDefinition(
+                    schema,
+                    {
+                      name: column.name,
+                      format: column.format,
+                      is_nullable: column.is_nullable,
+                      is_optional: false,
+                    },
+                    {
+                      types,
+                      schemas,
+                      tables,
+                      views,
+                    }
+                  )
+                )
+                .join(',\n')}
+            }`
+    }
+
+    // Case 3: returns base/array/composite/enum type.
+    const type = typesById.get(fn.return_type_id)
+    if (type) {
+      return pgTypeToTsType(schema, type.name, {
+        types,
+        schemas,
+        tables,
+        views,
+      })
+    }
+
+    return 'unknown'
+  }
+  // Special error case for functions that take table row but don't qualify as embedded functions
+  const hasTableRowError = (fn: PostgresFunction, inArgs: PostgresFunction['args']) => {
+    if (
+      inArgs.length === 1 &&
+      inArgs[0].name === '' &&
+      relationTypeByIds.get(inArgs[0].type_id) &&
+      !getTableNameFromRelationId(fn.return_type_relation_id, fn.return_type_id)
+    ) {
+      return true
+    }
+    return false
+  }
+
+  // Check for generic conflict cases that need error reporting
+  const getConflictError = (
+    schema: PostgresSchema,
+    fns: Array<{ fn: PostgresFunction; inArgs: PostgresFunction['args'] }>,
+    fn: PostgresFunction,
+    inArgs: PostgresFunction['args']
+  ) => {
+    // If there is a single function definition, there is no conflict
+    if (fns.length <= 1) return null
+
+    // Generic conflict detection patterns
+    // Pattern 1: No-args vs default-args conflicts
+    if (inArgs.length === 0) {
+      const conflictingFns = fns.filter(({ fn: otherFn, inArgs: otherInArgs }) => {
+        if (otherFn === fn) return false
+        return otherInArgs.length === 1 && otherInArgs[0].name === '' && otherInArgs[0].has_default
+      })
+
+      if (conflictingFns.length > 0) {
+        const conflictingFn = conflictingFns[0]
+        const returnTypeName = typesById.get(conflictingFn.fn.return_type_id)?.name || 'unknown'
+        return `Could not choose the best candidate function between: ${schema.name}.${fn.name}(), ${schema.name}.${fn.name}( => ${returnTypeName}). Try renaming the parameters or the function itself in the database so function overloading can be resolved`
+      }
+    }
+
+    // Pattern 2: Same parameter name but different types (unresolvable overloads)
+    if (inArgs.length === 1 && inArgs[0].name !== '') {
+      const conflictingFns = fns.filter(({ fn: otherFn, inArgs: otherInArgs }) => {
+        if (otherFn === fn) return false
+        return (
+          otherInArgs.length === 1 &&
+          otherInArgs[0].name === inArgs[0].name &&
+          otherInArgs[0].type_id !== inArgs[0].type_id
+        )
+      })
+
+      if (conflictingFns.length > 0) {
+        const allConflictingFunctions = [{ fn, inArgs }, ...conflictingFns]
+        const conflictList = allConflictingFunctions
+          .sort((a, b) => {
+            const aArgs = a.inArgs
+            const bArgs = b.inArgs
+            return (aArgs[0]?.type_id || 0) - (bArgs[0]?.type_id || 0)
+          })
+          .map((f) => {
+            const args = f.inArgs
+            return `${schema.name}.${fn.name}(${args.map((a) => `${a.name || ''} => ${typesById.get(a.type_id)?.name || 'unknown'}`).join(', ')})`
+          })
+          .join(', ')
+
+        return `Could not choose the best candidate function between: ${conflictList}. Try renaming the parameters or the function itself in the database so function overloading can be resolved`
+      }
+    }
+
+    return null
+  }
+
+  const getFunctionSignatures = (
+    schema: PostgresSchema,
+    fns: Array<{ fn: PostgresFunction; inArgs: PostgresFunction['args'] }>
+  ) => {
+    return fns
+      .map(({ fn, inArgs }) => {
+        let argsType = 'never'
+        let returnType = getFunctionReturnType(schema, fn)
+
+        // Check for specific error cases
+        const conflictError = getConflictError(schema, fns, fn, inArgs)
+        if (conflictError) {
+          if (inArgs.length > 0) {
+            const argsNameAndType = inArgs.map(({ name, type_id, has_default }) => {
+              const type = typesById.get(type_id)
+              let tsType = 'unknown'
+              if (type) {
+                tsType = pgTypeToTsType(schema, type.name, {
+                  types,
+                  schemas,
+                  tables,
+                  views,
+                })
+              }
+              return { name, type: tsType, has_default }
+            })
+            argsType = `{ ${argsNameAndType.map(({ name, type, has_default }) => `${JSON.stringify(name)}${has_default ? '?' : ''}: ${type}`)} }`
+          }
+          returnType = `{ error: true } & ${JSON.stringify(conflictError)}`
+        } else if (hasTableRowError(fn, inArgs)) {
+          // Special case for computed fields returning scalars functions
+          if (inArgs.length > 0) {
+            const argsNameAndType = inArgs.map(({ name, type_id, has_default }) => {
+              const type = typesById.get(type_id)
+              let tsType = 'unknown'
+              if (type) {
+                tsType = pgTypeToTsType(schema, type.name, {
+                  types,
+                  schemas,
+                  tables,
+                  views,
+                })
+              }
+              return { name, type: tsType, has_default }
+            })
+            argsType = `{ ${argsNameAndType.map(({ name, type, has_default }) => `${JSON.stringify(name)}${has_default ? '?' : ''}: ${type}`)} }`
+          }
+          returnType = `{ error: true } & ${JSON.stringify(`the function ${schema.name}.${fn.name} with parameter or with a single unnamed json/jsonb parameter, but no matches were found in the schema cache`)}`
+        } else if (inArgs.length > 0) {
+          const argsNameAndType = inArgs.map(({ name, type_id, has_default }) => {
+            const type = typesById.get(type_id)
+            let tsType = 'unknown'
+            if (type) {
+              tsType = pgTypeToTsType(schema, type.name, {
+                types,
+                schemas,
+                tables,
+                views,
+              })
+            }
+            return { name, type: tsType, has_default }
+          })
+          argsType = `{ ${argsNameAndType.map(({ name, type, has_default }) => `${JSON.stringify(name)}${has_default ? '?' : ''}: ${type}`)} }`
+        }
+
+        return `{ Args: ${argsType}; Returns: ${getFunctionTsReturnType(fn, returnType)} }`
+      })
+      .join(' |\n')
+  }
+
+  const internal_supabase_schema = postgrestVersion
+    ? `// Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: '${postgrestVersion}'
+  }`
+    : ''
+
+  function generateNullableUnionTsType(tsType: string, isNullable: boolean) {
+    // Only add the null union if the type is not unknown as unknown already includes null
+    if (tsType === 'unknown' || tsType === 'any' || !isNullable) {
+      return tsType
+    }
+    return `${tsType} | null`
+  }
+
+  function generateColumnTsDefinition(
+    schema: PostgresSchema,
+    column: {
+      name: string
+      format: string
+      is_nullable: boolean
+      is_optional: boolean
+    },
+    context: {
+      types: PostgresType[]
+      schemas: PostgresSchema[]
+      tables: PostgresTable[]
+      views: PostgresView[]
+    }
+  ) {
+    return `${JSON.stringify(column.name)}${column.is_optional ? '?' : ''}: ${generateNullableUnionTsType(pgTypeToTsType(schema, column.format, context), column.is_nullable)}`
+  }
+
+  let output = `
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+
+export type Database = {
+  ${internal_supabase_schema}
+  ${schemas.map((schema) => {
+    const {
+      tables: schemaTables,
+      views: schemaViews,
+      functions: schemaFunctions,
+      enums: schemaEnums,
+      compositeTypes: schemaCompositeTypes,
+    } = introspectionBySchema[schema.name]
+    return `${JSON.stringify(schema.name)}: {
+          Tables: {
+            ${
+              schemaTables.length === 0
+                ? '[_ in never]: never'
+                : schemaTables.map(
+                    ({ table, relationships }) => `${JSON.stringify(table.name)}: {
+                  Row: {
+                    ${[
+                      ...columnsByTableId[table.id].map((column) =>
+                        generateColumnTsDefinition(
+                          schema,
+                          {
+                            name: column.name,
+                            format: column.format,
+                            is_nullable: column.is_nullable,
+                            is_optional: false,
+                          },
+                          { types, schemas, tables, views }
+                        )
+                      ),
+                      ...schemaFunctions
+                        .filter(({ fn }) => fn.argument_types === table.name)
+                        .map(({ fn }) => {
+                          return `${JSON.stringify(fn.name)}: ${generateNullableUnionTsType(getFunctionReturnType(schema, fn), true)}`
+                        }),
+                    ]}
+                  }
+                  Insert: {
+                    ${columnsByTableId[table.id].map((column) => {
+                      if (column.identity_generation === 'ALWAYS') {
+                        return `${JSON.stringify(column.name)}?: never`
+                      }
+                      return generateColumnTsDefinition(
+                        schema,
+                        {
+                          name: column.name,
+                          format: column.format,
+                          is_nullable: column.is_nullable,
+                          is_optional:
+                            column.is_nullable ||
+                            column.is_identity ||
+                            column.default_value !== null,
+                        },
+                        { types, schemas, tables, views }
+                      )
+                    })}
+                  }
+                  Update: {
+                    ${columnsByTableId[table.id].map((column) => {
+                      if (column.identity_generation === 'ALWAYS') {
+                        return `${JSON.stringify(column.name)}?: never`
+                      }
+
+                      return generateColumnTsDefinition(
+                        schema,
+                        {
+                          name: column.name,
+                          format: column.format,
+                          is_nullable: column.is_nullable,
+                          is_optional: true,
+                        },
+                        { types, schemas, tables, views }
+                      )
+                    })}
+                  }
+                  Relationships: [
+                    ${relationships.map(generateRelationshiptTsDefinition)}
+                  ]
+                }`
+                  )
+            }
+          }
+          Views: {
+            ${
+              schemaViews.length === 0
+                ? '[_ in never]: never'
+                : schemaViews.map(
+                    ({ view, relationships }) => `${JSON.stringify(view.name)}: {
+                  Row: {
+                    ${[
+                      ...columnsByTableId[view.id].map((column) =>
+                        generateColumnTsDefinition(
+                          schema,
+                          {
+                            name: column.name,
+                            format: column.format,
+                            is_nullable: column.is_nullable,
+                            is_optional: false,
+                          },
+                          { types, schemas, tables, views }
+                        )
+                      ),
+                      ...schemaFunctions
+                        .filter(({ fn }) => fn.argument_types === view.name)
+                        .map(
+                          ({ fn }) =>
+                            `${JSON.stringify(fn.name)}: ${generateNullableUnionTsType(getFunctionReturnType(schema, fn), true)}`
+                        ),
+                    ]}
+                  }
+                  ${
+                    view.is_updatable
+                      ? `Insert: {
+                           ${columnsByTableId[view.id].map((column) => {
+                             if (!column.is_updatable) {
+                               return `${JSON.stringify(column.name)}?: never`
+                             }
+                             return generateColumnTsDefinition(
+                               schema,
+                               {
+                                 name: column.name,
+                                 format: column.format,
+                                 is_nullable: true,
+                                 is_optional: true,
+                               },
+                               { types, schemas, tables, views }
+                             )
+                           })}
+                         }
+                         Update: {
+                           ${columnsByTableId[view.id].map((column) => {
+                             if (!column.is_updatable) {
+                               return `${JSON.stringify(column.name)}?: never`
+                             }
+                             return generateColumnTsDefinition(
+                               schema,
+                               {
+                                 name: column.name,
+                                 format: column.format,
+                                 is_nullable: true,
+                                 is_optional: true,
+                               },
+                               { types, schemas, tables, views }
+                             )
+                           })}
+                         }
+                        `
+                      : ''
+                  }Relationships: [
+                    ${relationships.map(generateRelationshiptTsDefinition)}
+                  ]
+                }`
+                  )
+            }
+          }
+          Functions: {
+            ${(() => {
+              if (schemaFunctions.length === 0) {
+                return '[_ in never]: never'
+              }
+              const schemaFunctionsGroupedByName = schemaFunctions.reduce(
+                (acc, curr) => {
+                  acc[curr.fn.name] ??= []
+                  acc[curr.fn.name].push(curr)
+                  return acc
+                },
+                {} as Record<string, typeof schemaFunctions>
+              )
+              for (const fnName in schemaFunctionsGroupedByName) {
+                schemaFunctionsGroupedByName[fnName].sort((a, b) =>
+                  b.fn.definition.localeCompare(a.fn.definition)
+                )
+              }
+
+              return Object.entries(schemaFunctionsGroupedByName)
+                .map(([fnName, fns]) => {
+                  const functionSignatures = getFunctionSignatures(schema, fns)
+                  return `${JSON.stringify(fnName)}:\n${functionSignatures}`
+                })
+                .join(',\n')
+            })()}
+          }
+          Enums: {
+            ${
+              schemaEnums.length === 0
+                ? '[_ in never]: never'
+                : schemaEnums.map(
+                    (enum_) =>
+                      `${JSON.stringify(enum_.name)}: ${enum_.enums
+                        .map((variant) => JSON.stringify(variant))
+                        .join('|')}`
+                  )
+            }
+          }
+          CompositeTypes: {
+            ${
+              schemaCompositeTypes.length === 0
+                ? '[_ in never]: never'
+                : schemaCompositeTypes.map(
+                    ({ name, attributes }) =>
+                      `${JSON.stringify(name)}: {
+                        ${attributes.map(({ name, type_id }) => {
+                          const type = typesById.get(type_id)
+                          let tsType = 'unknown'
+                          if (type) {
+                            tsType = `${generateNullableUnionTsType(
+                              pgTypeToTsType(schema, type.name, {
+                                types,
+                                schemas,
+                                tables,
+                                views,
+                              }),
+                              true
+                            )}`
+                          }
+                          return `${JSON.stringify(name)}: ${tsType}`
+                        })}
+                      }`
+                  )
+            }
+          }
+        }`
+  })}
+}
+
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, ${JSON.stringify(GENERATE_TYPES_DEFAULT_SCHEMA)}>]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+  ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+  ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = DefaultSchemaTableNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+  ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never
+> = DefaultSchemaEnumNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+  ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+  : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof DatabaseWithoutInternals }
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+  ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+  : never
+
+export const Constants = {
+  ${schemas.map((schema) => {
+    const schemaEnums = introspectionBySchema[schema.name].enums
+    return `${JSON.stringify(schema.name)}: {
+          Enums: {
+            ${schemaEnums.map(
+              (enum_) =>
+                `${JSON.stringify(enum_.name)}: [${enum_.enums
+                  .map((variant) => JSON.stringify(variant))
+                  .join(', ')}]`
+            )}
+          }
+        }`
+  })}
+} as const
+`
+
+  output = await prettier.format(output, {
+    parser: 'typescript',
+    semi: false,
+  })
+  return output
+}
+
+// TODO: Make this more robust. Currently doesn't handle range types - returns them as unknown.
+const pgTypeToTsType = (
+  schema: PostgresSchema,
+  pgType: string,
+  {
+    types,
+    schemas,
+    tables,
+    views,
+  }: {
+    types: PostgresType[]
+    schemas: PostgresSchema[]
+    tables: PostgresTable[]
+    views: PostgresView[]
+  }
+): string => {
+  if (pgType === 'bool') {
+    return 'boolean'
+  } else if (['int2', 'int4', 'int8', 'float4', 'float8', 'numeric'].includes(pgType)) {
+    return 'number'
+  } else if (
+    [
+      'bytea',
+      'bpchar',
+      'varchar',
+      'date',
+      'text',
+      'citext',
+      'time',
+      'timetz',
+      'timestamp',
+      'timestamptz',
+      'uuid',
+      'vector',
+    ].includes(pgType)
+  ) {
+    return 'string'
+  } else if (['json', 'jsonb'].includes(pgType)) {
+    return 'Json'
+  } else if (pgType === 'void') {
+    return 'undefined'
+  } else if (pgType === 'record') {
+    return 'Record<string, unknown>'
+  } else if (pgType.startsWith('_')) {
+    return `(${pgTypeToTsType(schema, pgType.substring(1), {
+      types,
+      schemas,
+      tables,
+      views,
+    })})[]`
+  } else {
+    const enumTypes = types.filter((type) => type.name === pgType && type.enums.length > 0)
+    if (enumTypes.length > 0) {
+      const enumType = enumTypes.find((type) => type.schema === schema.name) || enumTypes[0]
+      if (schemas.some(({ name }) => name === enumType.schema)) {
+        return `Database[${JSON.stringify(enumType.schema)}]['Enums'][${JSON.stringify(
+          enumType.name
+        )}]`
+      }
+      return enumType.enums.map((variant) => JSON.stringify(variant)).join('|')
+    }
+
+    const compositeTypes = types.filter(
+      (type) => type.name === pgType && type.attributes.length > 0
+    )
+    if (compositeTypes.length > 0) {
+      const compositeType =
+        compositeTypes.find((type) => type.schema === schema.name) || compositeTypes[0]
+      if (schemas.some(({ name }) => name === compositeType.schema)) {
+        return `Database[${JSON.stringify(
+          compositeType.schema
+        )}]['CompositeTypes'][${JSON.stringify(compositeType.name)}]`
+      }
+      return 'unknown'
+    }
+
+    const tableRowTypes = tables.filter((table) => table.name === pgType)
+    if (tableRowTypes.length > 0) {
+      const tableRowType =
+        tableRowTypes.find((type) => type.schema === schema.name) || tableRowTypes[0]
+      if (schemas.some(({ name }) => name === tableRowType.schema)) {
+        return `Database[${JSON.stringify(tableRowType.schema)}]['Tables'][${JSON.stringify(
+          tableRowType.name
+        )}]['Row']`
+      }
+      return 'unknown'
+    }
+
+    const viewRowTypes = views.filter((view) => view.name === pgType)
+    if (viewRowTypes.length > 0) {
+      const viewRowType =
+        viewRowTypes.find((type) => type.schema === schema.name) || viewRowTypes[0]
+      if (schemas.some(({ name }) => name === viewRowType.schema)) {
+        return `Database[${JSON.stringify(viewRowType.schema)}]['Views'][${JSON.stringify(
+          viewRowType.name
+        )}]['Row']`
+      }
+      return 'unknown'
+    }
+
+    return 'unknown'
+  }
+}

--- a/packages/neon-js/src/vendor/postgres-meta/templates/typescript.ts
+++ b/packages/neon-js/src/vendor/postgres-meta/templates/typescript.ts
@@ -3,10 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) Supabase Inc. — see ../LICENSE
 // Modified by Neon for vendoring purposes, 2026-04-30:
-//   none
+//   - re-pointed `'../../lib/generators.js'` to `'../lib/generators.js'`
+//     and `'../../lib/index.js'` to `'../lib/index.js'` to fit our flatter
+//     vendor directory layout (no `src/server/` parent dir here).
+//   - re-pointed `'../constants.js'` to `'../constants.js'` (relative to
+//     `templates/`, this resolves to `vendor/postgres-meta/constants.ts`,
+//     a slim file holding just the three values this template imports).
 
 import prettier from 'prettier'
-import type { GeneratorMetadata } from '../../lib/generators.js'
+import type { GeneratorMetadata } from '../lib/generators.js'
 import type {
   PostgresColumn,
   PostgresFunction,
@@ -14,7 +19,7 @@ import type {
   PostgresTable,
   PostgresType,
   PostgresView,
-} from '../../lib/index.js'
+} from '../lib/index.js'
 import {
   GENERATE_TYPES_DEFAULT_SCHEMA,
   VALID_FUNCTION_ARGS_MODE,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)
+        version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0)
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@19.2.3)
@@ -235,7 +235,7 @@ importers:
         version: 0.31.7
       drizzle-orm:
         specifier: 0.45.0
-        version: 0.45.0(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)
+        version: 0.45.0(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0)
       lucide-react:
         specifier: 0.555.0
         version: 0.555.0(react@19.2.1)
@@ -293,7 +293,7 @@ importers:
     dependencies:
       '@daveyplate/better-auth-ui':
         specifier: ^3.3.15
-        version: 3.4.0(hd7ap4xf342fbz3kvg5mzcy3ha)
+        version: 3.4.0(mgkdmvkylepqa64cpdxxm4d2pm)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.0(react@19.2.3))
@@ -335,7 +335,7 @@ importers:
         version: 4.2.2(vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       better-auth:
         specifier: 1.4.9
-        version: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -481,7 +481,7 @@ importers:
         version: 2.79.0
       better-auth:
         specifier: 1.4.9
-        version: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.6.8(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.6.8(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       jose:
         specifier: 6.1.2
         version: 6.1.2
@@ -509,13 +509,13 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: 1.4.9
-        version: 1.4.9(@better-auth/core@1.6.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.2.0)
+        version: 1.4.9(@better-auth/core@1.6.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.2.0)
       '@captchafox/react':
         specifier: ^1.10.0
         version: 1.11.0(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@daveyplate/better-auth-ui':
         specifier: 3.3.9
-        version: 3.3.9(3z2pgdnpv2ibrhzxvcgk5yxo7u)
+        version: 3.3.9(tipi3vukmojzchcvpg5ylthd3a)
       '@hcaptcha/react-hcaptcha':
         specifier: ^1.12.1
         version: 1.17.4(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
@@ -569,7 +569,7 @@ importers:
         version: 0.1.4(@types/react@19.1.13)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       better-auth:
         specifier: 1.4.9
-        version: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -654,16 +654,31 @@ importers:
       '@neondatabase/postgrest-js':
         specifier: workspace:*
         version: link:../postgrest-js
-      '@supabase/postgres-meta':
-        specifier: 0.93.1
-        version: 0.93.1
       meow:
         specifier: 14.0.0
         version: 14.0.0
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+      pg-format:
+        specifier: 1.0.4
+        version: 1.0.4
+      postgres-array:
+        specifier: 3.0.4
+        version: 3.0.4
+      prettier:
+        specifier: 3.8.1
+        version: 3.8.1
       zod:
         specifier: 4.1.12
         version: 4.1.12
     devDependencies:
+      '@types/pg':
+        specifier: 8.20.0
+        version: 8.20.0
+      '@types/pg-format':
+        specifier: 1.0.5
+        version: 1.0.5
       msw:
         specifier: 2.6.8
         version: 2.6.8(@types/node@24.12.0)(typescript@5.9.3)
@@ -1529,35 +1544,6 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fastify/ajv-compiler@4.0.5':
-    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
-
-  '@fastify/cors@9.0.1':
-    resolution: {integrity: sha512-YY9Ho3ovI+QHIL2hW+9X4XqQjXLjJqsU+sMV/xFsxZkE8p3GNnYVFpoOxF7SsP5ZL76gwvbo3V9L+FIekBGU4Q==}
-
-  '@fastify/error@4.2.0':
-    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
-
-  '@fastify/fast-json-stringify-compiler@5.0.3':
-    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
-
-  '@fastify/forwarded@3.0.1':
-    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
-
-  '@fastify/merge-json-schemas@0.2.1':
-    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
-
-  '@fastify/proxy-addr@5.1.0':
-    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
-
-  '@fastify/swagger@8.15.0':
-    resolution: {integrity: sha512-zy+HEEKFqPMS2sFUsQU5X0MHplhKJvWeohBwTCkBAJA/GDYGLGUWQaETEhptiqxK7Hs0fQB9B4MDb3pbwIiCwA==}
-
-  '@fastify/type-provider-typebox@3.6.0':
-    resolution: {integrity: sha512-HTeOLvirfGg0u1KGao3iXn5rZpYNqlrOmyDnXSXAbWVPa+mDQTTBNs/x5uZzOB6vFAqr0Xcf7x1lxOamNSYKjw==}
-    peerDependencies:
-      '@sinclair/typebox': '>=0.26 <=0.32'
-
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -1984,193 +1970,13 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opentelemetry/api-logs@0.57.2':
-    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
-    engines: {node: '>=14'}
-
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/context-async-hooks@1.30.1':
-    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/core@1.30.1':
-    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/instrumentation-amqplib@0.46.1':
-    resolution: {integrity: sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-connect@0.43.1':
-    resolution: {integrity: sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-dataloader@0.16.1':
-    resolution: {integrity: sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-express@0.47.1':
-    resolution: {integrity: sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-fs@0.19.1':
-    resolution: {integrity: sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-generic-pool@0.43.1':
-    resolution: {integrity: sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-graphql@0.47.1':
-    resolution: {integrity: sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-hapi@0.45.2':
-    resolution: {integrity: sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-http@0.57.2':
-    resolution: {integrity: sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-ioredis@0.47.1':
-    resolution: {integrity: sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-kafkajs@0.7.1':
-    resolution: {integrity: sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-knex@0.44.1':
-    resolution: {integrity: sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-koa@0.47.1':
-    resolution: {integrity: sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-lru-memoizer@0.44.1':
-    resolution: {integrity: sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mongodb@0.52.0':
-    resolution: {integrity: sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mongoose@0.46.1':
-    resolution: {integrity: sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mysql2@0.45.2':
-    resolution: {integrity: sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-mysql@0.45.1':
-    resolution: {integrity: sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-pg@0.51.1':
-    resolution: {integrity: sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-redis-4@0.46.1':
-    resolution: {integrity: sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-tedious@0.18.1':
-    resolution: {integrity: sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-undici@0.10.1':
-    resolution: {integrity: sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.7.0
-
-  '@opentelemetry/instrumentation@0.57.2':
-    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/redis-common@0.36.2':
-    resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
-    engines: {node: '>=14'}
-
-  '@opentelemetry/resources@1.30.1':
-    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@1.30.1':
-    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/semantic-conventions@1.28.0':
-    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
-    engines: {node: '>=14'}
-
   '@opentelemetry/semantic-conventions@1.40.0':
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
-
-  '@opentelemetry/sql-common@0.40.1':
-    resolution: {integrity: sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
 
   '@oxc-project/types@0.101.0':
     resolution: {integrity: sha512-nuFhqlUzJX+gVIPPfuE6xurd4lST3mdcWOhyK/rZO0B9XWMKm79SuszIQEnSMmmDhq1DC8WWVYGVd+6F93o1gQ==}
@@ -2303,21 +2109,10 @@ packages:
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
     engines: {node: '>=20.0.0'}
 
-  '@pgsql/types@13.11.1':
-    resolution: {integrity: sha512-5JeN7DZYCVbxPPFI47Z370Jzr3eHZpqgwCdutYWV8e8XtuhxF7UuvWvOsx2oPJe9KnQen0vzJWnVq/61bRvxmw==}
-
-  '@pinojs/redact@0.4.0':
-    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
-
   '@playwright/test@1.59.0':
     resolution: {integrity: sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@prisma/instrumentation@6.11.1':
-    resolution: {integrity: sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==}
-    peerDependencies:
-      '@opentelemetry/api': ^1.8
 
   '@publint/pack@0.1.4':
     resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
@@ -3579,54 +3374,12 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
-  '@sentry-internal/node-cpu-profiler@2.2.0':
-    resolution: {integrity: sha512-oLHVYurqZfADPh5hvmQYS5qx8t0UZzT2u6+/68VXsFruQEOnYJTODKgU3BVLmemRs3WE6kCJjPeFdHVYOQGSzQ==}
-    engines: {node: '>=18'}
-
-  '@sentry/core@9.47.1':
-    resolution: {integrity: sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==}
-    engines: {node: '>=18'}
-
-  '@sentry/node-core@9.47.1':
-    resolution: {integrity: sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.0.0
-      '@opentelemetry/core': ^1.30.1 || ^2.0.0
-      '@opentelemetry/instrumentation': '>=0.57.1 <1'
-      '@opentelemetry/resources': ^1.30.1 || ^2.0.0
-      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.0.0
-      '@opentelemetry/semantic-conventions': ^1.34.0
-
-  '@sentry/node@9.47.1':
-    resolution: {integrity: sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==}
-    engines: {node: '>=18'}
-
-  '@sentry/opentelemetry@9.47.1':
-    resolution: {integrity: sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.9.0
-      '@opentelemetry/context-async-hooks': ^1.30.1 || ^2.0.0
-      '@opentelemetry/core': ^1.30.1 || ^2.0.0
-      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.0.0
-      '@opentelemetry/semantic-conventions': ^1.34.0
-
-  '@sentry/profiling-node@9.47.1':
-    resolution: {integrity: sha512-4Llq0it2nL/1iJcEEm3JwdRyvRAjYuoS0MB9+9eKRaCJBIj//3fOcyjw75BbhdSFBhkDMRv2W5b3gn9oPrJAHA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   '@simplewebauthn/browser@13.3.0':
     resolution: {integrity: sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==}
 
   '@simplewebauthn/server@13.3.0':
     resolution: {integrity: sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==}
     engines: {node: '>=20.0.0'}
-
-  '@sinclair/typebox@0.31.28':
-    resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -3641,22 +3394,6 @@ packages:
   '@supabase/auth-js@2.79.0':
     resolution: {integrity: sha512-p2GKvdbF9d/6C+dtS6iNcSicPr6eUfkvovD60HWlWsD+oOjC483DzFWrzGjNpBwnswhfMRP8Qn3rYA0VWaOfjw==}
     engines: {node: '>=20.0.0'}
-
-  '@supabase/pg-protocol@0.0.2':
-    resolution: {integrity: sha512-OLp5LeWRmfJy4vwV753hsCE90vzNSTSAwhsbinCIeoT455DHBufrkktVc4YvPXYEFj+EzpVKw/N0piX+AvBMBg==}
-
-  '@supabase/pg@0.0.3':
-    resolution: {integrity: sha512-WW4VdNYQocmcg7dZYk92vHY2nhhMhxoJhZ20m7PzuKe8p4vSdkv2tSM8HUCpZDiLxC6djfVeMk39ukcwEpFdzg==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
-
-  '@supabase/postgres-meta@0.93.1':
-    resolution: {integrity: sha512-cTKLFPqtaMHAUaiHfWj28xEv6tqb5ffsMByZprgJFDCqTBflIftsDp4mYelK5Kdra7OWy1XgLacsMjQ3FbxFSQ==}
-    engines: {node: '>=20', npm: '>=9'}
 
   '@supabase/postgrest-js@2.79.0':
     resolution: {integrity: sha512-2i8EFm3/49ecjt6dk/TGVROBbtOmhryiC4NL3u0FBIrm2hqj+FvbELv1jjM6r+a6abnh+uzIV/bFsWHAa/k3/w==}
@@ -3829,9 +3566,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
-
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -3847,9 +3581,6 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/mysql@2.15.26':
-    resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
-
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
@@ -3862,14 +3593,11 @@ packages:
   '@types/node@24.7.2':
     resolution: {integrity: sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==}
 
-  '@types/pg-pool@2.0.6':
-    resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+  '@types/pg-format@1.0.5':
+    resolution: {integrity: sha512-i+oEEJEC+1I3XAhgqtVp45Faj8MBbV0Aoq4rHsHD7avgLjyDkaWKObd514g0Q/DOUkdxU0P4CQ0iq2KR4SoJcw==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
-
-  '@types/pg@8.6.1':
-    resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
 
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
@@ -3887,14 +3615,8 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  '@types/shimmer@1.2.0':
-    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
-
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
-
-  '@types/tedious@4.0.14':
-    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -4168,17 +3890,9 @@ packages:
       '@types/react':
         optional: true
 
-  abstract-logging@2.0.1:
-    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
-
-  acorn-import-attributes@1.9.5:
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -4297,10 +4011,6 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
-
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4311,9 +4021,6 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
-
-  avvio@9.2.0:
-    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   axe-core@4.11.2:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
@@ -4409,13 +4116,6 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
-
-  big-integer@1.6.52:
-    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
-    engines: {node: '>=0.6'}
-
-  bintrees@1.0.2:
-    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
@@ -4555,9 +4255,6 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  close-with-grace@2.5.0:
-    resolution: {integrity: sha512-MewUtZQU6N4YVHIne63zGtjIQzTINgr6lQp2Y0CutaCw2FsdYahW57dH1Wdz+aV5ipbBzEBZD5znwX2NooS+IA==}
-
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -4588,9 +4285,6 @@ packages:
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
-
-  commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -4651,9 +4345,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -4741,10 +4432,6 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -4761,9 +4448,6 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
-
-  discontinuous-range@1.0.0:
-    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -5305,9 +4989,6 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
-  fast-decode-uri-component@1.0.1:
-    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -5322,28 +5003,11 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-json-stringify@6.3.0:
-    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
-
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-querystring@1.1.2:
-    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
-
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
-  fastify-metrics@10.6.0:
-    resolution: {integrity: sha512-QIPncCnwBOEObMn+VaRhsBC1ox8qEsaiYF2sV/A1UbXj7ic70W8/HNn/hlEC2W8JQbBeZMx++o1um2fPfhsFDQ==}
-    peerDependencies:
-      fastify: '>=5.8.5'
-
-  fastify-plugin@4.5.1:
-    resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
-
-  fastify@5.8.5:
-    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5380,10 +5044,6 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-my-way@9.5.0:
-    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
-    engines: {node: '>=20'}
-
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -5406,9 +5066,6 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
-
-  forwarded-parse@2.1.2:
-    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -5482,10 +5139,6 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
-
-  get-stdin@8.0.0:
-    resolution: {integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==}
-    engines: {node: '>=10'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -5629,9 +5282,6 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  import-in-the-middle@1.15.0:
-    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
-
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
@@ -5664,10 +5314,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  ipaddr.js@2.3.0:
-    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
-    engines: {node: '>= 10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -5888,13 +5534,6 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  json-schema-ref-resolver@3.0.0:
-    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
-
-  json-schema-resolver@2.0.0:
-    resolution: {integrity: sha512-pJ4XLQP4Q9HTxl6RVDLJ8Cyh1uitSs0CzDBAz1uoJ4sRD/Bk7cFSXL1FUXDW3zJ7YnfliJx6eu8Jn283bpZ4Yg==}
-    engines: {node: '>=10'}
-
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -5921,10 +5560,6 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jsox@1.2.125:
-    resolution: {integrity: sha512-HIf1uwublnXZsy7p3yHTrhzMzrLO6xKnqXytT9pEil5QxaXi8eyer7Is4luF5hYSV4kD3v03Y32FWoAeVYTghQ==}
-    hasBin: true
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -5958,12 +5593,6 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
-
-  libpg-query@13.6.0:
-    resolution: {integrity: sha512-zaCGweMgNiPRGRfNVR8wO+XNCl2jZOx8eOXTbaIPgkePI6UJ2FKbHrRSHO5qJSvLxGm5j/5ry7uAdFw3lCn7gw==}
-
-  light-my-request@6.6.0:
-    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -6218,15 +5847,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  mnemonist@0.39.6:
-    resolution: {integrity: sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==}
-
-  module-details-from-path@1.0.4:
-    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
-
-  moo@0.5.3:
-    resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -6284,10 +5904,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  nearley@2.20.1:
-    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
-    hasBin: true
-
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -6319,10 +5935,6 @@ packages:
       sass:
         optional: true
 
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
-
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
@@ -6344,10 +5956,6 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
-
-  node-sql-parser@4.18.0:
-    resolution: {integrity: sha512-2YEOR5qlI1zUFbGMLKNfsrR5JUvFg9LxIRVE+xJe962pfVLH0rnItqLzv96XVs1Y1UIR8FxsXAuvX/lYAWZ2BQ==}
-    engines: {node: '>=8'}
 
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
@@ -6402,18 +6010,11 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  obliterator@2.0.5:
-    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
-
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
-
-  on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -6433,9 +6034,6 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
-
-  openapi-types@12.1.3:
-    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -6541,14 +6139,17 @@ packages:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
 
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
-
-  pgsql-deparser@13.19.1:
-    resolution: {integrity: sha512-iCkE5h6wrXtRjT8ygdj7YktDVE3TwTYOLDmpEGT+8WWY47722584Zcr8kN/mk+2nA8mMVqH1Wwzwuu+aAdvjpQ==}
-
-  pgsql-parser@13.19.1:
-    resolution: {integrity: sha512-px+T9MY97vMzJWupiKSBXONJuQXtP6ix63RDH0xkZWG+Nv0qw45CnfMZrySmNp21YEOXVvlZTNTYN1MxulC6iQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -6564,16 +6165,6 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
-
-  pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
-
-  pino-std-serializers@7.1.0:
-    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
-
-  pino@9.14.0:
-    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
-    hasBin: true
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
@@ -6653,12 +6244,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-sql@0.17.1:
-    resolution: {integrity: sha512-CR9UpTkUSC/f69AV597hnYcBo77iUhsBPkUER7BUa4YHRRtRUJGfL5LDoHAlUHWGTZNiJdHHELlzK6I3R9XuAw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      prettier: ^3.0.3
-
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
@@ -6671,16 +6256,6 @@ packages:
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
-
-  process-warning@4.0.1:
-    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
-
-  process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-
-  prom-client@14.2.0:
-    resolution: {integrity: sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==}
-    engines: {node: '>=10'}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -6728,9 +6303,6 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
     peerDependencies:
@@ -6743,13 +6315,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  railroad-diagrams@1.0.0:
-    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
-
-  randexp@0.4.6:
-    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
-    engines: {node: '>=0.12'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -6871,10 +6436,6 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
-  real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
-
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -6906,10 +6467,6 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  require-in-the-middle@7.5.2:
-    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
-    engines: {node: '>=8.6.0'}
-
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -6934,23 +6491,12 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
-  ret@0.1.15:
-    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
-    engines: {node: '>=0.12'}
-
-  ret@0.5.0:
-    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
-    engines: {node: '>=10'}
-
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rolldown-plugin-dts@0.18.4:
     resolution: {integrity: sha512-7UpdiICFd/BhdjKtDPeakCFRk6pbkTGFe0Z6u01egt4c8aoO+JoPGF1Smc+JRuCH2s5j5hBdteBi0e10G0xQdQ==}
@@ -7016,14 +6562,6 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
-  safe-regex2@5.1.0:
-    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
-    hasBin: true
-
-  safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -7032,9 +6570,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -7093,9 +6628,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shimmer@1.2.1:
-    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
-
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -7125,9 +6657,6 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  sonic-boom@4.2.1:
-    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
-
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -7151,10 +6680,6 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sql-formatter@14.0.0:
-    resolution: {integrity: sha512-VcHYMRvZqg3RNjjxNB/puT9O1hR5QLXTvgTaBtxXcvmRQwSnH9M+oW2Ti+uFuVVU8HoNlOjU2uKHv8c0FQNsdQ==}
-    hasBin: true
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -7285,12 +6810,6 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
-  tdigest@0.1.2:
-    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
-
-  thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
-
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -7322,10 +6841,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  toad-cache@3.7.0:
-    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
-    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -8005,11 +7520,11 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@better-auth/api-key@1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))':
+  '@better-auth/api-key@1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.0
-      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       zod: 4.3.6
 
   '@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0)':
@@ -8036,26 +7551,26 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/passkey@1.4.9(@better-auth/core@1.6.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.2.0)':
+  '@better-auth/passkey@1.4.9(@better-auth/core@1.6.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.2.0)':
     dependencies:
       '@better-auth/core': 1.6.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       better-call: 2.0.2(zod@4.3.6)
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/passkey@1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@1.1.7(zod@4.3.6))(nanostores@1.2.0)':
+  '@better-auth/passkey@1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@1.1.7(zod@4.3.6))(nanostores@1.2.0)':
     dependencies:
       '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.0
-      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       better-call: 1.1.7(zod@4.3.6)
       nanostores: 1.2.0
       zod: 4.3.6
@@ -8101,28 +7616,28 @@ snapshots:
 
   '@captchafox/types@1.4.0': {}
 
-  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@18.0.0))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
+  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@18.0.0))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
     dependencies:
       '@tanstack/query-core': 5.96.1
       '@tanstack/react-query': 5.96.1(react@18.0.0)
-      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
 
-  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@19.2.3))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@daveyplate/better-auth-tanstack@1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@19.2.3))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/query-core': 5.96.1
       '@tanstack/react-query': 5.96.1(react@19.2.3)
-      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@daveyplate/better-auth-ui@3.3.9(3z2pgdnpv2ibrhzxvcgk5yxo7u)':
+  '@daveyplate/better-auth-ui@3.3.9(tipi3vukmojzchcvpg5ylthd3a)':
     dependencies:
-      '@better-auth/passkey': 1.4.9(@better-auth/core@1.6.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.2.0)
+      '@better-auth/passkey': 1.4.9(@better-auth/core@1.6.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.2.0)
       '@better-fetch/fetch': 1.1.21
       '@captchafox/react': 1.11.0(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@18.0.0))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@18.0.0))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@hcaptcha/react-hcaptcha': 1.17.4(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@hookform/resolvers': 5.2.2(react-hook-form@7.72.0(react@18.0.0))
       '@instantdb/react': 0.22.179(react@18.0.0)
@@ -8146,7 +7661,7 @@ snapshots:
       '@triplit/client': 1.0.50(typescript@5.9.3)
       '@triplit/react': 1.0.51(react@18.0.0)(typescript@5.9.3)
       '@wojtekmaj/react-recaptcha-v3': 0.1.4(@types/react@19.1.13)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       input-otp: 1.4.2(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
@@ -8166,13 +7681,13 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@daveyplate/better-auth-ui@3.4.0(hd7ap4xf342fbz3kvg5mzcy3ha)':
+  '@daveyplate/better-auth-ui@3.4.0(mgkdmvkylepqa64cpdxxm4d2pm)':
     dependencies:
-      '@better-auth/api-key': 1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))
-      '@better-auth/passkey': 1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@1.1.7(zod@4.3.6))(nanostores@1.2.0)
+      '@better-auth/api-key': 1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))
+      '@better-auth/passkey': 1.5.6(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(better-call@1.1.7(zod@4.3.6))(nanostores@1.2.0)
       '@better-fetch/fetch': 1.1.21
       '@captchafox/react': 1.11.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@19.2.3))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@daveyplate/better-auth-tanstack': 1.3.6(@tanstack/query-core@5.96.1)(@tanstack/react-query@5.96.1(react@19.2.3))(better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@hcaptcha/react-hcaptcha': 2.0.2
       '@hookform/resolvers': 5.2.2(react-hook-form@7.72.0(react@19.2.3))
       '@instantdb/react': 0.22.179(react@19.2.3)
@@ -8197,7 +7712,7 @@ snapshots:
       '@triplit/client': 1.0.50(typescript@5.9.3)
       '@triplit/react': 1.0.51(react@19.2.3)(typescript@5.9.3)
       '@wojtekmaj/react-recaptcha-v3': 0.1.4(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
+      better-auth: 1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3))
       better-call: 1.1.7(zod@4.3.6)
       bowser: 2.14.1
       class-variance-authority: 0.7.1
@@ -8538,48 +8053,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
-
-  '@fastify/ajv-compiler@4.0.5':
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
-
-  '@fastify/cors@9.0.1':
-    dependencies:
-      fastify-plugin: 4.5.1
-      mnemonist: 0.39.6
-
-  '@fastify/error@4.2.0': {}
-
-  '@fastify/fast-json-stringify-compiler@5.0.3':
-    dependencies:
-      fast-json-stringify: 6.3.0
-
-  '@fastify/forwarded@3.0.1': {}
-
-  '@fastify/merge-json-schemas@0.2.1':
-    dependencies:
-      dequal: 2.0.3
-
-  '@fastify/proxy-addr@5.1.0':
-    dependencies:
-      '@fastify/forwarded': 3.0.1
-      ipaddr.js: 2.3.0
-
-  '@fastify/swagger@8.15.0':
-    dependencies:
-      fastify-plugin: 4.5.1
-      json-schema-resolver: 2.0.0
-      openapi-types: 12.1.3
-      rfdc: 1.4.1
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fastify/type-provider-typebox@3.6.0(@sinclair/typebox@0.31.28)':
-    dependencies:
-      '@sinclair/typebox': 0.31.28
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -9020,247 +8493,9 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opentelemetry/api-logs@0.57.2':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-
-  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.28.0
-
-  '@opentelemetry/instrumentation-amqplib@0.46.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-connect@0.43.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@types/connect': 3.4.38
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-dataloader@0.16.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-express@0.47.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-fs@0.19.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-generic-pool@0.43.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-graphql@0.47.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-hapi@0.45.2(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-http@0.57.2(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.28.0
-      forwarded-parse: 2.1.2
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-ioredis@0.47.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/redis-common': 0.36.2
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-kafkajs@0.7.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-knex@0.44.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-koa@0.47.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-lru-memoizer@0.44.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mongodb@0.52.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mongoose@0.46.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mysql2@0.45.2(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-mysql@0.45.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@types/mysql': 2.15.26
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-pg@0.51.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
-      '@types/pg': 8.6.1
-      '@types/pg-pool': 2.0.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-redis-4@0.46.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/redis-common': 0.36.2
-      '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-tedious@0.18.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@types/tedious': 4.0.14
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.57.2
-      '@types/shimmer': 1.2.0
-      import-in-the-middle: 1.15.0
-      require-in-the-middle: 7.5.2
-      semver: 7.7.4
-      shimmer: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/redis-common@0.36.2': {}
-
-  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.28.0
-
-  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.28.0
-
-  '@opentelemetry/semantic-conventions@1.28.0': {}
-
   '@opentelemetry/semantic-conventions@1.40.0': {}
-
-  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@oxc-project/types@0.101.0': {}
 
@@ -9422,20 +8657,9 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
-  '@pgsql/types@13.11.1': {}
-
-  '@pinojs/redact@0.4.0': {}
-
   '@playwright/test@1.59.0':
     dependencies:
       playwright: 1.59.0
-
-  '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@publint/pack@0.1.4': {}
 
@@ -11305,83 +10529,6 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@sentry-internal/node-cpu-profiler@2.2.0':
-    dependencies:
-      detect-libc: 2.1.2
-      node-abi: 3.89.0
-
-  '@sentry/core@9.47.1': {}
-
-  '@sentry/node-core@9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@sentry/core': 9.47.1
-      '@sentry/opentelemetry': 9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      import-in-the-middle: 1.15.0
-
-  '@sentry/node@9.47.1':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-amqplib': 0.46.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-connect': 0.43.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-dataloader': 0.16.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-express': 0.47.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-fs': 0.19.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-generic-pool': 0.43.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-graphql': 0.47.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-hapi': 0.45.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-http': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-ioredis': 0.47.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-kafkajs': 0.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-knex': 0.44.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-koa': 0.47.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.44.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongodb': 0.52.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mongoose': 0.46.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql': 0.45.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-mysql2': 0.45.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-pg': 0.51.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-redis-4': 0.46.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-tedious': 0.18.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation-undici': 0.10.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@prisma/instrumentation': 6.11.1(@opentelemetry/api@1.9.1)
-      '@sentry/core': 9.47.1
-      '@sentry/node-core': 9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      '@sentry/opentelemetry': 9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      import-in-the-middle: 1.15.0
-      minimatch: 9.0.9
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sentry/opentelemetry@9.47.1(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      '@sentry/core': 9.47.1
-
-  '@sentry/profiling-node@9.47.1':
-    dependencies:
-      '@sentry-internal/node-cpu-profiler': 2.2.0
-      '@sentry/core': 9.47.1
-      '@sentry/node': 9.47.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@simplewebauthn/browser@13.3.0': {}
 
   '@simplewebauthn/server@13.3.0':
@@ -11395,8 +10542,6 @@ snapshots:
       '@peculiar/asn1-x509': 2.6.1
       '@peculiar/x509': 1.14.3
 
-  '@sinclair/typebox@0.31.28': {}
-
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -11406,45 +10551,6 @@ snapshots:
   '@supabase/auth-js@2.79.0':
     dependencies:
       tslib: 2.8.1
-
-  '@supabase/pg-protocol@0.0.2': {}
-
-  '@supabase/pg@0.0.3(@supabase/pg@0.0.3)':
-    dependencies:
-      pg-connection-string: 2.12.0
-      pg-pool: 3.13.0(@supabase/pg@0.0.3)
-      pg-protocol: '@supabase/pg-protocol@0.0.2'
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    optionalDependencies:
-      pg-cloudflare: 1.3.0
-    transitivePeerDependencies:
-      - pg
-
-  '@supabase/postgres-meta@0.93.1':
-    dependencies:
-      '@fastify/cors': 9.0.1
-      '@fastify/swagger': 8.15.0
-      '@fastify/type-provider-typebox': 3.6.0(@sinclair/typebox@0.31.28)
-      '@sentry/node': 9.47.1
-      '@sentry/profiling-node': 9.47.1
-      '@sinclair/typebox': 0.31.28
-      close-with-grace: 2.5.0
-      crypto-js: 4.2.0
-      fastify: 5.8.5
-      fastify-metrics: 10.6.0(fastify@5.8.5)
-      pg: '@supabase/pg@0.0.3(@supabase/pg@0.0.3)'
-      pg-connection-string: 2.12.0
-      pg-format: 1.0.4
-      pg-protocol: '@supabase/pg-protocol@0.0.2'
-      pgsql-parser: 13.19.1
-      pino: 9.14.0
-      postgres-array: 3.0.4
-      prettier: 3.8.1
-      prettier-plugin-sql: 0.17.1(prettier@3.8.1)
-    transitivePeerDependencies:
-      - pg-native
-      - supports-color
 
   '@supabase/postgrest-js@2.79.0':
     dependencies:
@@ -11649,10 +10755,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 20.19.37
-
   '@types/cookie@0.6.0': {}
 
   '@types/deep-eql@4.0.2': {}
@@ -11662,10 +10764,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
-
-  '@types/mysql@2.15.26':
-    dependencies:
-      '@types/node': 20.19.37
 
   '@types/node@20.19.37':
     dependencies:
@@ -11683,17 +10781,9 @@ snapshots:
     dependencies:
       undici-types: 7.14.0
 
-  '@types/pg-pool@2.0.6':
-    dependencies:
-      '@types/pg': 8.20.0
+  '@types/pg-format@1.0.5': {}
 
   '@types/pg@8.20.0':
-    dependencies:
-      '@types/node': 20.19.37
-      pg-protocol: 1.13.0
-      pg-types: 2.2.0
-
-  '@types/pg@8.6.1':
     dependencies:
       '@types/node': 20.19.37
       pg-protocol: 1.13.0
@@ -11715,13 +10805,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/shimmer@1.2.0': {}
-
   '@types/statuses@2.0.6': {}
-
-  '@types/tedious@4.0.14':
-    dependencies:
-      '@types/node': 20.19.37
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -12107,16 +11191,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  abstract-logging@2.0.1: {}
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
-
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -12254,8 +11332,6 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  atomic-sleep@1.0.0: {}
-
   autoprefixer@10.4.20(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.2
@@ -12270,11 +11346,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  avvio@9.2.0:
-    dependencies:
-      '@fastify/error': 4.2.0
-      fastq: 1.20.1
-
   axe-core@4.11.2: {}
 
   axobject-query@4.1.0: {}
@@ -12285,7 +11356,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.13: {}
 
-  better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)):
+  better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(pg@8.20.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/telemetry': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))
@@ -12301,13 +11372,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)
+      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0)
       next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      pg: 8.20.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       vitest: 4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
-  better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)):
+  better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/telemetry': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))
@@ -12323,13 +11395,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)
+      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0)
       next: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      pg: 8.20.0
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
       vitest: 4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.12.14(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
-  better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.6.8(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)):
+  better-auth@1.4.9(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0))(next@16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(pg@8.20.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)(vitest@4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.6.8(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/telemetry': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.6))(jose@6.1.2)(kysely@0.28.15)(nanostores@1.2.0))
@@ -12345,8 +11418,9 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)
+      drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0)
       next: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      pg: 8.20.0
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
       vitest: 4.0.7(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(msw@2.6.8(@types/node@24.12.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
@@ -12368,10 +11442,6 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
-
-  big-integer@1.6.52: {}
-
-  bintrees@1.0.2: {}
 
   birpc@4.0.0: {}
 
@@ -12529,8 +11599,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  close-with-grace@2.5.0: {}
-
   clsx@2.1.1: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
@@ -12558,8 +11626,6 @@ snapshots:
   commander@11.1.0: {}
 
   commander@14.0.3: {}
-
-  commander@2.20.3: {}
 
   concat-map@0.0.1: {}
 
@@ -12608,8 +11674,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  crypto-js@4.2.0: {}
 
   cssesc@3.0.0: {}
 
@@ -12676,8 +11740,6 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dequal@2.0.3: {}
-
   destr@2.0.5: {}
 
   detect-europe-js@0.1.2: {}
@@ -12687,8 +11749,6 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   diff@8.0.4: {}
-
-  discontinuous-range@1.0.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -12730,19 +11790,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.0(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15):
+  drizzle-orm@0.45.0(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0):
     optionalDependencies:
       '@neondatabase/serverless': 1.0.2
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       kysely: 0.28.15
+      pg: 8.20.0
 
-  drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15):
+  drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.28.15)(pg@8.20.0):
     optionalDependencies:
       '@neondatabase/serverless': 1.0.2
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       kysely: 0.28.15
+      pg: 8.20.0
 
   dts-resolver@2.1.3: {}
 
@@ -13496,8 +12558,6 @@ snapshots:
 
   exsolve@1.0.8: {}
 
-  fast-decode-uri-component@1.0.1: {}
-
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -13518,48 +12578,9 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-json-stringify@6.3.0:
-    dependencies:
-      '@fastify/merge-json-schemas': 0.2.1
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
-      json-schema-ref-resolver: 3.0.0
-      rfdc: 1.4.1
-
   fast-levenshtein@2.0.6: {}
 
-  fast-querystring@1.1.2:
-    dependencies:
-      fast-decode-uri-component: 1.0.1
-
   fast-uri@3.1.0: {}
-
-  fastify-metrics@10.6.0(fastify@5.8.5):
-    dependencies:
-      fastify: 5.8.5
-      fastify-plugin: 4.5.1
-      prom-client: 14.2.0
-
-  fastify-plugin@4.5.1: {}
-
-  fastify@5.8.5:
-    dependencies:
-      '@fastify/ajv-compiler': 4.0.5
-      '@fastify/error': 4.2.0
-      '@fastify/fast-json-stringify-compiler': 5.0.3
-      '@fastify/proxy-addr': 5.1.0
-      abstract-logging: 2.0.1
-      avvio: 9.2.0
-      fast-json-stringify: 6.3.0
-      find-my-way: 9.5.0
-      light-my-request: 6.6.0
-      pino: 9.14.0
-      process-warning: 5.0.0
-      rfdc: 1.4.1
-      secure-json-parse: 4.1.0
-      semver: 7.7.4
-      toad-cache: 3.7.0
 
   fastq@1.20.1:
     dependencies:
@@ -13599,12 +12620,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-my-way@9.5.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-querystring: 1.1.2
-      safe-regex2: 5.1.0
-
   find-up-simple@1.0.1: {}
 
   find-up@5.0.0:
@@ -13626,8 +12641,6 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
-
-  forwarded-parse@2.1.2: {}
 
   forwarded@0.2.0: {}
 
@@ -13693,8 +12706,6 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-
-  get-stdin@8.0.0: {}
 
   get-stream@6.0.1: {}
 
@@ -13834,13 +12845,6 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-in-the-middle@1.15.0:
-    dependencies:
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      cjs-module-lexer: 1.4.3
-      module-details-from-path: 1.0.4
-
   import-without-cache@0.2.5: {}
 
   imurmurhash@0.1.4: {}
@@ -13868,8 +12872,6 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
-
-  ipaddr.js@2.3.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -14060,18 +13062,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-ref-resolver@3.0.0:
-    dependencies:
-      dequal: 2.0.3
-
-  json-schema-resolver@2.0.0:
-    dependencies:
-      debug: 4.4.3
-      rfdc: 1.4.1
-      uri-js: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -14093,8 +13083,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsox@1.2.125: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -14125,16 +13113,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  libpg-query@13.6.0:
-    dependencies:
-      '@pgsql/types': 13.11.1
-
-  light-my-request@6.6.0:
-    dependencies:
-      cookie: 1.1.1
-      process-warning: 4.0.1
-      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -14320,14 +13298,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mnemonist@0.39.6:
-    dependencies:
-      obliterator: 2.0.5
-
-  module-details-from-path@1.0.4: {}
-
-  moo@0.5.3: {}
-
   mri@1.2.0: {}
 
   ms@2.1.3: {}
@@ -14447,13 +13417,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  nearley@2.20.1:
-    dependencies:
-      commander: 2.20.3
-      moo: 0.5.3
-      railroad-diagrams: 1.0.0
-      randexp: 0.4.6
-
   negotiator@1.0.0: {}
 
   next-themes@0.4.6(react-dom@18.0.0(react@18.0.0))(react@18.0.0):
@@ -14549,10 +13512,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.7.4
-
   node-addon-api@7.1.1: {}
 
   node-domexception@1.0.0: {}
@@ -14573,10 +13532,6 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.36: {}
-
-  node-sql-parser@4.18.0:
-    dependencies:
-      big-integer: 1.6.52
 
   normalize-range@0.1.2: {}
 
@@ -14639,13 +13594,9 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  obliterator@2.0.5: {}
-
   obug@2.1.1: {}
 
   ohash@2.0.11: {}
-
-  on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -14671,8 +13622,6 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
-
-  openapi-types@12.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -14762,9 +13711,9 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-pool@3.13.0(@supabase/pg@0.0.3):
+  pg-pool@3.13.0(pg@8.20.0):
     dependencies:
-      pg: '@supabase/pg@0.0.3(@supabase/pg@0.0.3)'
+      pg: 8.20.0
 
   pg-protocol@1.13.0: {}
 
@@ -14776,19 +13725,19 @@ snapshots:
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
 
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
-
-  pgsql-deparser@13.19.1:
-    dependencies:
-      '@pgsql/types': 13.11.1
-
-  pgsql-parser@13.19.1:
-    dependencies:
-      '@pgsql/types': 13.11.1
-      libpg-query: 13.6.0
-      pgsql-deparser: 13.19.1
 
   picocolors@1.1.1: {}
 
@@ -14797,26 +13746,6 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@2.3.0: {}
-
-  pino-abstract-transport@2.0.0:
-    dependencies:
-      split2: 4.2.0
-
-  pino-std-serializers@7.1.0: {}
-
-  pino@9.14.0:
-    dependencies:
-      '@pinojs/redact': 0.4.0
-      atomic-sleep: 1.0.0
-      on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 2.0.0
-      pino-std-serializers: 7.1.0
-      process-warning: 5.0.0
-      quick-format-unescaped: 4.0.4
-      real-require: 0.2.0
-      safe-stable-stringify: 2.5.0
-      sonic-boom: 4.2.1
-      thread-stream: 3.1.0
 
   pkce-challenge@5.0.1: {}
 
@@ -14886,14 +13815,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-sql@0.17.1(prettier@3.8.1):
-    dependencies:
-      jsox: 1.2.125
-      node-sql-parser: 4.18.0
-      prettier: 3.8.1
-      sql-formatter: 14.0.0
-      tslib: 2.8.1
-
   prettier@3.8.1: {}
 
   pretty-ms@9.3.0:
@@ -14901,14 +13822,6 @@ snapshots:
       parse-ms: 4.0.0
 
   prismjs@1.30.0: {}
-
-  process-warning@4.0.1: {}
-
-  process-warning@5.0.0: {}
-
-  prom-client@14.2.0:
-    dependencies:
-      tdigest: 0.1.2
 
   prompts@2.4.2:
     dependencies:
@@ -14956,8 +13869,6 @@ snapshots:
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
-
-  quick-format-unescaped@4.0.4: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -15021,13 +13932,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  railroad-diagrams@1.0.0: {}
-
-  randexp@0.4.6:
-    dependencies:
-      discontinuous-range: 1.0.0
-      ret: 0.1.15
 
   range-parser@1.2.1: {}
 
@@ -15216,8 +14120,6 @@ snapshots:
 
   readdirp@5.0.0: {}
 
-  real-require@0.2.0: {}
-
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -15258,14 +14160,6 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2:
-    dependencies:
-      debug: 4.4.3
-      module-details-from-path: 1.0.4
-      resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-
   requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
@@ -15292,15 +14186,9 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  ret@0.1.15: {}
-
-  ret@0.5.0: {}
-
   rettime@0.10.1: {}
 
   reusify@1.1.0: {}
-
-  rfdc@1.4.1: {}
 
   rolldown-plugin-dts@0.18.4(rolldown@1.0.0-beta.53(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@5.9.3):
     dependencies:
@@ -15437,12 +14325,6 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  safe-regex2@5.1.0:
-    dependencies:
-      ret: 0.5.0
-
-  safe-stable-stringify@2.5.0: {}
-
   safer-buffer@2.1.2: {}
 
   scheduler@0.21.0:
@@ -15450,8 +14332,6 @@ snapshots:
       loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
-
-  secure-json-parse@4.1.0: {}
 
   selderee@0.11.0:
     dependencies:
@@ -15596,8 +14476,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shimmer@1.2.1: {}
-
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -15634,10 +14512,6 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  sonic-boom@4.2.1:
-    dependencies:
-      atomic-sleep: 1.0.0
-
   sonner@2.0.7(react-dom@18.0.0(react@18.0.0))(react@18.0.0):
     dependencies:
       react: 18.0.0
@@ -15665,12 +14539,6 @@ snapshots:
   source-map@0.6.1: {}
 
   split2@4.2.0: {}
-
-  sql-formatter@14.0.0:
-    dependencies:
-      argparse: 2.0.1
-      get-stdin: 8.0.0
-      nearley: 2.20.1
 
   stable-hash@0.0.5: {}
 
@@ -15812,14 +14680,6 @@ snapshots:
 
   tapable@2.3.2: {}
 
-  tdigest@0.1.2:
-    dependencies:
-      bintrees: 1.0.2
-
-  thread-stream@3.1.0:
-    dependencies:
-      real-require: 0.2.0
-
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -15844,8 +14704,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Vendor the **introspection portion** of [`@supabase/postgres-meta`](https://github.com/supabase/postgres-meta) (pinned to `v0.93.1`, commit `dc50199ca163b32ba4bdfa601dd3a9076ed2b640`) into `packages/neon-js/src/vendor/postgres-meta/` and drop `@supabase/postgres-meta` from runtime dependencies.

Refs: #0000

## Why

`@supabase/postgres-meta` ships the introspection library and a Fastify HTTP server in a single npm tarball, dragging in a chain of vulnerable transitive deps every time anyone runs `npm install @neondatabase/neon-js`:

- `fastify` (≤ 4.x CVE chain)
- `@sentry/node` (heavy, unused at runtime by the CLI)
- `pgsql-parser`, `prettier-plugin-sql` (only used by `Parser.parse/deparse/format` — never called by `generateTypes`)
- `pino`, `swagger`, `fastify-metrics`, `crypto-js`, `close-with-grace`
- The `npm:@supabase/pg@0.0.3` fork (a hard pin nobody else uses)

`pnpm` `overrides` in this repo cannot fix this for downstream consumers — overrides only apply when **they** install transitively from us, and would not propagate through their own overrides. Vendoring the ~1% of postgres-meta we actually use lets us drop the entire HTTP server subtree (and its CVE surface) from the published tarball.

Only `packages/neon-js/src/cli/commands/generate-types.ts` consumed the dep, via three named exports: `PostgresMeta`, `getGeneratorMetadata`, `apply`. `postgrest-js` and `auth` did not import it.

## What is in the PR

Three commits:

1. **`feat: Vendor supabase/postgres-meta @ v0.93.1`** — bulk copy of 44 `.ts` files (lib + sql + templates/typescript) into `packages/neon-js/src/vendor/postgres-meta/`. Verbatim from upstream except for an SPDX/provenance header on each file. Adds `LICENSE` (Apache-2.0) and `README.md`.
2. **`impr: Strip Sentry, SQL parser, typebox; switch to upstream pg`** — surgical edits:
   - `lib/db.ts`: removed every `Sentry.startSpan(...)` wrapper, dropped the `RESULT_SIZE_EXCEEDED` branch, swapped `npm:@supabase/pg@0.0.3` for upstream `pg@^8`.
   - `lib/PostgresMeta.ts`: dropped the `Parser` import and the `parse`/`deparse`/`format` field assignments.
   - `lib/types.ts`: rewrote every `Type.Object(...) + Static<typeof ...>` pair as a plain TS `interface` / discriminated union — drops the `@sinclair/typebox` runtime dep. Replaced `pg-protocol`'s `DatabaseError` import with a structural alias.
   - `templates/typescript.ts`: re-pointed `'../../lib/...'` imports to `'../lib/...'` for the flatter vendor layout.
   - Added a slim `constants.ts` (3 values pulled from upstream `src/server/constants.ts`) and `lib/index.ts` (slim re-export).
3. **`refc: Switch generate-types.ts to vendored postgres-meta`** — wires the CLI:
   - `packages/neon-js/package.json`: removed `@supabase/postgres-meta`, added `pg ^8.13`, `pg-format 1.0.4`, `postgres-array 3.0.4`, `prettier 3.8.1` (versions match what the workspace already resolves to). Added `@types/pg`, `@types/pg-format` to devDeps. Added vendor `LICENSE` + `README.md` to `files`.
   - `packages/neon-js/src/cli/commands/generate-types.ts`: rewrote the three imports.
   - `eslint.config.mjs`, `packages/neon-js/.prettierignore`: ignore `src/vendor/**` so upstream code stays diff-clean.
   - `CLAUDE.md` / `AGENTS.md` / `packages/neon-js/CHANGELOG.md`: updated docs.
   - `pnpm-lock.yaml`: refreshed.

## License obligations

Upstream `package.json` declares `MIT`, but the actual `LICENSE` file shipped is **Apache-2.0**. To stay on the strictly safer side we treat the vendored sub-tree as Apache-2.0:

- Per-file SPDX headers (`Apache-2.0`) on every vendored `.ts` file.
- Each file lists the modifications applied (Apache-2.0 §4(b)).
- Full upstream `LICENSE` shipped at `packages/neon-js/src/vendor/postgres-meta/LICENSE` and listed in the package's `files` array so it ends up in the npm tarball (Apache-2.0 §4(a)).
- No NOTICE file exists upstream, so none is required (§4(d)).

The rest of `@neondatabase/neon-js` is also Apache-2.0, so license compatibility is trivial.

## Verification

Run from `packages/neon-js`:

- `pnpm --filter @neondatabase/neon-js typecheck` — clean.
- `pnpm --filter @neondatabase/neon-js test:ci` — 17 type tests pass.
- `pnpm --filter @neondatabase/neon-js build` — succeeds; `dist/cli/index.mjs` (~147 kB) contains the inlined vendored introspection code.
- `pnpm --filter @neondatabase/neon-js lint` — clean (vendor is ignored).
- `npm pack --dry-run` — tarball contains `src/vendor/postgres-meta/LICENSE` + `README.md`; `grep -r "@supabase/postgres-meta" dist/` returns nothing.

## Test plan

- [ ] Reviewer: diff `packages/neon-js/src/vendor/postgres-meta/` against `https://github.com/supabase/postgres-meta/tree/v0.93.1/src/lib` to verify the only differences are the per-file headers and the modifications listed in commit 2's message.
- [ ] Reviewer: confirm the package's published tarball no longer pulls `@supabase/postgres-meta` (and its fastify chain) by inspecting `dist/cli/index.mjs` and the `dependencies` block in `dist/package.json`.
- [ ] Optional: from a scratch directory, `npm i ./packages/neon-js/neondatabase-neon-js-*.tgz` and run `npx neon-js gen-types --connection-string $TEST_PG_URL` against a real Postgres. Output should be byte-identical to the previous unvendored version (same SQL, same template).

## Notes on deviations from the original plan

- **License**: the plan called the upstream license MIT (matching `package.json`); the actual shipped `LICENSE` file is Apache-2.0. We respect the file as authoritative and use Apache-2.0 SPDX headers + state-changes attribution.
- **typebox conversion**: 594 LOC of `Type.Object(...) + Static<typeof ...>` rewritten as plain TS interfaces. No callers imported the schema constants (only the types), so the rewrite is local to `types.ts`.
- **`import type` conversion**: the package's tsconfig has `verbatimModuleSyntax: true`, which forced converting all `import { ...types... } from './types.js'` to `import type` across the vendored files. This was a mechanical change applied via script and listed in commit 2's modification log.

Closes nothing — this is the first PR in this work.

Upstream tag: <https://github.com/supabase/postgres-meta/releases/tag/v0.93.1>

This pull request and its description were written by Isaac.


---

## Automated verification (added 2026-04-30)

Run on the PR head against a real Postgres 16 testcontainer with a comprehensive fixture (every schema feature exercised by `lib/sql/*.sql.ts` and `apply()`). All scripts and fixture SQL are saved under `/tmp/` on the verification host (`vendor-fixture.sql`, `sql-diff-check.sh`, `vendor-smoke.mjs`, `vendor-diff.mjs`).

| # | Check | Result | Evidence |
|---|---|---|---|
| 1 | SQL byte-identity vs upstream `v0.93.1` | PASS | 21/21 `.sql.ts` files identical to upstream after stripping our SPDX header. |
| 2 | Forbidden token grep in vendor source | PASS | 0 hits in code (matches in `README.md` + `// comments` are intentional documentation of removals). Tokens checked: `@sentry`, `Sentry.`, `pgsql-parser`, `prettier-plugin-sql`, `@sinclair/typebox`, `RESULT_SIZE_EXCEEDED`, `@supabase/pg`, `import.*Parser`. |
| 3 | Tarball + dist bundle inspection | PASS | `npm pack --dry-run`: 37 files; includes `src/vendor/postgres-meta/LICENSE` and `src/vendor/postgres-meta/README.md`. `dist/cli/index.mjs` (~147 kB) contains `class PostgresMeta`, `getGeneratorMetadata`, `apply` and zero matches for any forbidden token. |
| 4 | Dep tree clean (`pnpm why`) | PASS | `pnpm why` for `fastify`, `@sentry/node`, `@sinclair/typebox`, `pgsql-parser`, `prettier-plugin-sql`, `@supabase/postgres-meta` all return empty (no path through this workspace). |
| 5 | Type-check (`tsc --noEmit`) | PASS | `pnpm --filter @neondatabase/neon-js typecheck` exits 0 with no errors. |
| 6 | Lint (`eslint .`) | PASS | `pnpm exec eslint packages/neon-js/.` exits 0; vendor tree is excluded by `eslint.config.mjs` per intent. |
| 7 | Differential test vs unvendored `@supabase/postgres-meta@0.93.1` | PASS | End-to-end `getGeneratorMetadata` + `apply` against a real PG16 with `schemas: ['public', 'app']`. Vendored output: 15,641 chars. Upstream output: 15,641 chars. **Byte-identical.** Temp devDep alias was installed for the test only and reverted; lockfile is unchanged. |
| 8 | Smoke test (constructor / shape / no leaks) | PASS | 18/18 assertions: `dist/cli/index.mjs` exists; bundle contains `PostgresMeta`/`getGeneratorMetadata`/`apply`; bundle has zero forbidden tokens; vendor tree exports correct shape; `generate-types.ts` imports vendored paths only. |
| 9 | Coverage of vendored code via differential run | WARN | 48.7% statements / 68.85% branches over 49 files. The diff run only invokes `getGeneratorMetadata` + `apply` for type generation; it does **not** invoke the unused `apply()`/`update()`/`remove()` methods on each `PostgresMetaXxx.ts`. See "Dead-code candidates" below. Output below also confirms `PostgresMeta.ts` (100%), `generators.ts` (87.83%), `templates/typescript.ts` (86.87%) — i.e. the on-path code is well-covered. |

### Dead-code candidates (vendored but never reached on the `generateTypes` path)

These files have <30% statement coverage on the diff run because `generateTypes` only calls the `list()` introspection methods, not the mutating CRUD wrappers. Safe to delete in a follow-up if we want to trim the vendor surface further:

- `lib/PostgresMetaColumnPrivileges.ts` (24.4%)
- `lib/PostgresMetaColumns.ts` mutators (16.7% overall — `list()` is covered, the `create/update/remove` paths are not)
- `lib/PostgresMetaExtensions.ts` (25.66%)
- `lib/PostgresMetaFunctions.ts` (22.87%)
- `lib/PostgresMetaPolicies.ts` (22.09%)
- `lib/PostgresMetaPublications.ts` (12.25%)
- `lib/PostgresMetaRoles.ts` (12.94%)
- `lib/PostgresMetaTablePrivileges.ts` (28.08%)
- `lib/PostgresMetaTriggers.ts` (23.52%)
- `lib/sql/{column_privileges,config,indexes,policies,publications,roles,table_privileges,triggers}.sql.ts` are also under 30% — only the `list` queries fire on the `generateTypes` path.

`lib/index.ts` (0%) and `lib/types.ts` (0%) show as 0% because they contain only type-level exports that don't generate runtime code; this is expected (not actually dead).

**Recommendation**: leave them in this PR (verbatim vendor of upstream is easier to audit and bump). If you want a strict-minimum follow-up, run `knip` or `ts-prune` and trim.

### Reproducing locally

```bash
# from the worktree
docker run --rm -d --name vendor-pg-test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=test -p 55432:5432 postgres:16-alpine
sleep 4
docker cp /tmp/vendor-fixture.sql vendor-pg-test:/fixture.sql
docker exec vendor-pg-test psql -U postgres -d test -v ON_ERROR_STOP=1 -f /fixture.sql

cd packages/neon-js
pnpm add -D '@supabase/postgres-meta-original@npm:@supabase/postgres-meta@0.93.1'   # temp, do not commit
node --import tsx /tmp/vendor-diff.mjs   # expect "IDENTICAL: outputs are byte-equal"
pnpm remove @supabase/postgres-meta-original
git checkout -- ../../pnpm-lock.yaml     # revert lockfile churn
```

### Known divergences from upstream

- **Per-file SPDX header** added to every vendored `.ts` (Apache-2.0 §4(b)).
- **`Parser.ts` not vendored** — upstream's `parse`/`deparse`/`format` field assignments removed from `lib/PostgresMeta.ts`. Not used by `generateTypes`.
- **`@sentry/node` calls removed** from `lib/db.ts` (`Sentry.startSpan(...)` wrappers and the `RESULT_SIZE_EXCEEDED` error branch).
- **`@sinclair/typebox` runtime removed** — `lib/types.ts` rewritten as plain TS interfaces / discriminated unions. The Typebox **schema constants** are not exported anywhere from upstream's public API surface that we use, so this is invisible to callers.
- **`@supabase/pg` fork → upstream `pg@^8`** in `lib/db.ts`. `pg-protocol`'s `DatabaseError` import replaced with a structural alias.
- **Flatter layout**: `templates/typescript.ts` re-points `'../../lib/...'` to `'../lib/...'`.

### Risks identified

1. The verification only ran against **PG16** today. The differential equivalence is strong evidence the introspection SQL behaves the same on 16; a Tier-2 matrix run across 14/15/17 would cement this. (Deferred — not blocking; nothing in the diff is version-specific.)
2. **Coverage on mutating wrappers is low by design** — we don't call them. If a future PR exposes those code paths to consumers, add fixture coverage at that time.
3. **No CI snapshot of upstream SQL is committed** — the SQL byte-identity check fetches from GitHub at verification time. For long-term hermetic CI, we should snapshot upstream into `tests/fixtures/upstream-sql-v0.93.1/` per the original verification plan.

### What was NOT done

- ❌ Tier-2 cross-PG-version matrix (14/15/17). Deferred — needs CI infra.
- ❌ Committed Tier-1 vitest harness (the snapshot/SQL/forbidden-token tests as permanent CI). Deferred — out of scope for the vendor PR itself; can be a follow-up.
- ❌ AST-equivalence test (only needed if byte-diff fails; it didn't).

PR remains in **draft** status — verification confirms behavioral parity but reviewer should still eyeball the surgical edits in commit 2 before flipping ready-for-review.
