### PR TITLE
feat(auth): configurable SameSite for Next.js proxy cookies

### DIFF
--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Next.js cookie SameSite**: Proxied `Set-Cookie` headers and minted `session_data` cookies now use `SameSite=Strict` by default (previously forced to `Lax`). Set `cookies.sameSite` to `'lax'` or `'none'` when you need the previous behavior or third-party iframe embedding (`'none'` requires `Secure`, which these cookies already set).
+
 ### Deprecated
 
 - UI exports from `@neondatabase/auth/react`, `@neondatabase/auth/react/ui`, `@neondatabase/auth/react/ui/server`, `@neondatabase/auth/ui/css`, and `@neondatabase/auth/ui/tailwind` are deprecated. Install `@neondatabase/auth-ui` and import UI components, server helpers, and styles directly from that package instead. These compatibility exports will be removed in the next major version.

--- a/packages/auth/src/next/server/handler.ts
+++ b/packages/auth/src/next/server/handler.ts
@@ -49,6 +49,7 @@ export function authApiHandler(config: NeonAuthConfig) {
       cookieSecret: cookies.secret,
       sessionDataTtl: cookies.sessionDataTtl,
       domain: cookies.domain,
+      sameSite: cookies.sameSite,
     });
   };
 

--- a/packages/auth/src/next/server/index.test.ts
+++ b/packages/auth/src/next/server/index.test.ts
@@ -91,6 +91,12 @@ describe('config validation', () => {
 
     expect(() => createNeonAuth(config)).not.toThrow();
   });
