### PR TITLE
[neon-js/deps] chore: Bundle 6 Dependabot bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@0ee1beea589a67d33340072691a5d42abec7ae6b # v1
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@0ee1beea589a67d33340072691a5d42abec7ae6b # v1
+        uses: anthropics/claude-code-action@ef50f123a3a9be95b60040d042717517407c7256 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           egress-policy: audit
 

--- a/examples/neon-auth-orgs-example/package.json
+++ b/examples/neon-auth-orgs-example/package.json
@@ -20,7 +20,7 @@
     "cmdk": "^1.1.1",
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.575.0",
-    "next": "16.1.6",
+    "next": "16.1.7",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",

--- a/examples/nextjs-admin-portal/package.json
+++ b/examples/nextjs-admin-portal/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@neondatabase/auth": "workspace:*",
     "lucide-react": "^0.555.0",
-    "next": "16.0.7",
+    "next": "16.1.7",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },

--- a/examples/nextjs-neon-auth/package.json
+++ b/examples/nextjs-neon-auth/package.json
@@ -20,7 +20,7 @@
     "drizzle-kit": "0.31.7",
     "drizzle-orm": "0.45.2",
     "lucide-react": "0.555.0",
-    "next": "16.0.7",
+    "next": "16.1.7",
     "next-themes": "0.4.6",
     "react": "19.2.1",
     "react-dom": "19.2.1",

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -76,7 +76,7 @@
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",
     "autoprefixer": "10.4.20",
-    "postcss": "8.5.6",
+    "postcss": "8.5.10",
     "postcss-import": "16.1.1"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,13 +636,13 @@ importers:
         version: 19.1.9(@types/react@19.1.13)
       autoprefixer:
         specifier: 10.4.20
-        version: 10.4.20(postcss@8.5.6)
+        version: 10.4.20(postcss@8.5.10)
       postcss:
-        specifier: 8.5.6
-        version: 8.5.6
+        specifier: 8.5.10
+        version: 8.5.10
       postcss-import:
         specifier: 16.1.1
-        version: 16.1.1(postcss@8.5.6)
+        version: 16.1.1(postcss@8.5.10)
 
   packages/internal: {}
 
@@ -6119,6 +6119,10 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -11243,14 +11247,14 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  autoprefixer@10.4.20(postcss@8.5.6):
+  autoprefixer@10.4.20(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001784
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -13670,9 +13674,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@16.1.1(postcss@8.5.6):
+  postcss-import@16.1.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
@@ -13685,6 +13689,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1


### PR DESCRIPTION
## Summary

Bundles 6 open Dependabot PRs into a single approval. Each commit corresponds to one Dependabot bump.

## Bumps

- `step-security/harden-runner` 2.11.0 → 2.11.1 (supersedes #95)
- `anthropics/claude-code-action` 1.0.78 → 1.0.110 (supersedes #113)
- `postcss` 8.5.6 → 8.5.10 in `packages/auth-ui` (supersedes #117)
- `next` 16.0.7 → 16.1.7 in `examples/nextjs-neon-auth` (supersedes #55)
- `next` 16.0.7 → 16.1.7 in `examples/nextjs-admin-portal` (supersedes #56)
- `next` 16.1.6 → 16.1.7 in `examples/neon-auth-orgs-example` (supersedes #60)

## Skipped Dependabot PRs (closed separately)

- #54 — `next 16.0.6→16.1.7` in `packages/auth`: obsolete, main already past target.
- #97 — `better-auth 1.4.18→1.4.22`: deliberately pinned at 1.4.18 to sync with neon-cloud/neon-auth (#126).
- #102 — `postcss` root: duplicate of #117.

## Test plan

- [x] `pnpm install` regenerates lockfile cleanly
- [x] `pnpm --filter @neondatabase/neon-js typecheck` passes
- [x] `pnpm --filter @neondatabase/auth typecheck` passes
- [x] `pnpm --filter @neondatabase/auth-ui typecheck` passes
- [ ] Reviewer: confirm CI greens up across all examples

Refs: #0000

This pull request and its description were written by Isaac.