### PR TITLE
feat(examples): organization multi-tenancy in react-neon-js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -788,12 +788,23 @@ The `skills/` directory contains AI-assistant skills for helping developers set 
 - Neon Auth Next.js/server observability: **opt-out** defaults (`warn` to `console`); apps can set **`logLevel: 'silent'`** on `createNeonAuth` to mute or inject a custom **`logger`**.
 - When adding SDK-facing observability or debugging aids, update the package changelog and show usage in an example app when it helps adopters.
 - Prefer **`logger`** + **`logLevel`** as the only controls for server/proxy logging—avoid separate boolean or feature flags solely to toggle logs.
+- User-facing Neon Auth docs (website repo): describe **current** SDK behavior—avoid "after upgrading" and migration framing outside dedicated migration guides.
+- In user-facing Neon Auth docs (`neondatabase/website`): prefer **"Neon Auth logging"** over "console output"; omit **(opt-out)** from titles/headings; **`logLevel`** tables list explicit emitted levels per row (not ranges like “through `info`”); use **`<NextjsProxyNote/>`** for **`proxy.ts`** (Next.js 16+) vs **`middleware.ts`** samples.
+- For copy-paste prompts, use a **single plain `text` fenced block** so the full prompt copies in one action—not `markdown` the UI may render as separate sections.
+- Multi-tenancy demos should let signed-in users create **personal** rows (`organization_id IS NULL`) alongside org-scoped team data—don't require an active organization for all authenticated writes.
+- Prefer RLS helpers that return the **full JWT `o` claim** (jsonb) over id-only accessors; extract `id` / `slug` / `role` with `->>` in policies.
 
 ## Learned Workspace Facts
 
 - `createNeonAuth` accepts optional **`logger`** and **`logLevel`** (including **`'silent'`** via `resolveNeonAuthLogging`); related types are re-exported from `@neondatabase/auth/next/server`.
-- The auth **proxy** (`packages/auth/src/server/proxy/request.ts`) logs structured warn/debug lines for upstream fetch outcomes and uses **`classifyFetchFailure`** / `packages/auth/src/server/network-error.ts` for transport vs HTTP error taxonomy returned to clients.
+- The auth **proxy** (`packages/auth/src/server/proxy/request.ts`) logs structured warn/debug lines for upstream fetch outcomes; failed upstream `fetch` returns synthetic **502** JSON with stable **`NETWORK_*`** codes via **`classifyFetchFailure`** (`packages/auth/src/server/network-error.ts`).
 - **`examples/nextjs-neon-auth/app/iframe-test/page.tsx`** is the App Router counterpart to iframe-hosted OAuth/popup testing in **`examples/react-neon-js/`**.
