### PR TITLE
feat(examples): add iframe-test page to nextjs-neon-auth example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -787,11 +787,13 @@ The `skills/` directory contains AI-assistant skills for helping developers set 
 
 - Neon Auth Next.js/server observability: **opt-out** defaults (`warn` to `console`); apps can set **`logLevel: 'silent'`** on `createNeonAuth` to mute or inject a custom **`logger`**.
 - When adding SDK-facing observability or debugging aids, update the package changelog and show usage in an example app when it helps adopters.
+- Prefer **`logger`** + **`logLevel`** as the only controls for server/proxy logging—avoid separate boolean or feature flags solely to toggle logs.
 
 ## Learned Workspace Facts
 
 - `createNeonAuth` accepts optional **`logger`** and **`logLevel`** (including **`'silent'`** via `resolveNeonAuthLogging`); related types are re-exported from `@neondatabase/auth/next/server`.
 - The auth **proxy** (`packages/auth/src/server/proxy/request.ts`) logs structured warn/debug lines for upstream fetch outcomes and uses **`classifyFetchFailure`** / `packages/auth/src/server/network-error.ts` for transport vs HTTP error taxonomy returned to clients.
+- **`examples/nextjs-neon-auth/app/iframe-test/page.tsx`** is the App Router counterpart to iframe-hosted OAuth/popup testing in **`examples/react-neon-js/`**.
 
 ## References
 

