### PR TITLE
fix(examples): use auth-ui imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,16 +38,16 @@ Authentication adapters for Neon Auth supporting multiple auth providers:
 **Exports:**
 - `@neondatabase/auth` - Main exports (createAuthClient, types)
 - `@neondatabase/auth/react` - React adapter exports
-- `@neondatabase/auth/react/ui` - Re-exports from auth-ui
-- `@neondatabase/auth/react/ui/server` - Server-side utilities
+- `@neondatabase/auth-ui` - Preferred UI components package
+- `@neondatabase/auth-ui/server` - Preferred UI server utilities
 - `@neondatabase/auth/react/adapters` - BetterAuthReactAdapter
 - `@neondatabase/auth/vanilla` - Vanilla adapter exports
 - `@neondatabase/auth/vanilla/adapters` - SupabaseAuthAdapter, BetterAuthVanillaAdapter
 - `@neondatabase/auth/next` - Next.js integration (createAuthClient for client-side)
 - `@neondatabase/auth/next/server` - Next.js server integration (createNeonAuth for server-side)
 - `@neondatabase/auth/types` - Better Auth types (Session, User, Organization, etc.)
-- `@neondatabase/auth/ui/css` - Pre-built CSS
-- `@neondatabase/auth/ui/tailwind` - Tailwind CSS
+- `@neondatabase/auth-ui/css` - Pre-built CSS bundle
+- `@neondatabase/auth-ui/tailwind` - Tailwind-ready CSS
 
 ### `@neondatabase/neon-js` (packages/neon-js/)
 Main SDK package that combines authentication with PostgreSQL querying:
