### PR TITLE
chore(ci): use draft PR + ready_for_review to attach required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Build & Lint & Typecheck
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -79,7 +79,6 @@ jobs:
     permissions:
       contents: write      # push release branch
       pull-requests: write # open PR
-      actions: write       # dispatch ci.yml + unit-tests.yml on the release branch
 
     steps:
       - name: Harden the runner
@@ -335,6 +334,14 @@ jobs:
           title: ${{ steps.meta.outputs.pr_title }}
           body: ${{ steps.meta.outputs.body }}
           labels: release
+          # Open as draft so a human can flip "Ready for review" once. That
+          # ready_for_review event fires under the human's identity (not
+          # GITHUB_TOKEN), bypassing the recursion guard and producing real
+          # pull_request-event runs whose check-runs attach to the PR's
+          # required-checks rollup. `always-true` keeps the PR in draft on
+          # subsequent reruns; plain `true` would only set draft on creation
+          # and would mark a previously-draft PR as ready, breaking the flow.
+          draft: always-true
           # Don't delete the release branch on rerun — we want predictable, run-id-suffixed branches.
           delete-branch: false
 
@@ -348,22 +355,6 @@ jobs:
 
           echo "### PR" >> "$GITHUB_STEP_SUMMARY"
           echo "$PR_URL ($PR_OP)" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Trigger required checks on release branch
-        if: steps.cpr.outputs.pull-request-url != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BRANCH: ${{ steps.meta.outputs.branch }}
-        run: |
-          # Release PRs opened by peter-evans/create-pull-request via GITHUB_TOKEN
-          # don't trigger pull_request workflows (GitHub recursion guard).
-          # workflow_dispatch is exempt — dispatch ci.yml + unit-tests.yml manually
-          # so branch protection's required contexts (ci, unit-tests) report on the
-          # release branch HEAD SHA.
-          # See https://docs.github.com/en/actions/concepts/security/github_token
-          gh workflow run ci.yml --ref "$BRANCH"
-          gh workflow run unit-tests.yml --ref "$BRANCH"
-          echo "Dispatched ci.yml and unit-tests.yml on $BRANCH" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Release failure guidance
         if: failure()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem

PR #119 fixed the trigger problem: release PRs opened by `peter-evans/create-pull-request@v8` with GITHUB_TOKEN now run ci.yml and unit-tests.yml via `workflow_dispatch`, bypassing GitHub's recursion guard. The runs execute and pass.

But the check-runs aren't attached to the PR. Observed on #121:

- ci → SUCCESS on head SHA
- unit-tests → SUCCESS on head SHA
- PR rollup → still shows "Expected — Waiting for status to be reported"
- Required contexts never resolve, branch protection blocks merge forever

Root cause: GitHub only associates `pull_request`-event check-runs with PRs for branch-protection evaluation. `workflow_dispatch` runs publish check-runs against the SHA but they don't roll up.

## Why no PAT/App fix

Org policy forbids PATs and GitHub Apps. The canonical `peter-evans/create-pull-request` workaround (use a non-Actions token to open the PR) is unavailable.

## Fix: draft PRs + ready_for_review

The only no-PAT path that works:

1. `peter-evans/create-pull-request` opens release PRs as drafts (`draft: always-true`).
2. A human clicks "Ready for review" once per release.
3. The `pull_request: ready_for_review` event fires under the human's identity, not GITHUB_TOKEN — bypassing the recursion guard.
4. ci.yml and unit-tests.yml run as `pull_request` events; their check-runs attach to the PR; required contexts resolve.

`workflow_dispatch` post-create steps are removed (no longer needed).

## Summary of changes

- [ ] `prepare-release.yml`: `draft: always-true` on `peter-evans/create-pull-request@v8`. Remove post-create `gh workflow run ci.yml/unit-tests.yml` dispatch steps.
- [ ] `ci.yml`, `unit-tests.yml`: add `ready_for_review` to `pull_request.types`.

Refs: #119, #121

## Verification steps

- [ ] After merge, run prepare-release.yml end-to-end (or wait for the next scheduled release).
- [ ] Confirm the resulting PR is opened in draft state.
- [ ] Click "Ready for review" once.
- [ ] Confirm ci and unit-tests now run as `pull_request` events (visible in Actions tab; `event: pull_request`).
- [ ] Confirm the PR rollup transitions from "Expected" to running, then green.
- [ ] Approve and squash-merge as normal.