### PR TITLE
feat(examples): add cross-origin host toggle to iframe-test page

### DIFF
--- a/examples/nextjs-neon-auth/app/iframe-test/page.tsx
+++ b/examples/nextjs-neon-auth/app/iframe-test/page.tsx
@@ -10,8 +10,23 @@ const TEST_ROUTES = [
     { label: "Forgot Password", path: "/auth/forgot-password" },
 ] as const
 
+const HOSTS = [
+    { id: "local", label: "Local (same-origin)", baseUrl: "" },
+    {
+        id: "deployed",
+        label: "Deployed (cross-origin)",
+        baseUrl: "https://neon-auth-nextjs-demo.vercel.app",
+    },
+] as const
+
+type HostId = (typeof HOSTS)[number]["id"]
+
 export default function IframeTestPage() {
-    const [iframeSrc, setIframeSrc] = useState<string>("/auth/sign-in")
+    const [hostId, setHostId] = useState<HostId>("local")
+    const [routePath, setRoutePath] = useState<string>("/auth/sign-in")
+
+    const host = HOSTS.find((h) => h.id === hostId) ?? HOSTS[0]
+    const iframeSrc = `${host.baseUrl}${routePath}`
 
     return (
         <main className="container mx-auto max-w-5xl px-4 py-8 md:px-6 md:py-12">
@@ -54,14 +69,28 @@ export default function IframeTestPage() {
                 </div>
             </div>
 
+            <div className="mb-3 flex flex-wrap items-center gap-3">
+                <span className="text-sm text-muted-foreground">Host:</span>
+                {HOSTS.map((h) => (
+                    <Button
+                        key={h.id}
+                        size="sm"
+                        variant={hostId === h.id ? "default" : "outline"}
+                        onClick={() => setHostId(h.id)}
+                    >
+                        {h.label}
+                    </Button>
+                ))}
+            </div>
+
             <div className="mb-4 flex flex-wrap items-center gap-3">
                 <span className="text-sm text-muted-foreground">Test Route:</span>
                 {TEST_ROUTES.map((route) => (
                     <Button
                         key={route.path}
                         size="sm"
-                        variant={iframeSrc === route.path ? "default" : "outline"}
-                        onClick={() => setIframeSrc(route.path)}
+                        variant={routePath === route.path ? "default" : "outline"}
+                        onClick={() => setRoutePath(route.path)}
                     >
                         {route.label}
                     </Button>
@@ -88,6 +117,13 @@ export default function IframeTestPage() {
                     What to test:
                 </h3>
                 <ul className="list-disc space-y-1.5 pl-5 text-sm text-muted-foreground">
+                    <li>
+                        Try both <strong>Local (same-origin)</strong> and{" "}
+                        <strong>Deployed (cross-origin)</strong> hosts. The
+                        cross-origin case mirrors a real embedded scenario where your
+                        Next.js app is hosted on a different domain than the parent
+                        page (e.g. embedded apps, widgets, multi-tenant platforms).
+                    </li>
                     <li>Click the Google (or any social) SSO button inside the iframe</li>
                     <li>Verify the OAuth popup window opens correctly</li>
                     <li>
@@ -99,11 +135,28 @@ export default function IframeTestPage() {
                         <code className="rounded bg-muted px-1 font-mono text-xs">
                             X-Frame-Options
                         </code>{" "}
-                        / CSP errors (there should be none)
+                        / CSP errors (there should be none — the deployed app at{" "}
+                        <code className="rounded bg-muted px-1 font-mono text-xs">
+                            neon-auth-nextjs-demo.vercel.app
+                        </code>{" "}
+                        explicitly allows being framed)
                     </li>
                     <li>
                         Email/password and magic-link flows should also work normally
                         without any popup
+                    </li>
+                    <li>
+                        Note: in the cross-origin case the iframe&rsquo;s cookies are
+                        treated as third-party — modern browsers may require
+                        <code className="rounded bg-muted px-1 font-mono text-xs">
+                            SameSite=None; Secure; Partitioned
+                        </code>{" "}
+                        cookies (already configured in{" "}
+                        <code className="rounded bg-muted px-1 font-mono text-xs">
+                            @neondatabase/auth
+                        </code>
+                        ) and you may need to allow third-party cookies for the
+                        embedded origin.
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary

Follow-up to #135. Adds a **Host** selector to `/iframe-test` so the embedded `src` can switch between:

- **Local (same-origin)** — embeds `localhost:3000`, the same app rendering the page (covers same-origin embedding)
- **Deployed (cross-origin)** — embeds [`https://neon-auth-nextjs-demo.vercel.app`](https://neon-auth-nextjs-demo.vercel.app), so the parent page and the embedded auth app live on different domains

The cross-origin case is the more realistic embedded scenario — widgets, multi-tenant platforms, partner integrations, customer-facing dashboards, etc. — where most "auth in iframe" things break in subtle ways. This lets the example exercise both code paths from a single dev server.

The deployed app at `neon-auth-nextjs-demo.vercel.app` does not set `X-Frame-Options` or a `frame-ancestors` CSP (verified via `curl -I`), so it embeds cleanly. `@neondatabase/auth` already sets `SameSite=None; Secure; Partitioned` proxy cookies (#132), which is what's needed for the iframe's session cookies to survive the third-party context.

The "What to test" notes are expanded to call out the third-party cookie behaviour explicitly so adopters know what browser policies are at play.

## Test plan

- [ ] `cd examples/nextjs-neon-auth && pnpm dev`
- [ ] Visit `http://localhost:3000/iframe-test`
- [ ] **Local host**: Sign in with email/password and with Google SSO; confirm the iframe ends up signed-in and no popup is left dangling
- [ ] **Deployed host**: switch to "Deployed (cross-origin)"; the iframe should render the deployed sign-in form
- [ ] Sign in with email/password against the deployed app inside the iframe; cookies should be set on `vercel.app` (Application → Cookies in DevTools)
- [ ] Sign in with Google SSO against the deployed app inside the iframe; the popup opens on `vercel.app`, completes, closes, and the iframe shows the signed-in state
- [ ] Browser console shows no `X-Frame-Options` / CSP errors for either host