+
+  test.each(['strict', 'lax', 'none'] as const)('accepts cookies.sameSite=%s', (sameSite) => {
+    const config = createAuthConfig({ sameSite });
+
+    expect(() => createNeonAuth(config)).not.toThrow();
+  });
 });
 
 describe('return value structure', () => {

--- a/packages/auth/src/next/server/index.ts
+++ b/packages/auth/src/next/server/index.ts
@@ -121,6 +121,7 @@ export function createNeonAuth(config: NeonAuthConfig) {
 		cookieSecret: cookies.secret,
 		sessionDataTtl: cookies.sessionDataTtl,
 		domain: cookies.domain,
+		sameSite: cookies.sameSite,
 	});
 
 	// Attach handler and middleware directly to the server proxy object

--- a/packages/auth/src/next/server/middleware.ts
+++ b/packages/auth/src/next/server/middleware.ts
@@ -56,6 +56,7 @@ export function neonAuthMiddleware(config: NeonAuthMiddlewareConfig) {
       cookieSecret: cookies.secret,
       sessionDataTtl: cookies.sessionDataTtl,
       domain: cookies.domain,
+      sameSite: cookies.sameSite,
     });
 
     switch (result.action) {

--- a/packages/auth/src/server/client-factory.ts
+++ b/packages/auth/src/server/client-factory.ts
@@ -1,4 +1,5 @@
 import type { NeonAuthServer } from './types';
+import type { SessionCookieSameSite } from './config';
 import {
   NEON_AUTH_SERVER_PROXY_HEADER,
   type RequestContextFactory,
@@ -20,12 +21,14 @@ export interface NeonAuthServerConfig {
   cookieSecret: string;
   sessionDataTtl?: number;
   domain?: string;
+  sameSite?: SessionCookieSameSite;
 }
 
 export function createAuthServerInternal(
   config: NeonAuthServerConfig
 ): NeonAuthServer {
-  const { baseUrl, context: getContext, cookieSecret, sessionDataTtl, domain } = config;
+  const { baseUrl, context: getContext, cookieSecret, sessionDataTtl, domain, sameSite } = config;
+  const effectiveSameSite = sameSite ?? 'strict';
 
   const fetchWithAuth = async (
     path: string,
@@ -82,7 +85,7 @@ export function createAuthServerInternal(
             ...cookie,
             domain: domain,
             partitioned: undefined,
-            sameSite: 'lax' as const,
+            sameSite: effectiveSameSite,
           };
           await ctx.setCookie(cookie.name, cookie.value, cookieOptions);
         }
@@ -97,6 +100,7 @@ export function createAuthServerInternal(
             secret: cookieSecret,
             sessionDataTtl,
             domain,
+            sameSite,
           }
         );
 

--- a/packages/auth/src/server/config.ts
+++ b/packages/auth/src/server/config.ts
@@ -4,6 +4,9 @@
 
 import { ERRORS } from "./errors";
 
+/** Allowed values for the `SameSite` attribute on Neon Auth cookies. */
+export type SessionCookieSameSite = 'strict' | 'lax' | 'none';
+
 /**
  * Session cookie configuration
  */
@@ -41,6 +44,17 @@ export interface SessionCookieConfig {
 	 * @example '.example.com' // Share across subdomains
 	 */
 	domain?: string;
+
+	/**
+	 * `SameSite` for cookies set or rewritten by the server proxy (API route, middleware, RSC).
+	 *
+	 * - **`strict` (default)** — cookies are not sent on cross-site requests (strongest default).
+	 * - **`lax`** — previous hard-coded behavior; cookies sent on top-level cross-site navigations.
+	 * - **`none`** — use for third-party contexts (for example your app embedded in another site’s iframe); requires `Secure` (always applied for these cookies).
+	 *
+	 * @default 'strict'
+	 */
+	sameSite?: SessionCookieSameSite;
 }
 
 /**

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -5,5 +5,6 @@ export { parseSessionData, validateSessionData } from './session';
 
 export {
 	type NeonAuthConfig,
-	type NeonAuthMiddlewareConfig
+	type NeonAuthMiddlewareConfig,
+	type SessionCookieSameSite,
 } from './config';

--- a/packages/auth/src/server/middleware/oauth.ts
+++ b/packages/auth/src/server/middleware/oauth.ts
@@ -2,6 +2,7 @@ import { NEON_AUTH_SESSION_VERIFIER_PARAM_NAME } from '@/core/constants';
 import { NEON_AUTH_SESSION_CHALLENGE_COOKIE_NAME } from '../constants';
 import { handleAuthRequest, handleAuthResponse } from '../proxy';
 import { parseCookies } from 'better-auth/cookies';
+import type { SessionCookieSameSite } from '../config';
 
 /**
  * Result of OAuth token exchange
@@ -54,7 +55,8 @@ export async function exchangeOAuthToken(
   baseUrl: string,
   cookieSecret: string,
   sessionDataTtl?: number,
-  domain?: string
+  domain?: string,
+  sameSite?: SessionCookieSameSite
 ): Promise<OAuthExchangeResult | null> {
   const url = new URL(request.url);
   const verifier = url.searchParams.get(NEON_AUTH_SESSION_VERIFIER_PARAM_NAME);
@@ -87,6 +89,7 @@ export async function exchangeOAuthToken(
     secret: cookieSecret,
     sessionDataTtl,
     domain,
+    sameSite,
   });
 
   if (response.ok) {

--- a/packages/auth/src/server/middleware/processor.test.ts
+++ b/packages/auth/src/server/middleware/processor.test.ts
@@ -138,6 +138,7 @@ describe('processAuthMiddleware', () => {
         cookieSecret: TEST_SECRET,
         sessionDataTtl: undefined,
         domain: undefined,
+        sameSite: undefined,
       });
     });
 

--- a/packages/auth/src/server/middleware/processor.ts
+++ b/packages/auth/src/server/middleware/processor.ts
@@ -6,6 +6,7 @@ import { NEON_AUTH_SESSION_COOKIE_NAME, NEON_AUTH_SESSION_DATA_COOKIE_NAME } fro
 import type { SessionData } from '../types';
 import { parseCookies } from 'better-auth/cookies';
 import { serializeSetCookie } from '../utils/cookies';
+import type { SessionCookieSameSite } from '../config';
 
 /**
  * Result of middleware processing (framework-agnostic decision)
@@ -32,6 +33,8 @@ export interface AuthMiddlewareConfig {
 	sessionDataTtl?: number;
 	/** Cookie domain for session data cookie */
 	domain?: string;
+	/** SameSite for cookies set by middleware (default: strict) */
+	sameSite?: SessionCookieSameSite;
 }
 
 /**
@@ -62,7 +65,10 @@ export async function processAuthMiddleware(
 		cookieSecret,
 		sessionDataTtl,
 		domain,
+		sameSite,
 	} = config;
+
+	const effectiveSameSite = sameSite ?? 'strict';
 
 	// Always skip session check for login URL to prevent infinite redirect loop
 	if (pathname.startsWith(loginUrl)) {
@@ -78,7 +84,8 @@ export async function processAuthMiddleware(
 			baseUrl,
 			cookieSecret,
 			sessionDataTtl,
-			domain
+			domain,
+			sameSite
 		);
 		if (exchangeResult !== null) {
 			// OAuth exchange successful - redirect with session cookies
@@ -112,6 +119,7 @@ export async function processAuthMiddleware(
 			cookieSecret,
 			sessionDataTtl,
 			domain,
+			sameSite,
 		});
 
 		// Parse session data from response
@@ -151,7 +159,7 @@ export async function processAuthMiddleware(
 			domain,
 			httpOnly: true,
 			secure: true,
-			sameSite: 'lax',
+			sameSite: effectiveSameSite,
 			maxAge: 0,
 		}));
 	}

--- a/packages/auth/src/server/proxy/handler.test.ts
+++ b/packages/auth/src/server/proxy/handler.test.ts
@@ -45,6 +45,7 @@ describe('handleAuthProxyRequest', () => {
         secret: TEST_SECRET,
         sessionDataTtl: undefined,
         domain: undefined,
+        sameSite: undefined,
       });
       expect(result).toBe(cachedResponse);
       // Should NOT call upstream on cache hit
@@ -162,6 +163,7 @@ describe('handleAuthProxyRequest', () => {
         secret: TEST_SECRET,
         sessionDataTtl: 600,
         domain: '.example.com',
+        sameSite: undefined,
       });
     });
 
@@ -258,6 +260,7 @@ describe('handleAuthProxyRequest', () => {
         secret: TEST_SECRET,
         sessionDataTtl: undefined,
         domain: undefined,
+        sameSite: undefined,
       });
     });
   });

--- a/packages/auth/src/server/proxy/handler.ts
+++ b/packages/auth/src/server/proxy/handler.ts
@@ -2,6 +2,7 @@ import { trySessionCache } from '../session/cache-handler';
 import { handleAuthRequest } from './request';
 import { handleAuthResponse } from './response';
 import { API_ENDPOINTS } from '../endpoints';
+import type { SessionCookieSameSite } from '../config';
 
 export interface AuthProxyConfig {
 	/** Standard Web API Request object */
@@ -16,6 +17,8 @@ export interface AuthProxyConfig {
 	sessionDataTtl?: number;
 	/** Cookie domain for session data cookie */
 	domain?: string;
+	/** SameSite for proxied and minted cookies (default: strict) */
+	sameSite?: SessionCookieSameSite;
 }
 
 /**
@@ -33,7 +36,7 @@ export interface AuthProxyConfig {
  * @returns Standard Web API Response
  */
 export async function handleAuthProxyRequest(config: AuthProxyConfig): Promise<Response> {
-	const { request, path, baseUrl, cookieSecret, sessionDataTtl, domain } = config;
+	const { request, path, baseUrl, cookieSecret, sessionDataTtl, domain, sameSite } = config;
 
 	// Try cookie cache for /get-session GET requests (optimization)
 	if (
@@ -44,6 +47,7 @@ export async function handleAuthProxyRequest(config: AuthProxyConfig): Promise<R
 			secret: cookieSecret,
 			sessionDataTtl,
 			domain,
+			sameSite,
 		});
 		if (cachedResponse) {
 			// Cache hit - return immediately (no upstream call)
@@ -57,5 +61,6 @@ export async function handleAuthProxyRequest(config: AuthProxyConfig): Promise<R
 		secret: cookieSecret,
 		sessionDataTtl,
 		domain,
+		sameSite,
 	});
 }

