### PR TITLE
docs(auth): fix authApiHandler JSDoc catch-all segment name

### DIFF
--- a/packages/auth/src/next/server/handler.ts
+++ b/packages/auth/src/next/server/handler.ts
@@ -17,11 +17,11 @@ type Params = { path: string[] };
  * @throws Error if `cookies.secret` is less than 32 characters
  *
  * @example
- * Mount the `authApiHandler` to an API route. Create a route file inside `/api/auth/[...all]/route.ts` directory.
+ * Mount the `authApiHandler` to an API route. Create a route file inside `/api/auth/[...path]/route.ts` directory.
  * And add the following code:
  *
  * ```ts
- * // app/api/auth/[...all]/route.ts
+ * // app/api/auth/[...path]/route.ts
  * import { authApiHandler } from '@neondatabase/auth/next';
  *
  * export const { GET, POST } = authApiHandler({


### PR DESCRIPTION
The JSDoc said to create the route at `app/api/auth/[...all]/route.ts`, but the handler reads `params.path.join('/')` — following the doc as written causes a runtime crash because `params.path` is undefined.

Align with `createNeonAuth` JSDoc, `llms.txt`, and the examples, which all use `[...path]`.