@@ -91,7 +91,7 @@ UI components for Neon Auth built on top of [better-auth-ui](https://better-auth
 - `@neondatabase/auth-ui/tailwind` - Tailwind-ready CSS
 - `@neondatabase/auth-ui/server` - Server-side utilities
 
-**Note:** CSS is also re-exported from `@neondatabase/auth/ui/css` and `@neondatabase/auth/ui/tailwind` for convenience.
+**Note:** New examples should import UI components and styles directly from `@neondatabase/auth-ui`. Compatibility re-exports from `@neondatabase/auth` are deprecated.
 
 **Dependencies:**
 - `@neondatabase/auth` (peer dependency)
@@ -245,9 +245,9 @@ CSS is intentionally duplicated across packages for convenience imports:
 auth-ui (generates via Tailwind) → auth (copies) → neon-js (copies)
 ```
 
-**Why triplication?** Enables users to import CSS from whichever package they use:
+**Why triplication?** Preserves compatibility for older import paths while new code imports directly from auth-ui:
 - `@neondatabase/auth-ui/css` - Direct from source
-- `@neondatabase/auth/ui/css` - Convenience for auth-only users
+- Auth package CSS compatibility entrypoint - deprecated
 - `@neondatabase/neon-js/ui/css` - Convenience for full SDK users
 
 **End-user impact:** Minimal. npm deduplicates identical files during download. End users get ~47KB of CSS, not 141KB.
@@ -590,11 +590,11 @@ export default function AuthPage() {
 **CSS Import Options:**
 ```css
 /* Without Tailwind - import pre-built CSS */
-@import '@neondatabase/auth/ui/css';
+@import '@neondatabase/auth-ui/css';
 
 /* With Tailwind CSS v4 */
 @import 'tailwindcss';
-@import '@neondatabase/auth/ui/tailwind';
+@import '@neondatabase/auth-ui/tailwind';
 ```
 
 ## Adapter Features

--- a/examples/neon-auth-magic-link-example/README.md
+++ b/examples/neon-auth-magic-link-example/README.md
@@ -42,7 +42,7 @@ bun run dev
 ## How it works
 
 - **Landing page** (`/`) — single button to sign in
-- **Auth pages** (`/auth/*`) — handled by `@neondatabase/auth` UI components with `emailOTP` enabled
+- **Auth pages** (`/auth/*`) — use `@neondatabase/auth-ui` helpers with `emailOTP` enabled
 - **Dashboard** (`/dashboard`) — shows your email and session info after sign-in
 - **API route** (`/api/auth/*`) — proxies auth requests to Neon Auth
 

--- a/examples/neon-auth-magic-link-example/app/auth/[path]/page.tsx
+++ b/examples/neon-auth-magic-link-example/app/auth/[path]/page.tsx
@@ -1,5 +1,5 @@
 import { MagicLinkForm } from "@/components/magic-link-form";
-import { authViewPaths } from "@neondatabase/auth/react/ui/server";
+import { authViewPaths } from "@neondatabase/auth-ui/server";
 
 export const dynamicParams = false;
 

--- a/examples/neon-auth-magic-link-example/app/globals.css
+++ b/examples/neon-auth-magic-link-example/app/globals.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
-@import '@neondatabase/auth/ui/tailwind';
+@import '@neondatabase/auth-ui/tailwind';
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));

--- a/examples/neon-auth-magic-link-example/package.json
+++ b/examples/neon-auth-magic-link-example/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@neondatabase/auth": "workspace:*",
+    "@neondatabase/auth-ui": "workspace:*",
     "@neondatabase/serverless": "^1.0.2",
     "drizzle-kit": "^0.31.7",
     "drizzle-orm": "^0.45.0",

--- a/examples/neon-auth-magic-link-example/package.json
+++ b/examples/neon-auth-magic-link-example/package.json
@@ -11,6 +11,8 @@
     "db:push": "drizzle-kit push"
   },
   "dependencies": {
+    "@neondatabase/auth": "workspace:*",
+    "@neondatabase/auth-ui": "workspace:*",
     "@neondatabase/serverless": "^1.0.2",
     "drizzle-kit": "^0.31.7",
     "drizzle-orm": "^0.45.0",

--- a/examples/neon-auth-orgs-example/README.md
+++ b/examples/neon-auth-orgs-example/README.md
@@ -80,10 +80,10 @@ This is useful for **programmatic org provisioning** scenarios — for example, 
 ### Dependencies
 
 ```bash
-bun add @neondatabase/auth @neondatabase/serverless
+bun add @neondatabase/auth @neondatabase/auth-ui @neondatabase/serverless
 ```
 
-The auth package is `@neondatabase/auth` (used as a workspace dependency). The serverless driver (`@neondatabase/serverless`) is used for database access over HTTP.
+The auth package is `@neondatabase/auth` (used as a workspace dependency), UI components come from `@neondatabase/auth-ui`, and the serverless driver (`@neondatabase/serverless`) is used for database access over HTTP.
 
 ### Environment Variables
 
@@ -155,7 +155,7 @@ Unauthenticated users hitting `/dashboard/*` or `/account/*` are redirected to t
 In the root layout (`src/app/layout.tsx`), wrap the app with `NeonAuthUIProvider`:
 
 ```tsx
-import { NeonAuthUIProvider, UserButton } from "@neondatabase/auth/react";
+import { NeonAuthUIProvider, UserButton } from "@neondatabase/auth-ui";
 import { authClient } from "@/lib/auth/client";
 
 <NeonAuthUIProvider authClient={authClient} redirectTo="/dashboard" emailOTP>

--- a/examples/neon-auth-orgs-example/package.json
+++ b/examples/neon-auth-orgs-example/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@neondatabase/auth": "workspace:*",
+    "@neondatabase/auth-ui": "workspace:*",
     "@neondatabase/serverless": "^1.0.2",
     "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",

--- a/examples/neon-auth-orgs-example/src/app/account/[path]/page.tsx
+++ b/examples/neon-auth-orgs-example/src/app/account/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { AccountView } from "@neondatabase/auth/react";
-import { accountViewPaths } from "@neondatabase/auth/react/ui/server";
+import { AccountView } from "@neondatabase/auth-ui";
+import { accountViewPaths } from "@neondatabase/auth-ui/server";
 
 export const dynamicParams = false;
 

--- a/examples/neon-auth-orgs-example/src/app/auth/[path]/page.tsx
+++ b/examples/neon-auth-orgs-example/src/app/auth/[path]/page.tsx
@@ -1,4 +1,4 @@
-import { AuthView } from "@neondatabase/auth/react";
+import { AuthView } from "@neondatabase/auth-ui";
 
 export const dynamicParams = false;
 

--- a/examples/neon-auth-orgs-example/src/app/globals.css
+++ b/examples/neon-auth-orgs-example/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@neondatabase/auth/ui/tailwind";
+@import "@neondatabase/auth-ui/tailwind";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/examples/neon-auth-orgs-example/src/app/layout.tsx
+++ b/examples/neon-auth-orgs-example/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { NeonAuthUIProvider, UserButton } from "@neondatabase/auth/react";
+import { NeonAuthUIProvider, UserButton } from "@neondatabase/auth-ui";
 import { authClient } from "@/lib/auth/client";
 import { Toaster } from "@/components/ui/sonner";
 import { QueryProvider } from "@/components/query-provider";

--- a/examples/nextjs-neon-auth/README.md
+++ b/examples/nextjs-neon-auth/README.md
@@ -31,7 +31,7 @@ bun run dev
 ## Demos
 
 - **`/`** – Marketing landing page
-- **`/auth/sign-in`**, **`/auth/sign-up`** – Auth UI views (powered by `@neondatabase/auth/react/ui`)
+- **`/auth/sign-in`**, **`/auth/sign-up`** – Auth UI views (powered by `@neondatabase/auth-ui`)
 - **`/dashboard`**, **`/notes`**, **`/account/*`** – Protected routes that require a session
 - **`/iframe-test`** – Embeds the auth views in a same-origin iframe to verify that
   email/password and **OAuth (popup) flows work inside an iframe**

--- a/examples/nextjs-neon-auth/app/account/[path]/page.tsx
+++ b/examples/nextjs-neon-auth/app/account/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { AccountView } from '@neondatabase/auth/react/ui';
-import { accountViewPaths } from '@neondatabase/auth/react/ui/server';
+import { AccountView } from '@neondatabase/auth-ui';
+import { accountViewPaths } from '@neondatabase/auth-ui/server';
 
 export const dynamicParams = false;
 

--- a/examples/nextjs-neon-auth/app/auth/[path]/page.tsx
+++ b/examples/nextjs-neon-auth/app/auth/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { AuthView } from '@neondatabase/auth/react/ui';
-import { authViewPaths } from '@neondatabase/auth/react/ui/server';
+import { AuthView } from '@neondatabase/auth-ui';
+import { authViewPaths } from '@neondatabase/auth-ui/server';
 import Link from 'next/link';
 
 export const dynamicParams = false;

--- a/examples/nextjs-neon-auth/app/globals.css
+++ b/examples/nextjs-neon-auth/app/globals.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
-@import '@neondatabase/auth/ui/tailwind';
+@import '@neondatabase/auth-ui/tailwind';
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));

--- a/examples/nextjs-neon-auth/app/organization/[path]/page.tsx
+++ b/examples/nextjs-neon-auth/app/organization/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { OrganizationView } from '@neondatabase/auth/react/ui';
-import { organizationViewPaths } from '@neondatabase/auth/react/ui/server';
+import { OrganizationView } from '@neondatabase/auth-ui';
+import { organizationViewPaths } from '@neondatabase/auth-ui/server';
 
 export const dynamicParams = false;
 

--- a/examples/nextjs-neon-auth/app/providers.tsx
+++ b/examples/nextjs-neon-auth/app/providers.tsx
@@ -1,18 +1,22 @@
 "use client"
 
-import { NeonAuthUIProvider } from "@neondatabase/auth/react/ui"
+import { NeonAuthUIProvider } from "@neondatabase/auth-ui"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import type { ReactNode } from "react"
 
 import { authClient } from "@/lib/auth/client"
 
+type NeonAuthUIProviderAuthClient = Parameters<
+    typeof NeonAuthUIProvider
+>[0]["authClient"]
+
 export function Providers({ children }: { children: ReactNode }) {
     const router = useRouter()
 
     return (
         <NeonAuthUIProvider
-            authClient={authClient}
+            authClient={authClient as NeonAuthUIProviderAuthClient}
             navigate={router.push}
             replace={router.replace}
             onSessionChange={() => {

--- a/examples/nextjs-neon-auth/components/header.tsx
+++ b/examples/nextjs-neon-auth/components/header.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { SignedIn, SignedOut, UserButton } from "@neondatabase/auth/react/ui"
+import { SignedIn, SignedOut, UserButton } from "@neondatabase/auth-ui"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"

--- a/examples/nextjs-neon-auth/package.json
+++ b/examples/nextjs-neon-auth/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@neondatabase/auth": "workspace:*",
+    "@neondatabase/auth-ui": "workspace:*",
     "@neondatabase/serverless": "1.0.2",
     "@radix-ui/react-dropdown-menu": "2.1.16",
     "@radix-ui/react-slot": "1.2.3",

--- a/examples/nextjs-phone-login/app/auth/[path]/page.tsx
+++ b/examples/nextjs-phone-login/app/auth/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { AuthView } from '@neondatabase/auth/react/ui';
-import { authViewPaths } from '@neondatabase/auth/react/ui/server';
+import { AuthView } from '@neondatabase/auth-ui';
+import { authViewPaths } from '@neondatabase/auth-ui/server';
 import { PhoneSignInSection } from './phone-sign-in-section';
 
 export const dynamicParams = false;

--- a/examples/nextjs-phone-login/app/globals.css
+++ b/examples/nextjs-phone-login/app/globals.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
-@import '@neondatabase/auth/ui/tailwind';
+@import '@neondatabase/auth-ui/tailwind';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/examples/nextjs-phone-login/app/providers.tsx
+++ b/examples/nextjs-phone-login/app/providers.tsx
@@ -1,15 +1,19 @@
 'use client';
 
-import { NeonAuthUIProvider } from '@neondatabase/auth/react/ui';
+import { NeonAuthUIProvider } from '@neondatabase/auth-ui';
 import { authClient } from '@/lib/auth/client';
 import { useRouter } from 'next/navigation';
+
+type NeonAuthUIProviderAuthClient = Parameters<
+  typeof NeonAuthUIProvider
+>[0]['authClient'];
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const router = useRouter();
 
   return (
     <NeonAuthUIProvider
-      authClient={authClient}
+      authClient={authClient as NeonAuthUIProviderAuthClient}
       navigate={(path) => router.push(path)}
       replace={(path) => router.replace(path)}
       onSessionChange={() => router.refresh()}

--- a/examples/nextjs-phone-login/package.json
+++ b/examples/nextjs-phone-login/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@neondatabase/auth": "workspace:*",
+    "@neondatabase/auth-ui": "workspace:*",
     "@neondatabase/serverless": "1.0.2",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
 
   examples/neon-auth-magic-link-example:
     dependencies:
+      '@neondatabase/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
@@ -136,6 +142,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
@@ -270,6 +279,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: 1.0.2
         version: 1.0.2
@@ -352,6 +364,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: 1.0.2
         version: 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
@@ -140,6 +143,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: ^1.0.2
         version: 1.0.2
@@ -274,6 +280,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: 1.0.2
         version: 1.0.2
@@ -356,6 +365,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: 1.0.2
         version: 1.0.2

--- a/skills/neon-auth-nextjs/SKILL.md
+++ b/skills/neon-auth-nextjs/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when:
 
 1. **Server vs Client imports**: Use correct import paths
 2. **`'use client'` directive**: Required for client components using hooks
-3. **CSS Import**: Choose ONE - either `/ui/css` OR `/ui/tailwind`, never both
+3. **CSS Import**: Choose ONE - either `@neondatabase/auth-ui/css` OR `@neondatabase/auth-ui/tailwind`, never both
 4. **onSessionChange**: Always call `router.refresh()` to update Server Components
 
 ## Critical Imports
@@ -28,8 +28,8 @@ Use this skill when:
 |---------|-------------|
 | Unified Server (`createNeonAuth`) | `@neondatabase/auth/next/server` |
 | Client Auth | `@neondatabase/auth/next` |
-| UI Components | `@neondatabase/auth/react/ui` |
-| View Paths (static params) | `@neondatabase/auth/react/ui/server` |
+| UI Components | `@neondatabase/auth-ui` |
+| View Paths (static params) | `@neondatabase/auth-ui/server` |
 
 **Note**: Use `createNeonAuth()` from `@neondatabase/auth/next/server` to get a unified `auth` instance that provides:
 - `.handler()` - API route handler
@@ -42,7 +42,7 @@ Use this skill when:
 
 ### 1. Install
 ```bash
-npm install @neondatabase/auth
+npm install @neondatabase/auth @neondatabase/auth-ui
 ```
 
 ### 2. Environment (`.env.local`)
@@ -104,7 +104,7 @@ export const authClient = createAuthClient();
 ### 7. Provider (`app/providers.tsx`)
 ```typescript
 'use client';
-import { NeonAuthUIProvider } from '@neondatabase/auth/react/ui';
+import { NeonAuthUIProvider } from '@neondatabase/auth-ui';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { authClient } from '@/lib/auth/client';
@@ -130,7 +130,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
 ### 8. Layout (`app/layout.tsx`)
 ```typescript
 import { Providers } from './providers';
-import '@neondatabase/auth/ui/css';
+import '@neondatabase/auth-ui/css';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -145,8 +145,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 ### 9. Auth Pages (`app/auth/[path]/page.tsx`)
 ```typescript
-import { AuthView } from '@neondatabase/auth/react/ui';
-import { authViewPaths } from '@neondatabase/auth/react/ui/server';
+import { AuthView } from '@neondatabase/auth-ui';
+import { authViewPaths } from '@neondatabase/auth-ui/server';
 
 export function generateStaticParams() {
   return Object.values(authViewPaths).map((path) => ({ path }));
@@ -167,13 +167,13 @@ export default async function AuthPage({ params }: { params: Promise<{ path: str
 **Without Tailwind** (pre-built CSS bundle ~47KB):
 ```typescript
 // app/layout.tsx
-import '@neondatabase/auth/ui/css';
+import '@neondatabase/auth-ui/css';
 ```
 
 **With Tailwind CSS v4** (`app/globals.css`):
 ```css
 @import 'tailwindcss';
-@import '@neondatabase/auth/ui/tailwind';
+@import '@neondatabase/auth-ui/tailwind';
 ```
 
 **IMPORTANT**: Never import both - causes duplicate styles.
@@ -443,7 +443,7 @@ const session = await authClient.getSession();
 ### AuthView - Main Auth Interface
 
 ```typescript
-import { AuthView } from '@neondatabase/auth/react/ui';
+import { AuthView } from '@neondatabase/auth-ui';
 
 // Handles: sign-in, sign-up, forgot-password, reset-password, callback, sign-out
 <AuthView pathname={path} />
@@ -457,7 +457,7 @@ import {
   SignedOut,
   AuthLoading,
   RedirectToSignIn,
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 
 function MyPage() {
   return (
@@ -484,7 +484,7 @@ function MyPage() {
 ### UserButton
 
 ```typescript
-import { UserButton } from '@neondatabase/auth/react/ui';
+import { UserButton } from '@neondatabase/auth-ui';
 
 function Header() {
   return (
@@ -507,7 +507,7 @@ import {
   ChangeEmailCard,
   DeleteAccountCard,
   ProvidersCard,
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 ```
 
 ### Organization Components
@@ -518,7 +518,7 @@ import {
   OrganizationSettingsCards,
   OrganizationMembersCard,
   AcceptInvitationCard,
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 ```
 
 ---
@@ -592,7 +592,7 @@ import {
   SecuritySettingsCards,
   SessionsCard,
   ChangePasswordCard,
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 
 export default async function AccountPage({ params }: { params: Promise<{ path: string }> }) {
   const { path = 'settings' } = await params;

--- a/skills/neon-auth-react/SKILL.md
+++ b/skills/neon-auth-react/SKILL.md
@@ -21,13 +21,13 @@ Use this skill when:
 1. **Adapter Factory Pattern**: Always call adapters with `()` - they are factory functions
 2. **React Adapter Import**: Use subpath `@neondatabase/auth/react/adapters`
 3. **createAuthClient takes URL as first arg**: `createAuthClient(url, config)`
-4. **CSS Import**: Choose ONE - either `/ui/css` OR `/ui/tailwind`, never both
+4. **CSS Import**: Choose ONE - either `@neondatabase/auth-ui/css` OR `@neondatabase/auth-ui/tailwind`, never both
 
 ## Setup
 
 ### 1. Install
 ```bash
-npm install @neondatabase/auth
+npm install @neondatabase/auth @neondatabase/auth-ui
 ```
 
 ### 2. Create Client (`src/auth-client.ts`)
@@ -46,13 +46,13 @@ export const authClient = createAuthClient(
 
 ### 3. Create Provider (`src/providers.tsx`)
 ```typescript
-import { NeonAuthUIProvider } from '@neondatabase/auth/react/ui';
+import { NeonAuthUIProvider } from '@neondatabase/auth-ui';
 import { useNavigate } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { authClient } from './auth-client';
 
 // Import CSS (choose one)
-import '@neondatabase/auth/ui/css';
+import '@neondatabase/auth-ui/css';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
@@ -94,13 +94,13 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 **Without Tailwind** (pre-built CSS bundle ~47KB):
 ```css
 /* In your main CSS file or import in provider */
-@import '@neondatabase/auth/ui/css';
+@import '@neondatabase/auth-ui/css';
 ```
 
 **With Tailwind CSS v4**:
 ```css
 @import 'tailwindcss';
-@import '@neondatabase/auth/ui/tailwind';
+@import '@neondatabase/auth-ui/tailwind';
 ```
 
 **IMPORTANT**: Never import both - causes duplicate styles.
@@ -220,7 +220,7 @@ Full configuration options:
 Handles sign-in, sign-up, forgot password, and callback routes:
 
 ```typescript
-import { AuthView } from '@neondatabase/auth/react/ui';
+import { AuthView } from '@neondatabase/auth-ui';
 
 // Route: /auth/:pathname
 function AuthPage() {
@@ -240,7 +240,7 @@ import {
   SignedOut,
   AuthLoading,
   RedirectToSignIn
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 
 function MyPage() {
   return (
@@ -272,7 +272,7 @@ function MyPage() {
 Dropdown menu with user avatar, name, and sign-out:
 
 ```typescript
-import { UserButton } from '@neondatabase/auth/react/ui';
+import { UserButton } from '@neondatabase/auth-ui';
 
 function Header() {
   return (
@@ -295,7 +295,7 @@ import {
   ChangeEmailCard,        // Email change form
   DeleteAccountCard,      // Account deletion
   ProvidersCard,          // Linked OAuth providers
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 
 function AccountPage() {
   const { view } = useParams(); // 'settings', 'security', 'sessions'
@@ -326,7 +326,7 @@ import {
   OrganizationSettingsCards,  // Org settings
   OrganizationMembersCard,    // Member management
   AcceptInvitationCard,       // Accept org invite
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 ```
 
 ---
@@ -646,7 +646,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 ```typescript
 // pages/AuthPage.tsx
 import { useParams } from 'react-router-dom';
-import { AuthView } from '@neondatabase/auth/react/ui';
+import { AuthView } from '@neondatabase/auth-ui';
 
 export function AuthPage() {
   const { pathname } = useParams();
@@ -666,7 +666,7 @@ import {
   SecuritySettingsCards,
   SessionsCard,
   ChangePasswordCard,
-} from '@neondatabase/auth/react/ui';
+} from '@neondatabase/auth-ui';
 
 export function AccountPage() {
   const { view = 'settings' } = useParams();


### PR DESCRIPTION
## Problem

Bug bash found example apps importing the deprecated compatibility CSS path `@neondatabase/auth/ui/tailwind`, which can fail to resolve. Current Neon Auth UI docs prefer direct imports from `@neondatabase/auth-ui`.

## Summary of changes

- [x] Migrated affected example CSS, component, and server-helper imports to `@neondatabase/auth-ui` / `@neondatabase/auth-ui/server`.
- [x] Added `@neondatabase/auth-ui` as a `workspace:*` dependency to affected example packages and refreshed `pnpm-lock.yaml`.
- [x] Updated example docs and Neon Auth setup guidance to avoid deprecated compatibility UI imports.

Refs:
#0000

## Verification steps

- [x] `pnpm install --lockfile-only`
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter neon-todo run build`
- [x] `NEON_AUTH_BASE_URL=https://ep-xxx.neonauth.us-east-1.aws.neon.tech/neondb/auth NEON_AUTH_COOKIE_SECRET=REPLACE_WITH_RANDOM_SECRET_AT_LEAST_32_CHARS DATABASE_URL=postgresql://neondb_owner:password@ep-xxx.us-east-1.aws.neon.tech/neondb?sslmode=require pnpm --filter neon-auth-netxtjs run build`
- [x] `pnpm --filter neon-auth-netxtjs run lint`
- [ ] `pnpm --filter nextjs-phone-login run build` reaches TypeScript, then fails on an existing `components/phone-login-form.tsx` `sessionUser?.phoneNumber` type error unrelated to this import migration.
- [ ] `pnpm --filter neon-auth-magic-link-example run build` reaches TypeScript, then fails on an existing `components/magic-link-form.tsx` `authClient.signIn.magicLink` type error unrelated to this import migration.
- [ ] `pnpm --filter neon-auth-magic-link-example run lint` and `pnpm --filter neon-todo run lint` fail on existing React Hooks / `no-explicit-any` lint issues outside the changed import paths.
- [ ] `pnpm --filter nextjs-phone-login run lint` is blocked because the package script runs `next lint`, which Next 16 treats as an invalid project directory; direct `eslint` also fails on the existing ESLint config circular-reference error.