+- Neon Auth product docs live in **`neondatabase/website`** (`content/docs/auth/`); reference/troubleshooting covers server logging, **`NETWORK_*`** codes, and iframe **`sameSite`** (`nextjs-server.md`, `troubleshooting.md`).
+- Website **`<NextjsProxyNote/>`** component: **`content/docs/shared-content/nextjs-proxy-note.md`** — documents **`proxy.ts`** vs **`middleware.ts`** for Next.js version differences.
+- SDK releases use a **two-stage** pipeline: `prepare-release.yml` bumps versions and creates per-package tags in neon-js; npm publish runs in **`secure-public-registry-releases-eng`** on those tags.
+- Neon Auth session JWT includes organization claim **`o`**: `{ "id", "slug", "role" }` for the active org—used for RLS multi-tenancy via Data API.
+- **`pg_session_jwt`** is Neon's first-party extension ([`neondatabase/pg_session_jwt`](https://github.com/neondatabase/pg_session_jwt)); `auth.user_id()` / `auth.jwt()` live in the extension-owned **`auth`** schema (avoid custom functions there until Neon documents support).
+- Upstream plan: **`auth.organization()`** (jsonb) and **`auth.organization_id()`** (text) in `pg_session_jwt`; until shipped, **`examples/react-neon-js`** uses **`public.jwt_organization()`** as app-level RLS sugar with Organizations plugin + **`OrganizationSwitcher`**.
 
 ## References
 

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -103,6 +103,25 @@ export async function navigateToOrganizationSettings(page: Page): Promise<void> 
 }
 
 /**
+ * Ensure the signed-in user has an active organization (react-neon-js dashboard).
+ * Creates one via the OrganizationSwitcher when none exists.
+ */
+export async function ensureActiveOrganization(page: Page): Promise<void> {
+  const orgBanner = page.getByText('Select or create an organization');
+  const hasOrgBanner = await orgBanner.isVisible().catch(() => false);
+
+  if (!hasOrgBanner) {
+    return;
+  }
+
+  await page.getByLabel('Create organization').click();
+  await page.getByPlaceholder('My Organization').fill(`E2E Org ${Date.now()}`);
+  await page.getByRole('button', { name: /^create$/i }).click();
+
+  await expect(orgBanner).toBeHidden({ timeout: 15_000 });
+}
+
+/**
  * Create a new note
  */
 export async function createNote(page: Page, noteTitle: string): Promise<void> {

--- a/e2e/tests/neon-js.spec.ts
+++ b/e2e/tests/neon-js.spec.ts
@@ -13,7 +13,7 @@ test.describe('Data API', () => {
     });
 
     await test.step('Create new todo', async () => {
-      const addInput = page.getByPlaceholder('What needs to be done?');
+      const addInput = page.getByPlaceholder(/add a personal task/i);
       await expect(addInput).toBeVisible({ timeout: 10_000 });
 
       await addInput.fill(uniqueTodoTitle);

--- a/examples/react-neon-js/README.md
+++ b/examples/react-neon-js/README.md
@@ -6,11 +6,38 @@ This is a simple example of how to use Neon-js with React.
 
 - [x] Authentication
   - done through `neon-js` with `auth-ui` for components
+- [x] Organizations (multi-tenancy)
+  - `NeonAuthUIProvider` with `organization={{}}`, `OrganizationSwitcher`, and `/organization/:pathname` routes
+  - team todos scoped to the active organization via JWT claim `o` and RLS
+- [x] Personal todos
+  - signed-in users can create private todos (`organization_id` IS NULL) with or without an active org
 - [x] Authorization
-  - done through RLS (Row Level Security), by applying the policies in the migration
+  - Row Level Security in `migration.sql`
 - [x] Data fetching/mutating
-  - done through `neon-js`, which uses neon Data API
+  - done through `neon-js`, which uses the Neon Data API
 - [x] Database types
-  - generated `database.types.ts` with `npx neon-js gen-types --db-url "postgresql://user:pass@host/db"` from the Neon DB URL
+  - generated `database.types.ts` with `npx neon-js gen-types --db-url "postgresql://user:pass@host/db"`
 
+## Prerequisites
 
+1. Enable the **Organizations** plugin on your Neon Auth endpoint (Neon Console → Auth).
+2. Apply the database schema:
+   - **New project:** run `migration.sql`
+   - **Existing project (user-owned todos):** run `migration-organization.sql`
+   - **Existing project (org-only RLS):** run `migration-personal-todos.sql`
+
+## JWT organization claim
+
+Team todos use claim `o` on the session JWT:
+
+```json
+{
+  "o": {
+    "id": "<active-organization-id>",
+    "slug": "<organization-slug>",
+    "role": "<member-role>"
+  }
+}
+```
+
+RLS compares `organization_id` on team rows to `auth.jwt() -> 'o' ->> 'id'`. Personal rows keep `organization_id` NULL and are limited to `user_id = auth.user_id()`.

--- a/examples/react-neon-js/migration-organization.sql
+++ b/examples/react-neon-js/migration-organization.sql
@@ -32,12 +32,13 @@ DROP POLICY IF EXISTS "Authenticated users can update todos" ON public.todos;
 
 DROP POLICY IF EXISTS "Authenticated users can delete todos" ON public.todos;
 
-DROP FUNCTION IF EXISTS public.jwt_organization() ->> 'id';
+DROP FUNCTION IF EXISTS public.jwt_organization();
 
 CREATE OR REPLACE FUNCTION public.jwt_organization()
 RETURNS jsonb
 LANGUAGE sql
 STABLE
+SECURITY DEFINER
 SET search_path = public
 AS $$
   SELECT auth.jwt() -> 'o';

--- a/examples/react-neon-js/migration-organization.sql
+++ b/examples/react-neon-js/migration-organization.sql
@@ -1,29 +1,39 @@
--- Personal todos (organization_id IS NULL) and team todos (JWT `o` claim):
---   { "id": "<org-uuid>", "slug": "<org-slug>", "role": "<member-role>" }
--- Requires Neon Auth Organizations plugin enabled on the auth endpoint.
+-- Apply on existing databases that used the pre-organization migration.sql.
+-- Requires Neon Auth Organizations plugin enabled.
 
-CREATE TABLE public.todos (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
-    user_id text NOT NULL,
-    organization_id text,
-    title text NOT NULL,
-    completed boolean NOT NULL DEFAULT false,
-    is_public boolean NOT NULL DEFAULT false,
-    created_at timestamptz NOT NULL DEFAULT now(),
-    updated_at timestamptz NOT NULL DEFAULT now()
-);
+ALTER TABLE public.todos
+ADD COLUMN IF NOT EXISTS organization_id text;
 
-CREATE INDEX idx_todos_organization_id ON public.todos (organization_id)
+CREATE INDEX IF NOT EXISTS idx_todos_organization_id ON public.todos (organization_id)
 WHERE
     organization_id IS NOT NULL;
 
-CREATE INDEX idx_todos_is_public ON public.todos (is_public)
-WHERE
-    is_public = true;
+DROP POLICY IF EXISTS "Users can view their own todos" ON public.todos;
 
-ALTER TABLE public.todos ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users can create their own todos" ON public.todos;
 
--- Active organization from JWT claim `o`: { "id", "slug", "role" } (Neon Auth organization plugin).
+DROP POLICY IF EXISTS "Users can update their own todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Users can delete their own todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Org members can view org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Org members can create org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Org members can update org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Org members can delete org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can view todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can create todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can update todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can delete todos" ON public.todos;
+
+DROP FUNCTION IF EXISTS public.jwt_organization() ->> 'id';
+
 CREATE OR REPLACE FUNCTION public.jwt_organization()
 RETURNS jsonb
 LANGUAGE sql
@@ -33,7 +43,6 @@ AS $$
   SELECT auth.jwt() -> 'o';
 $$;
 
--- Signed-in users: org todos (JWT `o`), personal todos (organization_id IS NULL), or public.
 CREATE POLICY "Authenticated users can view todos" ON public.todos FOR
 SELECT TO authenticated USING (
     (
@@ -84,21 +93,3 @@ CREATE POLICY "Authenticated users can delete todos" ON public.todos FOR DELETE 
         AND user_id = auth.user_id ()
     )
 );
-
-GRANT SELECT ON public.todos TO anonymous;
-
-CREATE POLICY "Anonymous users can view public todos" ON public.todos FOR
-SELECT TO anonymous USING (is_public = true);
-
-CREATE OR REPLACE FUNCTION public.update_updated_at_column()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = now();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql SET search_path = public;
-
-CREATE TRIGGER update_todos_updated_at
-  BEFORE UPDATE ON public.todos
-  FOR EACH ROW
-  EXECUTE FUNCTION public.update_updated_at_column();

--- a/examples/react-neon-js/migration-personal-todos.sql
+++ b/examples/react-neon-js/migration-personal-todos.sql
@@ -1,0 +1,80 @@
+-- Add personal-todo RLS for databases that already applied org-only policies.
+-- Personal rows: organization_id IS NULL and user_id = auth.user_id().
+
+DROP POLICY IF EXISTS "Org members can view org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Org members can create org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Org members can update org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Org members can delete org todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can view todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can create todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can update todos" ON public.todos;
+
+DROP POLICY IF EXISTS "Authenticated users can delete todos" ON public.todos;
+
+DROP FUNCTION IF EXISTS public.jwt_organization() ->> 'id';
+
+CREATE OR REPLACE FUNCTION public.jwt_organization()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT auth.jwt() -> 'o';
+$$;
+
+CREATE POLICY "Authenticated users can view todos" ON public.todos FOR
+SELECT TO authenticated USING (
+    (
+        organization_id IS NOT NULL
+        AND organization_id = public.jwt_organization() ->> 'id'
+    )
+    OR (
+        organization_id IS NULL
+        AND user_id = auth.user_id ()
+    )
+    OR is_public = true
+);
+
+CREATE POLICY "Authenticated users can create todos" ON public.todos FOR
+INSERT
+TO authenticated
+WITH
+    CHECK (
+        auth.user_id () = user_id
+        AND (
+            (
+                organization_id IS NOT NULL
+                AND organization_id = public.jwt_organization() ->> 'id'
+            )
+            OR organization_id IS NULL
+        )
+    );
+
+CREATE POLICY "Authenticated users can update todos" ON public.todos FOR
+UPDATE TO authenticated USING (
+    (
+        organization_id IS NOT NULL
+        AND organization_id = public.jwt_organization() ->> 'id'
+    )
+    OR (
+        organization_id IS NULL
+        AND user_id = auth.user_id ()
+    )
+);
+
+CREATE POLICY "Authenticated users can delete todos" ON public.todos FOR DELETE TO authenticated USING (
+    (
+        organization_id IS NOT NULL
+        AND organization_id = public.jwt_organization() ->> 'id'
+    )
+    OR (
+        organization_id IS NULL
+        AND user_id = auth.user_id ()
+    )
+);

--- a/examples/react-neon-js/migration-personal-todos.sql
+++ b/examples/react-neon-js/migration-personal-todos.sql
@@ -17,12 +17,13 @@ DROP POLICY IF EXISTS "Authenticated users can update todos" ON public.todos;
 
 DROP POLICY IF EXISTS "Authenticated users can delete todos" ON public.todos;
 
-DROP FUNCTION IF EXISTS public.jwt_organization() ->> 'id';
+DROP FUNCTION IF EXISTS public.jwt_organization();
 
 CREATE OR REPLACE FUNCTION public.jwt_organization()
 RETURNS jsonb
 LANGUAGE sql
 STABLE
+SECURITY DEFINER
 SET search_path = public
 AS $$
   SELECT auth.jwt() -> 'o';

--- a/examples/react-neon-js/migration.sql
+++ b/examples/react-neon-js/migration.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE FUNCTION public.jwt_organization()
 RETURNS jsonb
 LANGUAGE sql
 STABLE
+SECURITY DEFINER
 SET search_path = public
 AS $$
   SELECT auth.jwt() -> 'o';

--- a/examples/react-neon-js/src/App.tsx
+++ b/examples/react-neon-js/src/App.tsx
@@ -22,6 +22,11 @@ const IframeTestPage = lazy(() =>
     default: module.IframeTestPage,
   }))
 );