--- a/packages/auth/src/server/proxy/response.test.ts
+++ b/packages/auth/src/server/proxy/response.test.ts
@@ -41,7 +41,7 @@ describe('handleAuthResponse – cookie sanitization', () => {
     expect(cookies[0]).not.toContain('Partitioned');
   });
 
-  test('replaces SameSite=None with SameSite=Lax', async () => {
+  test('replaces SameSite=None with SameSite=Strict by default', async () => {
     const upstream = upstreamResponse([
       '__Secure-neon-auth.session_challange=abc; Path=/; Secure; SameSite=None; Partitioned',
     ]);
@@ -49,23 +49,38 @@ describe('handleAuthResponse – cookie sanitization', () => {
     const result = await handleAuthResponse(upstream, BASE_URL, COOKIE_CONFIG);
 
     const cookies = result.headers.getSetCookie();
+    expect(cookies[0]).toContain('SameSite=Strict');
+    expect(cookies[0]).not.toContain('SameSite=None');
+  });
+
+  test('uses cookies.sameSite=lax when configured', async () => {
+    const upstream = upstreamResponse([
+      '__Secure-neon-auth.session_challange=abc; Path=/; Secure; SameSite=None; Partitioned',
+    ]);
+
+    const result = await handleAuthResponse(upstream, BASE_URL, {
+      ...COOKIE_CONFIG,
+      sameSite: 'lax',
+    });
+
+    const cookies = result.headers.getSetCookie();
     expect(cookies[0]).toContain('SameSite=Lax');
     expect(cookies[0]).not.toContain('SameSite=None');
   });
 
-  test('forces SameSite=Lax overriding upstream SameSite=Strict', async () => {
+  test('applies configured SameSite overriding upstream', async () => {
     const upstream = upstreamResponse([
-      '__Secure-neon-auth.session_challange=abc; Path=/; Secure; SameSite=Strict',
+      '__Secure-neon-auth.session_challange=abc; Path=/; Secure; SameSite=Lax',
     ]);
 
     const result = await handleAuthResponse(upstream, BASE_URL, COOKIE_CONFIG);
 
     const cookies = result.headers.getSetCookie();
-    expect(cookies[0]).toContain('SameSite=Lax');
-    expect(cookies[0]).not.toContain('SameSite=Strict');
+    expect(cookies[0]).toContain('SameSite=Strict');
+    expect(cookies[0]).not.toContain('SameSite=Lax');
   });
 
-  test('sets SameSite=Lax when upstream omits SameSite (parser default)', async () => {
+  test('sets SameSite=Strict when upstream omits SameSite (integration default)', async () => {
     const upstream = upstreamResponse([
       '__Secure-neon-auth.session_challange=xyz; Path=/; HttpOnly; Secure',
     ]);
@@ -73,7 +88,7 @@ describe('handleAuthResponse – cookie sanitization', () => {
     const result = await handleAuthResponse(upstream, BASE_URL, COOKIE_CONFIG);
 
     const cookies = result.headers.getSetCookie();
-    expect(cookies[0]).toContain('SameSite=Lax');
+    expect(cookies[0]).toContain('SameSite=Strict');
   });
 
   test('preserves other cookie attributes (HttpOnly, Secure, Path, Max-Age)', async () => {
@@ -128,7 +143,7 @@ describe('handleAuthResponse – multiple cookies', () => {
     expect(cookies).toHaveLength(2);
     for (const cookie of cookies) {
       expect(cookie).not.toContain('Partitioned');
-      expect(cookie).toContain('SameSite=Lax');
+      expect(cookie).toContain('SameSite=Strict');
     }
   });
 });

--- a/packages/auth/src/server/proxy/response.ts
+++ b/packages/auth/src/server/proxy/response.ts
@@ -22,7 +22,7 @@ export const handleAuthResponse = async (
   baseUrl: string,
   cookieConfig: SessionCookieConfig
 ) => {
-  const responseHeaders = prepareResponseHeaders(response, cookieConfig.domain);
+  const responseHeaders = prepareResponseHeaders(response, cookieConfig);
 
   // Mint session data cookie from upstream response
   const sessionDataCookie = await mintSessionDataFromResponse(response.headers, baseUrl, cookieConfig);
@@ -37,8 +37,10 @@ export const handleAuthResponse = async (
   })
 }
 
-const prepareResponseHeaders = (response: Response, domain?: string) => {
+const prepareResponseHeaders = (response: Response, cookieConfig: SessionCookieConfig) => {
   const headers = new Headers();
+  const effectiveSameSite = cookieConfig.sameSite ?? 'strict';
+  const { domain } = cookieConfig;
   for (const header of RESPONSE_HEADERS_ALLOWLIST) {
     // Special handling for set-cookie: HTTP allows multiple Set-Cookie headers
     if (header === 'set-cookie') {
@@ -48,14 +50,12 @@ const prepareResponseHeaders = (response: Response, domain?: string) => {
         // - Strip Partitioned: Safari does not send Partitioned cookies on top-level navigations,
         //   which breaks the OAuth challenge exchange when the callback hits a middleware route.
         //   The flag is also only meaningful for third-party contexts; proxied cookies are first-party.
-        // - Force SameSite=Lax: upstream sends SameSite=None (required alongside Partitioned).
-        //   Lax is correct for first-party cookies and safe for cross-subdomain use — subdomains
-        //   share the same registrable domain (eTLD+1) and are considered same-site by browsers.
-        // Domain assignment is the only conditional step.
+        // - Apply configured SameSite (default strict): upstream may send SameSite=None with Partitioned.
+        // Domain assignment is the only other conditional step.
         const parsedCookies = parseSetCookies(cookieHeader);
         for (const parsedCookie of parsedCookies) {
           parsedCookie.partitioned = undefined;
-          parsedCookie.sameSite = 'lax';
+          parsedCookie.sameSite = effectiveSameSite;
           if (domain) {
             parsedCookie.domain = domain;
           }

--- a/packages/auth/src/server/session/minting.ts
+++ b/packages/auth/src/server/session/minting.ts
@@ -43,7 +43,7 @@ async function mintSessionDataCookie(
       domain: cookieConfig.domain,
       httpOnly: true,
       secure: true,
-      sameSite: 'lax',
+      sameSite: cookieConfig.sameSite ?? 'strict',
       maxAge,
     });
   } catch (error) {
@@ -97,7 +97,7 @@ export async function mintSessionDataFromResponse(
       domain: cookieConfig.domain,
       httpOnly: true,
       secure: true,
-      sameSite: 'lax',
+      sameSite: cookieConfig.sameSite ?? 'strict',
       maxAge: 0,
     });
   }


### PR DESCRIPTION
## Summary

Adds `cookies.sameSite` to `createNeonAuth` / `NeonAuthConfig` (`'strict' | 'lax' | 'none'`), defaulting to **`'strict'`** when omitted.

The Next.js auth proxy previously forced `SameSite=Lax` on every rewritten `Set-Cookie` and on minted `session_data` / server `setCookie` paths. That is now driven by config so apps can opt into `'lax'` (legacy behavior) or `'none'` (e.g. third-party iframe embedding, with `Secure` already applied).

## Changes

- `SessionCookieConfig.sameSite` + exported `SessionCookieSameSite` from `@neondatabase/auth` server exports
- Proxy response sanitization, `handleAuthProxyRequest`, session minting, `createAuthServerInternal`, OAuth exchange, and middleware stale-cookie clearing all respect the same setting

## Testing

`pnpm --filter '@neondatabase/auth' run test:node` (146 tests)

## Notes

- Cross-site iframe scenarios typically need `sameSite: 'none'`, not `lax` or `strict`.
- `CHANGELOG.md` updated under `[Unreleased]`.