--- a/examples/nextjs-neon-auth/README.md
+++ b/examples/nextjs-neon-auth/README.md
@@ -28,6 +28,28 @@ bun run dev
 
 5. Open [http://localhost:3000](http://localhost:3000) to see the app.
 
+## Demos
+
+- **`/`** – Marketing landing page
+- **`/auth/sign-in`**, **`/auth/sign-up`** – Auth UI views (powered by `@neondatabase/auth/react/ui`)
+- **`/dashboard`**, **`/notes`**, **`/account/*`** – Protected routes that require a session
+- **`/iframe-test`** – Embeds the auth views in a same-origin iframe to verify that
+  email/password and **OAuth (popup) flows work inside an iframe**
+
+### Iframe / embedded auth
+
+`@neondatabase/auth` automatically detects when your app is rendered inside an
+`<iframe>` (via `globalThis.self !== globalThis.top`). When a user clicks a
+social/SSO button from inside an iframe, the SDK opens the OAuth provider in a
+popup window instead of attempting a top-level redirect (which OAuth providers
+block via `X-Frame-Options` / CSP). After the OAuth callback completes, the
+popup posts the session verifier back to the parent iframe via `postMessage`,
+which finalises the session in the embedded context.
+
+Visit `/iframe-test` to try this flow end-to-end. The same code paths apply
+when this Next.js app is embedded as an iframe inside any third-party host
+(embedded apps, widgets, multi-tenant platforms).
+
 ## Learn More
 
 - [Neon Auth Documentation](https://neon.tech/docs/guides/neon-auth)

--- a/examples/nextjs-neon-auth/app/iframe-test/page.tsx
+++ b/examples/nextjs-neon-auth/app/iframe-test/page.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+
+const TEST_ROUTES = [
+    { label: "Sign In", path: "/auth/sign-in" },
+    { label: "Sign Up", path: "/auth/sign-up" },
+    { label: "Forgot Password", path: "/auth/forgot-password" },
+] as const
+
+export default function IframeTestPage() {
+    const [iframeSrc, setIframeSrc] = useState<string>("/auth/sign-in")
+
+    return (
+        <main className="container mx-auto max-w-5xl px-4 py-8 md:px-6 md:py-12">
+            <div className="mb-6">
+                <h1 className="text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+                    SSO in iframe Test
+                </h1>
+                <p className="mt-2 text-muted-foreground">
+                    This page embeds the auth flow in an iframe to test SSO functionality
+                    inside a Next.js app.
+                </p>
+
+                <div className="mt-5 flex gap-4 rounded-lg border border-primary/30 bg-gradient-to-br from-primary/10 to-primary/5 p-4">
+                    <span className="text-2xl leading-none">✨</span>
+                    <div>
+                        <p className="text-sm font-semibold text-foreground">
+                            <a
+                                href="https://www.npmjs.com/package/@neondatabase/auth"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary hover:underline"
+                            >
+                                @neondatabase/auth
+                            </a>{" "}
+                            supports OAuth flows from within iframes
+                        </p>
+                        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                            Unlike many auth libraries that break when embedded, Neon Auth
+                            handles OAuth popups correctly even when your app runs inside an
+                            iframe — perfect for embedded apps, widgets, and multi-tenant
+                            platforms. The SDK detects the iframe context and automatically
+                            opens the OAuth provider in a popup, then completes the session
+                            in the iframe via{" "}
+                            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                                postMessage
+                            </code>
+                            .
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div className="mb-4 flex flex-wrap items-center gap-3">
+                <span className="text-sm text-muted-foreground">Test Route:</span>
+                {TEST_ROUTES.map((route) => (
+                    <Button
+                        key={route.path}
+                        size="sm"
+                        variant={iframeSrc === route.path ? "default" : "outline"}
+                        onClick={() => setIframeSrc(route.path)}
+                    >
+                        {route.label}
+                    </Button>
+                ))}
+            </div>
+
+            <div className="overflow-hidden rounded-lg border bg-card">
+                <div className="border-b bg-muted px-4 py-3">
+                    <span className="font-mono text-sm text-muted-foreground">
+                        iframe src: {iframeSrc}
+                    </span>
+                </div>
+                <iframe
+                    key={iframeSrc}
+                    src={iframeSrc}
+                    title="Auth iframe test"
+                    className="block h-[600px] w-full border-0"
+                    sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+                />
+            </div>
+
+            <div className="mt-6 rounded-lg border bg-muted/50 p-4">
+                <h3 className="mb-3 text-base font-semibold text-foreground">
+                    What to test:
+                </h3>
+                <ul className="list-disc space-y-1.5 pl-5 text-sm text-muted-foreground">
+                    <li>Click the Google (or any social) SSO button inside the iframe</li>
+                    <li>Verify the OAuth popup window opens correctly</li>
+                    <li>
+                        Complete the SSO flow in the popup and confirm the session is
+                        established back inside the iframe
+                    </li>
+                    <li>
+                        Check the browser console for any{" "}
+                        <code className="rounded bg-muted px-1 font-mono text-xs">
+                            X-Frame-Options
+                        </code>{" "}
+                        / CSP errors (there should be none)
+                    </li>
+                    <li>
+                        Email/password and magic-link flows should also work normally
+                        without any popup
+                    </li>
+                </ul>
+            </div>
+        </main>
+    )
+}

--- a/examples/nextjs-neon-auth/components/header.tsx
+++ b/examples/nextjs-neon-auth/components/header.tsx
@@ -34,6 +34,13 @@ export function Header() {
                     </svg>
                     <span className="hidden sm:inline font-semibold">Notely</span>
                 </Link>
+                <nav className="flex items-center gap-1">
+                    <Link href="/iframe-test">
+                        <Button variant="ghost" size="sm">
+                            Iframe Test
+                        </Button>
+                    </Link>
+                </nav>
                 <SignedIn>
                     <nav className="flex items-center gap-1">
                         <Link href="/dashboard">


### PR DESCRIPTION
## Summary

- Adds **`/iframe-test`** to the `nextjs-neon-auth` example, mirroring the existing iframe demo in `examples/react-neon-js/`. The page embeds the auth views in a same-origin `<iframe>` so you can verify that email/password and **OAuth (popup) flows work inside an iframe** in a Next.js App Router app.
- Adds an "Iframe Test" link to the example header (visible signed-out so anyone can reach the demo without an account).
- Documents the iframe/popup mechanism in `examples/nextjs-neon-auth/README.md` so adopters embedding their app inside an iframe (widgets, multi-tenant hosts, embedded apps) know what to expect from `@neondatabase/auth`.
- Records the new page as a workspace fact in `CLAUDE.md` next to its React counterpart.

### How the iframe popup flow works

`@neondatabase/auth` detects iframe context (`globalThis.self !== globalThis.top`). When a social/SSO button is clicked from inside an iframe, the SDK opens the OAuth provider in a popup window instead of a top-level redirect (which OAuth providers block via `X-Frame-Options` / CSP). After the OAuth callback completes, the popup posts the session verifier back to the parent iframe via `postMessage`, finalising the session in the embedded context.

This logic lives in `packages/auth/src/core/better-auth-methods.ts` and `packages/auth/src/core/oauth-popup.ts`; this PR only adds an example surface to exercise it from a Next.js app.

## Test plan

- [ ] `cd examples/nextjs-neon-auth && pnpm install && pnpm dev`
- [ ] Visit `http://localhost:3000/iframe-test`
- [ ] Switch between "Sign In" / "Sign Up" / "Forgot Password" route buttons; the iframe re-renders correctly
- [ ] Click a Google (or other social) SSO button **inside the iframe**; the OAuth popup opens, completes, closes, and the iframe shows a signed-in session
- [ ] Email/password sign-in inside the iframe completes without opening any popup
- [ ] Browser console shows no `X-Frame-Options` / CSP errors