+const OrganizationPage = lazy(() =>
+  import('./pages/OrganizationPage').then((module) => ({
+    default: module.OrganizationPage,
+  }))
+);
 
 // Loading fallback component
 function PageLoadingFallback() {
@@ -75,6 +80,9 @@ export default function App() {
           {/* Account settings */}
           <Route path="/account" element={<AccountPage />} />
           <Route path="/account/:view" element={<AccountPage />} />
+
+          {/* Organization management (members, settings, teams) */}
+          <Route path="/organization/:pathname" element={<OrganizationPage />} />
         </Routes>
       </Suspense>
     </>

--- a/examples/react-neon-js/src/components/Header.tsx
+++ b/examples/react-neon-js/src/components/Header.tsx
@@ -6,6 +6,7 @@ import {
   UserAvatar,
   AuthLoading,
   AuthUIContext,
+  OrganizationSwitcher,
 } from '@neondatabase/neon-js/auth/react';
 import { Link, NavLink } from 'react-router-dom';
 import { ThemeToggle } from './ThemeToggle';
@@ -59,6 +60,15 @@ export function Header() {
             Iframe Test
           </NavLink>
           <SignedIn>
+            <NavLink
+              to="/organization/settings"
+              style={({ isActive }) => ({
+                ...styles.navLink,
+                ...(isActive ? styles.navLinkActive : {}),
+              })}
+            >
+              Organizations
+            </NavLink>
             <NavLink
               to="/account/settings"
               style={({ isActive }) => ({
@@ -121,6 +131,9 @@ export function Header() {
 
           {/* Signed In State - Desktop Only */}
           <SignedIn>
+            <div style={styles.orgSwitcher} className="header-desktop-only">
+              <OrganizationSwitcher />
+            </div>
             <div className="header-desktop-only">
               <UserButton />
             </div>
@@ -218,6 +231,16 @@ export function Header() {
           </NavLink>
           <SignedIn>
             <NavLink
+              to="/organization/settings"
+              onClick={closeMobileMenu}
+              style={({ isActive }) => ({
+                ...styles.mobileNavLink,
+                ...(isActive ? styles.mobileNavLinkActive : {}),
+              })}
+            >
+              Organizations
+            </NavLink>
+            <NavLink
               to="/account/settings"
               onClick={closeMobileMenu}
               style={({ isActive }) => ({
@@ -233,6 +256,9 @@ export function Header() {
         <div style={styles.mobileMenuFooter}>
           {/* User Info - Mobile */}
           <SignedIn>
+            <div style={styles.mobileOrgSwitcher}>
+              <OrganizationSwitcher />
+            </div>
             <Link
               to="/account/settings"
               onClick={closeMobileMenu}
@@ -370,6 +396,12 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: '0.75rem',
+  },
+  orgSwitcher: {
+    maxWidth: '220px',
+  },
+  mobileOrgSwitcher: {
+    marginBottom: '0.5rem',
   },
   iconButton: {
     display: 'flex',

--- a/examples/react-neon-js/src/database.types.ts
+++ b/examples/react-neon-js/src/database.types.ts
@@ -15,6 +15,7 @@ export type Database = {
           created_at: string;
           id: string;
           is_public: boolean;
+          organization_id: string | null;
           title: string;
           updated_at: string;
           user_id: string;
@@ -24,6 +25,7 @@ export type Database = {
           created_at?: string;
           id?: string;
           is_public?: boolean;
+          organization_id?: string | null;
           title: string;
           updated_at?: string;
           user_id: string;
@@ -33,6 +35,7 @@ export type Database = {
           created_at?: string;
           id?: string;
           is_public?: boolean;
+          organization_id?: string | null;
           title?: string;
           updated_at?: string;
           user_id?: string;

--- a/examples/react-neon-js/src/pages/AccountPage.tsx
+++ b/examples/react-neon-js/src/pages/AccountPage.tsx
@@ -7,9 +7,10 @@ import {
   SecuritySettingsCards,
   SessionsCard,
   ChangePasswordCard,
+  OrganizationsCard,
 } from '@neondatabase/neon-js/auth/react';
 
-type AccountView = 'settings' | 'security' | 'sessions';
+type AccountView = 'settings' | 'security' | 'sessions' | 'organizations';
 
 export function AccountPage() {
   const { view } = useParams<{ view: string }>();
@@ -44,6 +45,9 @@ export function AccountPage() {
             <TabLink to="/account/sessions" active={currentView === 'sessions'}>
               📱 Sessions
             </TabLink>
+            <TabLink to="/account/organizations" active={currentView === 'organizations'}>
+              🏢 Organizations
+            </TabLink>
           </div>
 
           {/* Content */}
@@ -51,6 +55,7 @@ export function AccountPage() {
             {currentView === 'settings' && <SettingsView />}
             {currentView === 'security' && <SecurityView />}
             {currentView === 'sessions' && <SessionsView />}
+            {currentView === 'organizations' && <OrganizationsView />}
           </div>
         </div>
       </SignedIn>
@@ -113,6 +118,20 @@ function SecurityView() {
           Manage linked accounts and other security settings.
         </p>
         <SecuritySettingsCards />
+      </div>
+    </div>
+  );
+}
+
+function OrganizationsView() {
+  return (
+    <div style={styles.section}>
+      <div style={styles.sectionCard}>
+        <h2 style={styles.sectionTitle}>Organizations</h2>
+        <p style={styles.sectionDesc}>
+          Create organizations and collaborate with your team.
+        </p>
+        <OrganizationsCard />
       </div>
     </div>
   );

--- a/examples/react-neon-js/src/pages/DashboardPage.tsx
+++ b/examples/react-neon-js/src/pages/DashboardPage.tsx
@@ -26,7 +26,6 @@ function DashboardContent() {
   const { hooks } = useContext(AuthUIContext);
   const { data: session } = hooks.useSession();
   const { data: activeOrg } = hooks.useActiveOrganization();
-  const { data: activeMember } = hooks.useActiveMember();
 
   const [todos, setTodos] = useState<Todo[]>([]);
   const [newTodoTitle, setNewTodoTitle] = useState('');
@@ -46,6 +45,7 @@ function DashboardContent() {
   const isAuthenticated = Boolean(userId) && !isAnonymous;
   const isReadOnly = !isAuthenticated;
   const activeOrgId = activeOrg?.id ?? null;
+  const activeMemberRole = activeOrg?.members?.find((m) => m.userId === userId)?.role;
   const addToOrganization = Boolean(activeOrgId) && !addAsPersonal;
 
   // Fetch todos
@@ -283,7 +283,7 @@ function DashboardContent() {
                 </h1>
                 <p style={styles.email}>
                   {activeOrg
-                    ? `Team + personal tasks${activeMember?.role ? ` · ${activeMember.role}` : ''}`
+                    ? `Team + personal tasks${activeMemberRole ? ` · ${activeMemberRole}` : ''}`
                     : 'Personal tasks'}
                 </p>
               </div>

--- a/examples/react-neon-js/src/pages/DashboardPage.tsx
+++ b/examples/react-neon-js/src/pages/DashboardPage.tsx
@@ -25,12 +25,15 @@ export function DashboardPage() {
 function DashboardContent() {
   const { hooks } = useContext(AuthUIContext);
   const { data: session } = hooks.useSession();
+  const { data: activeOrg } = hooks.useActiveOrganization();
+  const { data: activeMember } = hooks.useActiveMember();
 
   const [todos, setTodos] = useState<Todo[]>([]);
   const [newTodoTitle, setNewTodoTitle] = useState('');
   const [filter, setFilter] = useState<FilterType>('all');
   const [isLoading, setIsLoading] = useState(true);
   const [isAdding, setIsAdding] = useState(false);
+  const [addAsPersonal, setAddAsPersonal] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const userId = session?.user?.id;
@@ -42,6 +45,8 @@ function DashboardContent() {
       : false;
   const isAuthenticated = Boolean(userId) && !isAnonymous;
   const isReadOnly = !isAuthenticated;
+  const activeOrgId = activeOrg?.id ?? null;
+  const addToOrganization = Boolean(activeOrgId) && !addAsPersonal;
 
   // Fetch todos
   const fetchTodos = useCallback(async () => {
@@ -54,7 +59,7 @@ function DashboardContent() {
         .select('*')
         .order('created_at', { ascending: false });
 
-      // If user is not authenticated, only show public todos
+      // Anonymous users only see public todos; org scope is enforced by RLS for signed-in users.
       if (!isAuthenticated) {
         query = query.eq('is_public', true);
       }
@@ -69,11 +74,15 @@ function DashboardContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [userId, isAuthenticated]);
+  }, [isAuthenticated, activeOrgId]);
 
   useEffect(() => {
     fetchTodos();
   }, [fetchTodos]);
+
+  useEffect(() => {
+    setAddAsPersonal(false);
+  }, [activeOrgId]);
 
   // Add todo
   const addTodo = async (e: React.FormEvent) => {
@@ -89,6 +98,7 @@ function DashboardContent() {
         .insert({
           title: newTodoTitle.trim(),
           user_id: userId,
+          organization_id: addToOrganization ? activeOrgId : null,
           completed: false,
         })
         .select()
@@ -224,6 +234,22 @@ function DashboardContent() {
 
   return (
     <div style={styles.container}>
+      {isAuthenticated && !activeOrgId && (
+        <div style={styles.orgBanner}>
+          <span style={{ fontSize: '1.25rem' }}>🏢</span>
+          <div style={{ flex: 1 }}>
+            <p style={styles.guestBannerTitle}>Personal tasks only</p>
+            <p style={styles.guestBannerText}>
+              New tasks are private to you. Create or select an organization in
+              the header to share tasks with your team.
+            </p>
+          </div>
+          <Link to="/organization/settings" style={styles.guestSignInButton}>
+            Manage orgs
+          </Link>
+        </div>
+      )}
+
       {/* Guest Banner */}
       {isReadOnly && (
         <div style={styles.guestBanner}>
@@ -251,9 +277,15 @@ function DashboardContent() {
               />
               <div>
                 <h1 style={styles.welcomeTitle}>
-                  {session?.user?.name || 'User'}'s Tasks
+                  {activeOrg?.name
+                    ? `${activeOrg.name} Tasks`
+                    : `${session?.user?.name || 'User'}'s Tasks`}
                 </h1>
-                <p style={styles.email}>{session?.user?.email}</p>
+                <p style={styles.email}>
+                  {activeOrg
+                    ? `Team + personal tasks${activeMember?.role ? ` · ${activeMember.role}` : ''}`
+                    : 'Personal tasks'}
+                </p>
               </div>
             </>
           ) : (
@@ -306,7 +338,11 @@ function DashboardContent() {
       <div style={styles.todoCard}>
         <div style={styles.todoHeader}>
           <h2 style={styles.todoTitle}>
-            {isReadOnly ? '🌐 Public Tasks' : '📝 My Tasks'}
+            {isReadOnly
+              ? '🌐 Public Tasks'
+              : activeOrg
+                ? '📝 Tasks'
+                : '📝 Personal Tasks'}
           </h2>
           {!isReadOnly && completedTodosCount > 0 && (
             <button onClick={clearCompleted} style={styles.clearButton}>
@@ -317,27 +353,46 @@ function DashboardContent() {
 
         {/* Add Todo Form - Only for authenticated users */}
         {!isReadOnly && (
-          <form onSubmit={addTodo} style={styles.addForm}>
-            <input
-              type="text"
-              value={newTodoTitle}
-              onChange={(e) => setNewTodoTitle(e.target.value)}
-              placeholder="What needs to be done?"
-              style={styles.addInput}
-              disabled={isAdding}
-            />
-            <button
-              type="submit"
-              disabled={!newTodoTitle.trim() || isAdding}
-              style={{
-                ...styles.addButton,
-                opacity: !newTodoTitle.trim() || isAdding ? 0.5 : 1,
-                cursor:
-                  !newTodoTitle.trim() || isAdding ? 'not-allowed' : 'pointer',
-              }}
-            >
-              {isAdding ? '...' : '+ Add'}
-            </button>
+          <form onSubmit={addTodo} style={styles.addFormColumn}>
+            <div style={styles.addForm}>
+              <input
+                type="text"
+                value={newTodoTitle}
+                onChange={(e) => setNewTodoTitle(e.target.value)}
+                placeholder={
+                  addToOrganization
+                    ? `Add a task for ${activeOrg?.name ?? 'your team'}…`
+                    : 'Add a personal task…'
+                }
+                style={styles.addInput}
+                disabled={isAdding}
+              />
+              <button
+                type="submit"
+                disabled={!newTodoTitle.trim() || isAdding}
+                style={{
+                  ...styles.addButton,
+                  opacity: !newTodoTitle.trim() || isAdding ? 0.5 : 1,
+                  cursor:
+                    !newTodoTitle.trim() || isAdding
+                      ? 'not-allowed'
+                      : 'pointer',
+                }}
+              >
+                {isAdding ? '...' : '+ Add'}
+              </button>
+            </div>
+            {activeOrgId && (
+              <label style={styles.personalToggle}>
+                <input
+                  type="checkbox"
+                  checked={addAsPersonal}
+                  onChange={(e) => setAddAsPersonal(e.target.checked)}
+                  disabled={isAdding}
+                />
+                Personal task (only visible to you)
+              </label>
+            )}
           </form>
         )}
 
@@ -441,10 +496,14 @@ function DashboardContent() {
       <div style={styles.tipsCard}>
         <h3 style={styles.tipsTitle}>💡 Quick Tips</h3>
         <ul style={styles.tipsList}>
+          <li>
+            Personal tasks are private; team tasks use the JWT{' '}
+            <code style={styles.inlineCode}>o</code> claim in RLS
+          </li>
+          <li>Use the organization switcher to share tasks with your team</li>
           <li>Click the checkbox to mark a task as complete</li>
-          <li>Use filters to focus on active or completed tasks</li>
-          <li>Click 🔒/🌐 to toggle public visibility for anonymous users</li>
-          <li>Clear completed tasks to keep your list tidy</li>
+          <li>Click 🔒/🌐 to share a task with anonymous visitors</li>
+          <li>Invite teammates from organization settings</li>
         </ul>
       </div>
     </div>
@@ -515,6 +574,12 @@ function TodoItem({
           {todo.title}
         </span>
         <span style={styles.todoDate}>
+          {!isReadOnly && (
+            <span style={styles.scopeBadge}>
+              {todo.organization_id ? '🏢 Team' : '👤 Personal'}
+              {' · '}
+            </span>
+          )}
           {new Date(todo.created_at).toLocaleDateString('en-US', {
             month: 'short',
             day: 'numeric',
@@ -611,6 +676,23 @@ const styles: Record<string, React.CSSProperties> = {
     border: '1px solid color-mix(in oklch, var(--primary) 30%, transparent)',
     borderRadius: 'var(--radius)',
     marginBottom: '1.5rem',
+  },
+  orgBanner: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1rem',
+    padding: '1rem 1.25rem',
+    backgroundColor: 'color-mix(in oklch, var(--secondary) 80%, transparent)',
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--radius)',
+    marginBottom: '1.5rem',
+  },
+  inlineCode: {
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: '0.8em',
+    padding: '0.1em 0.35em',
+    borderRadius: '0.25rem',
+    backgroundColor: 'var(--muted)',
   },
   guestBannerTitle: {
     color: 'var(--foreground)',
@@ -724,10 +806,23 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '0.25rem 0.5rem',
     borderRadius: '0.25rem',
   },
+  addFormColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.75rem',
+    marginBottom: '1.5rem',
+  },
   addForm: {
     display: 'flex',
     gap: '0.75rem',
-    marginBottom: '1.5rem',
+  },
+  personalToggle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    fontSize: '0.875rem',
+    color: 'var(--muted-foreground)',
+    cursor: 'pointer',
   },
   addInput: {
     flex: 1,
@@ -831,6 +926,9 @@ const styles: Record<string, React.CSSProperties> = {
   todoDate: {
     fontSize: '0.75rem',
     color: 'var(--muted-foreground)',
+  },
+  scopeBadge: {
+    fontWeight: 500,
   },
   deleteButton: {
     background: 'none',

--- a/examples/react-neon-js/src/pages/HomePage.tsx
+++ b/examples/react-neon-js/src/pages/HomePage.tsx
@@ -83,6 +83,12 @@ export function HomePage() {
             link="/account/settings"
           />
           <FeatureCard
+            icon="🏢"
+            title="Organizations"
+            description="Create teams, switch active organizations, and share todos with members."
+            link="/organization/settings"
+          />
+          <FeatureCard
             icon="👻"
             title="Anonymous Access"
             description="Browse the dashboard without an account. Anonymous tokens are generated automatically!"

--- a/examples/react-neon-js/src/pages/OrganizationPage.tsx
+++ b/examples/react-neon-js/src/pages/OrganizationPage.tsx
@@ -1,0 +1,38 @@
+import { useParams, Link } from 'react-router-dom';
+import { OrganizationView } from '@neondatabase/neon-js/auth/react';
+
+export function OrganizationPage() {
+  const { pathname } = useParams();
+
+  return (
+    <main style={styles.main}>
+      <OrganizationView pathname={pathname} />
+
+      <div style={styles.footer}>
+        <Link to="/dashboard" style={styles.backLink}>
+          ← Back to Dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  main: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 'calc(100vh - 64px)',
+    padding: '2rem 1rem',
+    gap: '1.5rem',
+  },
+  footer: {
+    textAlign: 'center',
+  },
+  backLink: {
+    color: 'var(--muted-foreground)',
+    textDecoration: 'none',
+    fontSize: '0.875rem',
+  },
+};

--- a/examples/react-neon-js/src/providers.tsx
+++ b/examples/react-neon-js/src/providers.tsx
@@ -63,6 +63,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       credentials={{
         forgotPassword: true,
       }}
+      organization={{}}
     >
       {children}
     </NeonAuthUIProvider>

--- a/packages/auth/src/core/better-auth-methods.ts
+++ b/packages/auth/src/core/better-auth-methods.ts
@@ -72,6 +72,7 @@ export const BETTER_AUTH_ENDPOINTS = {
   token: '/token',
   anonymousSignIn: '/sign-in/anonymous',
   anonymousToken: '/token/anonymous',
+  setActiveOrganization: '/organization/set-active',
 } as const;
 
 /**
@@ -180,6 +181,12 @@ export const BETTER_AUTH_METHODS_HOOKS: Record<string, MethodHook> = {
     onSuccess: () => {
       BETTER_AUTH_METHODS_CACHE.clearSessionCache();
       emitAuthEvent({ type: 'SIGN_OUT' });
+    },
+  },
+  setActiveOrganization: {
+    onRequest: () => {},
+    onSuccess: () => {
+      BETTER_AUTH_METHODS_CACHE.invalidateSessionCache();
     },
   },
   updateUser: {
@@ -397,6 +404,9 @@ export function deriveBetterAuthMethodFromUrl(
   }
   if (url.includes(BETTER_AUTH_ENDPOINTS.signOut)) {
     return 'signOut';
+  }
+  if (url.includes(BETTER_AUTH_ENDPOINTS.setActiveOrganization)) {
+    return 'setActiveOrganization';
   }
   if (url.includes(BETTER_AUTH_ENDPOINTS.updateUser)) {
     return 'updateUser';


### PR DESCRIPTION
## Summary

- Extend `examples/react-neon-js` with Neon Auth **Organizations** plugin: `OrganizationSwitcher`, `/organization/:pathname` routes, and `organization={{}}` on `NeonAuthUIProvider`.
- Add **RLS** for team todos scoped to JWT claim `o` (`public.jwt_organization() ->> 'id'`) plus **personal** todos (`organization_id IS NULL`).
- Ship incremental SQL migrations (`migration-organization.sql`, `migration-personal-todos.sql`) for existing databases.
- Update E2E to create personal todos without requiring an active org first.

## Test plan

- [ ] Enable Organizations plugin on Neon Auth endpoint used by the example
- [ ] Apply `migration.sql` (new DB) or `migration-organization.sql` + `migration-personal-todos.sql` (existing)
- [ ] Sign in → create personal todo without org → create org → add team todo → switch org
- [ ] Verify anonymous users still see public todos only
- [ ] Run `pnpm run build` and E2E against example (`pnpm run --filter e2e test:ci`) when credentials available