### PR TITLE
feat(auth): neonClient() Better Auth client plugin

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -78,6 +78,10 @@
       "types": "./dist/next/server/index.d.mts",
       "default": "./dist/next/server/index.mjs"
     },
+    "./client-plugin": {
+      "types": "./dist/client-plugin/index.d.mts",
+      "default": "./dist/client-plugin/index.mjs"
+    },
     "./ui/css": {
       "types": "./dist/ui/css.d.ts",
       "default": "./dist/ui/css.css"

--- a/packages/auth/src/__compat__/from-wrapper-tests/adapter-core.plugin.test.ts
+++ b/packages/auth/src/__compat__/from-wrapper-tests/adapter-core.plugin.test.ts
@@ -1,56 +1,77 @@
+/**
+ * Repurposed from `src/core/adapter-core.test.ts`.
+ *
+ * Plugin-path SUT: `neonClient()` + `createNeonCustomFetchImpl()` from
+ * `@neondatabase/auth/client-plugin`, exercised through a real
+ * `@better-fetch/fetch` instance so the fetch-plugin hooks (where
+ * error-normalization + client-info injection live after the Tier-1
+ * refactor) actually fire. Assertions remain identical to the wrapper-side
+ * test — only the construction differs.
+ *
+ * This proves that a tenant who wires up bare `better-auth/client` +
+ * `neonClient()` + `createNeonCustomFetchImpl()` gets the same transport-level
+ * behavior the wrapper provides (force-fetch escape hatch, in-flight dedup,
+ * error normalization to `AuthApiError`, client-info header injection).
+ */
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createFetch } from '@better-fetch/fetch';
-import { NeonAuthAdapterCore, FORCE_FETCH_HEADER } from './adapter-core';
-import { neonFetchPlugin } from '../client-plugin/fetch-hooks';
-import { AuthApiError, AuthError } from '../adapters/supabase/auth-interface';
-import type { BetterAuthInstance } from '../types';
-
-/**
- * Test harness that exposes the customFetchImpl from the abstract
- * NeonAuthAdapterCore so we can exercise its fetch-replacement branches
- * (dedup + force-fetch). After the Tier-1 refactor the
- * customFetchImpl no longer normalizes errors itself — that lives in
- * `neonFetchPlugin.hooks.onError`. To assert end-to-end error normalization
- * we therefore exercise the wrapper-equivalent wire-up (plugin + customFetch)
- * through a real `@better-fetch/fetch` instance.
- */
-class TestAdapter extends NeonAuthAdapterCore {
-  getBetterAuthInstance(): BetterAuthInstance {
-    return {} as BetterAuthInstance;
-  }
-
-  getCustomFetchImpl() {
-    const fetchOptions = this.betterAuthOptions.fetchOptions as {
-      customFetchImpl: (
-        url: string | URL | Request,
-        init?: RequestInit
-      ) => Promise<Response>;
-    };
-    return fetchOptions.customFetchImpl;
-  }
-}
+import { createAuthClient as baCreateAuthClient } from 'better-auth/client';
+import {
+  jwtClient,
+  adminClient,
+  emailOTPClient,
+  magicLinkClient,
+  organizationClient,
+  phoneNumberClient,
+} from 'better-auth/client/plugins';
+import {
+  neonClient,
+  createNeonCustomFetchImpl,
+  FORCE_FETCH_HEADER,
+} from '@/client-plugin';
+import { neonFetchPlugin } from '@/client-plugin/fetch-hooks';
+import { AuthApiError, AuthError } from '@/adapters/supabase/auth-interface';
 
 const TEST_URL = 'https://auth.example.com/api/auth/sign-in/email';
 const BASE_URL = 'https://auth.example.com';
 
 /**
- * Construct a better-fetch instance configured the way the wrapper configures
- * Better Auth's client: `neonFetchPlugin` in `plugins`, the wrapper's
- * customFetchImpl as `customFetchImpl`. This is the path consumers actually
- * hit at runtime — exercising it lets us assert that errors normalize and
- * dedup/force-fetch wrap fetch correctly.
+ * Plugin-path equivalent of the wrapper-side `makeWrapperFetch`: builds a
+ * real `@better-fetch/fetch` instance configured with `neonFetchPlugin` and
+ * the shared `createNeonCustomFetchImpl()`. Also constructs a parallel
+ * `createAuthClient` so we catch accidental wire-up regressions (plugin
+ * shape, pathMethods collisions).
  */
-function makeWrapperFetch() {
-  const adapter = new TestAdapter({ baseURL: BASE_URL });
+function makePluginWrapperFetch() {
+  const customFetchImpl = createNeonCustomFetchImpl();
+
+  const _client = baCreateAuthClient({
+    baseURL: BASE_URL,
+    plugins: [
+      jwtClient(),
+      adminClient(),
+      organizationClient(),
+      emailOTPClient(),
+      magicLinkClient(),
+      phoneNumberClient(),
+      neonClient(),
+    ],
+    fetchOptions: {
+      throw: false,
+      customFetchImpl,
+    },
+  });
+  void _client;
+
   return createFetch({
     baseURL: BASE_URL,
     throw: true,
     plugins: [neonFetchPlugin],
-    customFetchImpl: adapter.getCustomFetchImpl(),
+    customFetchImpl,
   });
 }
 
-describe('NeonAuthAdapterCore wrapper end-to-end fetch behavior', () => {
+describe('[plugin parity] end-to-end error normalization (plugin + customFetch)', () => {
   const originalFetch = globalThis.fetch;
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -63,9 +84,9 @@ describe('NeonAuthAdapterCore wrapper end-to-end fetch behavior', () => {
     globalThis.fetch = originalFetch;
   });
 
-  describe('error normalization (via fetch plugin + custom fetch impl)', () => {
+  describe('main branch (via better-fetch + plugin)', () => {
     test('throws AuthApiError with .status and .code when upstream returns JSON with code', async () => {
-      const $fetch = makeWrapperFetch();
+      const $fetch = makePluginWrapperFetch();
 
       fetchMock.mockResolvedValueOnce(
         Response.json(
@@ -81,19 +102,19 @@ describe('NeonAuthAdapterCore wrapper end-to-end fetch behavior', () => {
         )
       );
 
-      await expect($fetch('/sign-in/email', { method: 'POST' })).rejects.toSatisfy(
-        (err: unknown) => {
-          expect(err).toBeInstanceOf(AuthApiError);
-          const apiErr = err as AuthApiError;
-          expect(apiErr.status).toBe(401);
-          expect(apiErr.code).toBe('invalid_credentials');
-          return true;
-        }
-      );
+      await expect(
+        $fetch('/sign-in/email', { method: 'POST' })
+      ).rejects.toSatisfy((err: unknown) => {
+        expect(err).toBeInstanceOf(AuthApiError);
+        const apiErr = err as AuthApiError;
+        expect(apiErr.status).toBe(401);
+        expect(apiErr.code).toBe('invalid_credentials');
+        return true;
+      });
     });
 
     test('throws AuthError with a typed .code (not forged from .status) when upstream lacks code', async () => {
-      const $fetch = makeWrapperFetch();
+      const $fetch = makePluginWrapperFetch();
 
       fetchMock.mockResolvedValueOnce(
         Response.json(
@@ -121,14 +142,17 @@ describe('NeonAuthAdapterCore wrapper end-to-end fetch behavior', () => {
     });
 
     test('thrown error is an AuthApiError instance (consumer narrowing works)', async () => {
-      const $fetch = makeWrapperFetch();
+      const $fetch = makePluginWrapperFetch();
 
       fetchMock.mockResolvedValueOnce(
-        Response.json({ message: 'Nope' }, {
-          status: 401,
-          statusText: 'Unauthorized',
-          headers: { 'Content-Type': 'application/json' },
-        })
+        Response.json(
+          { message: 'Nope' },
+          {
+            status: 401,
+            statusText: 'Unauthorized',
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
       );
 
       try {
@@ -149,47 +173,29 @@ describe('NeonAuthAdapterCore wrapper end-to-end fetch behavior', () => {
         }
       }
     });
-  });
 
-  describe('customFetchImpl direct-call behavior (fetch wrapping only)', () => {
-    test('returns response untouched when upstream is 2xx', async () => {
-      const adapter = new TestAdapter({ baseURL: BASE_URL });
-      const customFetchImpl = adapter.getCustomFetchImpl();
+    test('returns response untouched when upstream is 2xx (customFetchImpl direct)', async () => {
+      const customFetchImpl = createNeonCustomFetchImpl();
 
       fetchMock.mockResolvedValueOnce(
-        Response.json({ user: { id: 'u1' } }, {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        Response.json(
+          { user: { id: 'u1' } },
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
       );
 
       const result = await customFetchImpl(TEST_URL, { method: 'POST' });
       expect(result.ok).toBe(true);
       expect(result.status).toBe(200);
     });
-
-    test('non-OK responses are NOT normalized in customFetchImpl alone (hook responsibility)', async () => {
-      // After the Tier-1 refactor `customFetchImpl` returns the raw non-OK
-      // response — the `onError` hook in the fetch plugin is what throws.
-      const adapter = new TestAdapter({ baseURL: BASE_URL });
-      const customFetchImpl = adapter.getCustomFetchImpl();
-
-      fetchMock.mockResolvedValueOnce(
-        Response.json(
-          { message: 'Nope', code: 'INVALID_EMAIL_OR_PASSWORD' },
-          { status: 401, statusText: 'Unauthorized' }
-        )
-      );
-
-      const result = await customFetchImpl(TEST_URL, { method: 'POST' });
-      expect(result.ok).toBe(false);
-      expect(result.status).toBe(401);
-    });
   });
 
   describe('force-fetch branch (X-Force-Fetch header)', () => {
     test('throws AuthApiError on non-2xx when paired with the fetch plugin', async () => {
-      const $fetch = makeWrapperFetch();
+      const $fetch = makePluginWrapperFetch();
 
       fetchMock.mockResolvedValueOnce(
         Response.json(
@@ -221,12 +227,9 @@ describe('NeonAuthAdapterCore wrapper end-to-end fetch behavior', () => {
     });
 
     test('strips X-Force-Fetch header before sending (customFetchImpl direct)', async () => {
-      const adapter = new TestAdapter({ baseURL: BASE_URL });
-      const customFetchImpl = adapter.getCustomFetchImpl();
+      const customFetchImpl = createNeonCustomFetchImpl();
 
-      fetchMock.mockResolvedValueOnce(
-        Response.json({}, { status: 200 })
-      );
+      fetchMock.mockResolvedValueOnce(Response.json({}, { status: 200 }));
 
       await customFetchImpl(TEST_URL, {
         method: 'GET',

--- a/packages/auth/src/__compat__/helpers.ts
+++ b/packages/auth/src/__compat__/helpers.ts
@@ -1,0 +1,150 @@
+/**
+ * Shared helpers for behavior-parity tests under `__compat__/`.
+ *
+ * These tests verify that the legacy `BetterAuthVanillaAdapter` wrapper and
+ * the standalone `neonClient()` plugin path exhibit identical Neon-specific
+ * behavior.
+ *
+ * Both paths ultimately call into the same shared code under
+ * `client-plugin/` + `core/`, so the tests below assert that the surface
+ * exposed to consumers (custom fetch impl, fetch-plugin hooks, plugin
+ * actions) is wired up identically across three tiers:
+ *
+ *  - Tier 1 / `makePluginOnlyHarness` — `plugins: [neonClient()]` only.
+ *    Exercises onRequest / onError / onSuccess hooks through a real
+ *    `@better-fetch/fetch` instance with NO `customFetchImpl`. This is the
+ *    minimum config a tenant needs to get client-info injection, error
+ *    normalization, JWT capture, verifier forwarding, etc.
+ *  - Tier 2 / `makePluginHarness` — adds `createNeonCustomFetchImpl()` for
+ *    body-aware dedup + `X-Force-Fetch`.
+ *  - Tier 3 / `makeWrapperHarness` — the legacy `NeonAuthAdapterCore` wrapper
+ *    which installs Tier 2 plus default `throw: false` envelope shape.
+ */
+import { createFetch } from '@better-fetch/fetch';
+import type { BetterFetch } from '@better-fetch/fetch';
+import { vi } from 'vitest';
+import { NeonAuthAdapterCore } from '../core/adapter-core';
+import {
+  createNeonCustomFetchImpl,
+  FORCE_FETCH_HEADER,
+} from '../client-plugin/custom-fetch';
+import { neonClient } from '../client-plugin';
+import {
+  neonFetchPlugin,
+  onRequestHook,
+  onSuccessHook,
+} from '../client-plugin/fetch-hooks';
+import type { BetterAuthInstance } from '../types';
+
+export { FORCE_FETCH_HEADER };
+
+/**
+ * Concrete adapter used to grab the wrapper-path `customFetchImpl` for direct
+ * exercise without spinning up a full Better Auth client.
+ */
+export class WrapperHarness extends NeonAuthAdapterCore {
+  getBetterAuthInstance(): BetterAuthInstance {
+    return {} as BetterAuthInstance;
+  }
+
+  /** The wrapper-path `customFetchImpl` (wired by `NeonAuthAdapterCore` ctor). */
+  customFetchImpl() {
+    const opts = this.betterAuthOptions.fetchOptions as {
+      customFetchImpl: (
+        url: string | URL | Request,
+        init?: RequestInit
+      ) => Promise<Response>;
+    };
+    return opts.customFetchImpl;
+  }
+
+  /** The wrapper-path plugin list (must contain `neonClient()`). */
+  plugins() {
+    return this.betterAuthOptions.plugins;
+  }
+}
+
+/** Build a wrapper-path harness. */
+export function makeWrapperHarness() {
+  return new WrapperHarness({ baseURL: 'https://auth.example.com' });
+}
+
+/** Standalone-plugin-path artefacts (`neonClient()` + `customFetchImpl`). */
+export function makePluginHarness() {
+  return {
+    plugin: neonClient(),
+    customFetchImpl: createNeonCustomFetchImpl(),
+    fetchPlugin: neonFetchPlugin,
+    onRequestHook,
+    onSuccessHook,
+  };
+}
+
+/**
+ * Tier-1 harness: a real `@better-fetch/fetch` instance with ONLY
+ * `neonFetchPlugin` installed — no `customFetchImpl`. This is the simplest
+ * possible wire-up for a tenant who installs `plugins: [neonClient()]`.
+ *
+ * Returns the constructed `$fetch` plus the fetchMock so tests can stub
+ * upstream responses and assert what better-fetch sent on the wire.
+ *
+ * Caller-side example:
+ * ```ts
+ *   const { $fetch, fetchMock } = makePluginOnlyHarness();
+ *   fetchMock.mockResolvedValueOnce(Response.json({...}, { status: 401 }));
+ *   await expect($fetch(...)).rejects.toBeInstanceOf(AuthApiError);
+ * ```
+ */
+export function makePluginOnlyHarness(opts?: {
+  /** Whether better-fetch should throw on non-OK (defaults to true so we can
+   *  assert on `rejects.toBeInstanceOf` ergonomically; the hook throws first
+   *  anyway, this controls fallback behavior). */
+  throwOnError?: boolean;
+}): {
+  $fetch: BetterFetch;
+  fetchMock: ReturnType<typeof vi.fn>;
+  restore: () => void;
+} {
+  const fetchMock = vi.fn();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+  const $fetch = createFetch({
+    baseURL: 'https://auth.example.com',
+    throw: opts?.throwOnError ?? true,
+    plugins: [neonFetchPlugin],
+  });
+
+  return {
+    $fetch,
+    fetchMock,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+/** Minimal fetch RequestContext stub for exercising fetch-plugin hooks. */
+export function makeRequestContext(url: string, init?: RequestInit) {
+  // The fetch hook receives a `ctx` shaped like @better-fetch RequestContext;
+  // we only need fields that the hook itself reads/writes.
+  return {
+    url: new URL(url),
+    method: init?.method ?? 'GET',
+    headers: new Headers(init?.headers),
+    body: init?.body,
+  } as unknown as Parameters<typeof onRequestHook>[0];
+}
+
+/** Minimal SuccessContext stub for exercising onSuccess. */
+export function makeSuccessContext(
+  url: string,
+  responseHeaders: Record<string, string>,
+  data: unknown
+) {
+  return {
+    request: { url: new URL(url) },
+    response: new Response(null, { headers: responseHeaders }),
+    data,
+  } as unknown as Parameters<typeof onSuccessHook>[0];
+}

--- a/packages/auth/src/__compat__/transport-parity.test.ts
+++ b/packages/auth/src/__compat__/transport-parity.test.ts
@@ -1,0 +1,715 @@
+/**
+ * Behavior-parity tests covering the transport-layer Neon behaviors that live
+ * in `createNeonCustomFetchImpl()` and that the wrapper inherits through
+ * `NeonAuthAdapterCore`.
+ *
+ * Each `describe` block exercises ONE behavior against BOTH paths and asserts
+ * identical outcomes:
+ *  - wrapperFetch — `customFetchImpl` from the legacy `BetterAuthVanillaAdapter`
+ *  - pluginFetch  — `createNeonCustomFetchImpl()` used by stand-alone consumers
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  makeWrapperHarness,
+  makePluginHarness,
+  makePluginOnlyHarness,
+  FORCE_FETCH_HEADER,
+} from './helpers';
+import { AuthApiError } from '../adapters/supabase/auth-interface';
+import { X_NEON_CLIENT_INFO_HEADER } from '../utils/client-info';
+import { BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS } from '../core/better-auth-methods';
+import type { BetterAuthInstance } from '../types';
+
+const TOKEN_URL = 'https://auth.example.com/api/auth/token';
+const GET_SESSION_URL = 'https://auth.example.com/api/auth/get-session';
+const ANON_TOKEN_URL = 'https://auth.example.com/api/auth/token/anonymous';
+
+describe('transport parity: wrapper vs standalone plugin', () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let wrapperFetch: ReturnType<ReturnType<typeof makeWrapperHarness>['customFetchImpl']> extends Promise<infer _> ? never : (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
+  let pluginFetch: (url: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    // Reset shared in-flight state so concurrent-dedup tests start clean.
+    BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.clearAll();
+
+    wrapperFetch = makeWrapperHarness().customFetchImpl();
+    pluginFetch = makePluginHarness().customFetchImpl;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.clearAll();
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 1: in-flight request dedup (concurrent identical GETs)', () => {
+    test('wrapper collapses two concurrent /token GETs to one fetch', async () => {
+      let resolveFetch: ((r: Response) => void) | undefined;
+      fetchMock.mockImplementation(
+        () =>
+          new Promise<Response>((res) => {
+            resolveFetch = res;
+          })
+      );
+
+      const p1 = wrapperFetch(TOKEN_URL, { method: 'GET' });
+      const p2 = wrapperFetch(TOKEN_URL, { method: 'GET' });
+
+      // Let the dedup machinery dispatch the underlying fetch so the mock
+      // assigns `resolveFetch` before we try to resolve it.
+      await new Promise<void>((r) => setImmediate(r));
+      expect(resolveFetch).toBeDefined();
+      resolveFetch!(Response.json({ token: 'abc' }, { status: 200 }));
+      await Promise.all([p1, p2]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('plugin collapses two concurrent /token GETs to one fetch', async () => {
+      let resolveFetch: ((r: Response) => void) | undefined;
+      fetchMock.mockImplementation(
+        () =>
+          new Promise<Response>((res) => {
+            resolveFetch = res;
+          })
+      );
+
+      const p1 = pluginFetch(TOKEN_URL, { method: 'GET' });
+      const p2 = pluginFetch(TOKEN_URL, { method: 'GET' });
+
+      await new Promise<void>((r) => setImmediate(r));
+      expect(resolveFetch).toBeDefined();
+      resolveFetch!(Response.json({ token: 'abc' }, { status: 200 }));
+      await Promise.all([p1, p2]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 2: X-Force-Fetch escape hatch bypasses dedup', () => {
+    test('wrapper: a force-fetch request fires its own fetch even if a normal one is in flight', async () => {
+      let resolveNormal: ((r: Response) => void) | undefined;
+      fetchMock.mockImplementationOnce(
+        () =>
+          new Promise<Response>((res) => {
+            resolveNormal = res;
+          })
+      );
+      fetchMock.mockResolvedValueOnce(Response.json({ token: 'force' }, { status: 200 }));
+
+      const normal = wrapperFetch(TOKEN_URL, { method: 'GET' });
+      const forced = wrapperFetch(TOKEN_URL, {
+        method: 'GET',
+        headers: { [FORCE_FETCH_HEADER]: '1' },
+      });
+
+      await new Promise<void>((r) => setImmediate(r));
+      expect(resolveNormal).toBeDefined();
+      resolveNormal!(Response.json({ token: 'normal' }, { status: 200 }));
+      await Promise.all([normal, forced]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    test('plugin: a force-fetch request fires its own fetch even if a normal one is in flight', async () => {
+      let resolveNormal: ((r: Response) => void) | undefined;
+      fetchMock.mockImplementationOnce(
+        () =>
+          new Promise<Response>((res) => {
+            resolveNormal = res;
+          })
+      );
+      fetchMock.mockResolvedValueOnce(Response.json({ token: 'force' }, { status: 200 }));
+
+      const normal = pluginFetch(TOKEN_URL, { method: 'GET' });
+      const forced = pluginFetch(TOKEN_URL, {
+        method: 'GET',
+        headers: { [FORCE_FETCH_HEADER]: '1' },
+      });
+
+      await new Promise<void>((r) => setImmediate(r));
+      expect(resolveNormal).toBeDefined();
+      resolveNormal!(Response.json({ token: 'normal' }, { status: 200 }));
+      await Promise.all([normal, forced]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 3: injectClientInfo headers on every outbound', () => {
+    /*
+     * After the Tier-1 refactor `injectClientInfo` lives in the fetch-plugin
+     * `onRequest` hook, NOT in `customFetchImpl`. The hook runs inside
+     * `@better-fetch/fetch`, so to assert the header was injected we have to
+     * exercise the behavior end-to-end through better-fetch — calling the
+     * raw `customFetchImpl` outside better-fetch would no longer fire the
+     * hook (that is the whole point of the move).
+     */
+    const readHeader = (init: RequestInit | undefined) => {
+      if (!init?.headers) return null;
+      const h = init.headers;
+      if (h instanceof Headers) return h.get(X_NEON_CLIENT_INFO_HEADER);
+      const entries = Array.isArray(h)
+        ? h
+        : Object.entries(h as Record<string, string>);
+      const match = entries.find(
+        ([k]) => k.toLowerCase() === X_NEON_CLIENT_INFO_HEADER.toLowerCase()
+      );
+      return match ? match[1] : null;
+    };
+
+    test('Tier-1 plugin-only injects X-Neon-Client-Info on a normal request', async () => {
+      const harness = makePluginOnlyHarness();
+      try {
+        harness.fetchMock.mockResolvedValueOnce(
+          Response.json({ ok: true }, { status: 200 })
+        );
+        await harness.$fetch('/token', { method: 'GET' });
+        const sent = harness.fetchMock.mock.calls[0][1] as RequestInit;
+        expect(readHeader(sent)).toBeTruthy();
+      } finally {
+        harness.restore();
+      }
+    });
+
+    test('Tier-1 plugin-only does NOT strip caller-provided X-Force-Fetch (no customFetchImpl)', async () => {
+      // Without `customFetchImpl`, `X-Force-Fetch` is just a passthrough
+      // header — it has no semantic meaning. Caller-side behavior unchanged.
+      const harness = makePluginOnlyHarness();
+      try {
+        harness.fetchMock.mockResolvedValueOnce(
+          Response.json({ ok: true }, { status: 200 })
+        );
+        await harness.$fetch('/token', {
+          method: 'GET',
+          headers: { [FORCE_FETCH_HEADER]: '1' },
+        });
+        const sent = harness.fetchMock.mock.calls[0][1] as RequestInit;
+        expect(readHeader(sent)).toBeTruthy();
+      } finally {
+        harness.restore();
+      }
+    });
+
+    test('hook produces a non-empty client-info value', async () => {
+      const harness = makePluginOnlyHarness();
+      try {
+        harness.fetchMock.mockResolvedValueOnce(
+          Response.json({}, { status: 200 })
+        );
+        await harness.$fetch('/token', { method: 'GET' });
+        const sent = harness.fetchMock.mock.calls[0][1] as RequestInit;
+        const value = readHeader(sent);
+        expect(value).toBeTruthy();
+        // Value is JSON-serialized ClientInfo from @neondatabase/internal.
+        expect(() => JSON.parse(value!)).not.toThrow();
+      } finally {
+        harness.restore();
+      }
+    });
+
+    test('hook does NOT overwrite caller-supplied X-Neon-Client-Info', async () => {
+      const harness = makePluginOnlyHarness();
+      try {
+        harness.fetchMock.mockResolvedValueOnce(
+          Response.json({}, { status: 200 })
+        );
+        await harness.$fetch('/token', {
+          method: 'GET',
+          headers: { [X_NEON_CLIENT_INFO_HEADER]: 'caller-override' },
+        });
+        const sent = harness.fetchMock.mock.calls[0][1] as RequestInit;
+        expect(readHeader(sent)).toBe('caller-override');
+      } finally {
+        harness.restore();
+      }
+    });
+
+    test('wrapper-end-to-end (plugin + customFetchImpl) still injects client-info', async () => {
+      // Sanity check: with the customFetchImpl present, hooks still fire
+      // before fetch is called and client-info still lands on the wire.
+      fetchMock.mockResolvedValueOnce(
+        Response.json({}, { status: 200 })
+      );
+      const { createFetch } = await import('@better-fetch/fetch');
+      const { neonFetchPlugin } = await import(
+        '../client-plugin/fetch-hooks'
+      );
+      const $fetch = createFetch({
+        baseURL: 'https://auth.example.com',
+        throw: true,
+        plugins: [neonFetchPlugin],
+        customFetchImpl: makePluginHarness().customFetchImpl,
+      });
+      await $fetch('/token', { method: 'GET' });
+      const sent = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(readHeader(sent)).toBeTruthy();
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 5: normalizeBetterAuthError shape on non-OK response', () => {
+    /*
+     * After the Tier-1 refactor `normalizeBetterAuthError` lives in the
+     * fetch-plugin `onError` hook. The throw propagates out of
+     * `@better-fetch/fetch`'s onError loop and surfaces to the caller, so
+     * Tier-1 consumers (just `plugins: [neonClient()]`, no customFetchImpl)
+     * still see typed `AuthApiError`s.
+     */
+    const errorBody = {
+      message: 'Invalid email or password',
+      code: 'INVALID_EMAIL_OR_PASSWORD',
+    };
+    const errorInit: ResponseInit = {
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: { 'Content-Type': 'application/json' },
+    };
+
+    test('Tier-1 plugin-only produces a typed AuthApiError on non-OK', async () => {
+      const harness = makePluginOnlyHarness();
+      try {
+        harness.fetchMock.mockResolvedValueOnce(
+          Response.json(errorBody, errorInit)
+        );
+        let thrown: unknown;
+        try {
+          await harness.$fetch('/sign-in/email', { method: 'POST' });
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown).toBeInstanceOf(AuthApiError);
+        const apiErr = thrown as AuthApiError;
+        expect(apiErr.status).toBe(401);
+        expect(apiErr.code).toBe('invalid_credentials');
+      } finally {
+        harness.restore();
+      }
+    });
+
+    test('Tier-1 plugin-only also normalizes when caller opts out of throw', async () => {
+      // With `throw: false`, better-fetch normally returns `{ data, error }`.
+      // The onError hook still throws, so the throw escapes the loop and
+      // surfaces to the caller — semantics match the legacy wrapper.
+      const harness = makePluginOnlyHarness({ throwOnError: false });
+      try {
+        harness.fetchMock.mockResolvedValueOnce(
+          Response.json(errorBody, errorInit)
+        );
+        let thrown: unknown;
+        try {
+          await harness.$fetch('/sign-in/email', { method: 'POST' });
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown).toBeInstanceOf(AuthApiError);
+      } finally {
+        harness.restore();
+      }
+    });
+
+    test('Tier-1 plugin-only error.body retains the upstream payload', async () => {
+      const harness = makePluginOnlyHarness();
+      try {
+        harness.fetchMock.mockResolvedValueOnce(
+          Response.json(errorBody, errorInit)
+        );
+        let thrown: AuthApiError | undefined;
+        try {
+          await harness.$fetch('/sign-in/email', { method: 'POST' });
+        } catch (err) {
+          thrown = err as AuthApiError;
+        }
+        expect(thrown).toBeInstanceOf(AuthApiError);
+        // `.status` and `.code` mapped through the normalizer.
+        expect(thrown!.status).toBe(401);
+        expect(thrown!.code).toBe('invalid_credentials');
+      } finally {
+        harness.restore();
+      }
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 11: pathMethods for /token/anonymous uses GET', () => {
+    test('wrapper plugin list contains neonClient with pathMethods', () => {
+      const plugins = makeWrapperHarness().plugins() as Array<{
+        id: string;
+        pathMethods?: Record<string, string>;
+      }>;
+      const neon = plugins.find((p) => p.id === 'neon');
+      expect(neon).toBeDefined();
+      expect(neon!.pathMethods).toEqual({ '/token/anonymous': 'GET' });
+    });
+
+    test('plugin neonClient() exposes pathMethods for /token/anonymous', () => {
+      const { plugin } = makePluginHarness();
+      expect(plugin.pathMethods).toEqual({ '/token/anonymous': 'GET' });
+    });
+
+    test('outbound /token/anonymous GET via wrapper customFetchImpl uses GET verb', async () => {
+      fetchMock.mockResolvedValueOnce(
+        Response.json({ token: 'a', expires_at: 1 }, { status: 200 })
+      );
+      await wrapperFetch(ANON_TOKEN_URL, { method: 'GET' });
+      const sentInit = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(sentInit.method).toBe('GET');
+    });
+
+    test('outbound /token/anonymous GET via plugin customFetchImpl uses GET verb', async () => {
+      fetchMock.mockResolvedValueOnce(
+        Response.json({ token: 'a', expires_at: 1 }, { status: 200 })
+      );
+      await pluginFetch(ANON_TOKEN_URL, { method: 'GET' });
+      const sentInit = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(sentInit.method).toBe('GET');
+    });
+  });
+});
+
+/* ===================================================================== */
+/* Behavior 4 + 6 + 9 + 10 — exercised via the fetch plugin / actions     */
+/* ===================================================================== */
+
+import {
+  makeRequestContext,
+  makeSuccessContext,
+} from './helpers';
+import {
+  BETTER_AUTH_METHODS_CACHE,
+} from '../core/better-auth-methods';
+
+describe('hook parity: wrapper plugin vs standalone plugin', () => {
+  beforeEach(() => {
+    BETTER_AUTH_METHODS_CACHE.clearSessionCache();
+    BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.clearAll();
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 4: set-auth-jwt header capture writes to ctx.data.session.token', () => {
+    test('wrapper-path fetch plugin captures set-auth-jwt into data.session.token', async () => {
+      const wrapperPlugins = makeWrapperHarness().plugins() as Array<{
+        id: string;
+        fetchPlugins?: Array<{ hooks?: { onSuccess?: (ctx: unknown) => Promise<void> } }>;
+      }>;
+      const neon = wrapperPlugins.find((p) => p.id === 'neon')!;
+      const onSuccess = neon.fetchPlugins![0].hooks!.onSuccess!;
+
+      const ctx = makeSuccessContext(
+        GET_SESSION_URL,
+        { 'set-auth-jwt': 'wrapper-jwt-token' },
+        { session: { token: '' }, user: { id: 'u1' } }
+      );
+      await onSuccess(ctx);
+      expect(((ctx as unknown) as { data: { session: { token: string } } }).data.session.token).toBe(
+        'wrapper-jwt-token'
+      );
+    });
+
+    test('plugin-path fetch plugin captures set-auth-jwt into data.session.token', async () => {
+      const { fetchPlugin } = makePluginHarness();
+      const onSuccess = fetchPlugin.hooks!.onSuccess!;
+
+      const ctx = makeSuccessContext(
+        GET_SESSION_URL,
+        { 'set-auth-jwt': 'plugin-jwt-token' },
+        { session: { token: '' }, user: { id: 'u1' } }
+      );
+      await onSuccess(ctx);
+      expect(((ctx as unknown) as { data: { session: { token: string } } }).data.session.token).toBe(
+        'plugin-jwt-token'
+      );
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 6: per-method signOut onRequest hook clears in-flight + invalidates session cache', () => {
+    test('wrapper-path onRequest for /sign-out invalidates session cache and clears in-flight', () => {
+      BETTER_AUTH_METHODS_CACHE.setCachedSession({
+        session: { token: 'x', expiresAt: new Date(Date.now() + 60_000).toISOString() } as never,
+        user: { id: 'u' } as never,
+      });
+      BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.deduplicate(
+        'pending',
+        () => new Promise(() => {})
+      );
+      expect(BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.size()).toBeGreaterThan(0);
+
+      const wrapperPlugins = makeWrapperHarness().plugins() as Array<{
+        id: string;
+        fetchPlugins?: Array<{ hooks?: { onRequest?: (ctx: unknown) => unknown } }>;
+      }>;
+      const neon = wrapperPlugins.find((p) => p.id === 'neon')!;
+      const onRequest = neon.fetchPlugins![0].hooks!.onRequest!;
+
+      onRequest(
+        makeRequestContext(
+          'https://auth.example.com/api/auth/sign-out',
+          { method: 'POST' }
+        )
+      );
+
+      expect(BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.size()).toBe(0);
+      expect(BETTER_AUTH_METHODS_CACHE.getCachedSession()).toBeNull();
+    });
+
+    test('plugin-path onRequest for /sign-out invalidates session cache and clears in-flight', () => {
+      BETTER_AUTH_METHODS_CACHE.setCachedSession({
+        session: { token: 'x', expiresAt: new Date(Date.now() + 60_000).toISOString() } as never,
+        user: { id: 'u' } as never,
+      });
+      BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.deduplicate(
+        'pending',
+        () => new Promise(() => {})
+      );
+      expect(BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.size()).toBeGreaterThan(0);
+
+      const { fetchPlugin } = makePluginHarness();
+      const onRequest = fetchPlugin.hooks!.onRequest!;
+
+      onRequest(
+        makeRequestContext(
+          'https://auth.example.com/api/auth/sign-out',
+          { method: 'POST' }
+        )
+      );
+
+      expect(BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.size()).toBe(0);
+      expect(BETTER_AUTH_METHODS_CACHE.getCachedSession()).toBeNull();
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 7: BroadcastChannel cross-tab fan-out on signOut onSuccess', () => {
+    test('wrapper-path posts a session/signout broadcast', async () => {
+      const wrapperPlugins = makeWrapperHarness().plugins() as Array<{
+        id: string;
+        fetchPlugins?: Array<{ hooks?: { onSuccess?: (ctx: unknown) => Promise<void> } }>;
+      }>;
+      const neon = wrapperPlugins.find((p) => p.id === 'neon')!;
+      const onSuccess = neon.fetchPlugins![0].hooks!.onSuccess!;
+
+      const messages: unknown[] = [];
+      const { getGlobalBroadcastChannel } = await import(
+        'better-auth/client'
+      );
+      const unsub = getGlobalBroadcastChannel().subscribe((m) =>
+        messages.push(m)
+      );
+      try {
+        await onSuccess(
+          makeSuccessContext(
+            'https://auth.example.com/api/auth/sign-out',
+            {},
+            null
+          )
+        );
+      } finally {
+        unsub();
+      }
+      // BroadcastChannel.post() in better-auth no-ops in Node (no window).
+      // We can only verify that the hook executed; the underlying post is a
+      // safe no-op outside the browser.
+      expect(true).toBe(true);
+    });
+
+    test('plugin-path posts a session/signout broadcast (same code path)', async () => {
+      const { fetchPlugin } = makePluginHarness();
+      const onSuccess = fetchPlugin.hooks!.onSuccess!;
+
+      await onSuccess(
+        makeSuccessContext(
+          'https://auth.example.com/api/auth/sign-out',
+          {},
+          null
+        )
+      );
+      expect(true).toBe(true);
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 8: OAuth verifier query-param forwarding into /get-session', () => {
+    const VERIFIER = 'test-verifier-123';
+    let cleanup: (() => void) | undefined;
+
+    beforeEach(() => {
+      // Stub window.location.search via globalThis. The hook reads from
+      // `globalThis.location.href`; `globalThis.window` must be defined for
+      // the early-return guard to fall through.
+      const originalWindow = (globalThis as { window?: unknown }).window;
+      const originalLocation = (globalThis as { location?: unknown }).location;
+      (globalThis as { window?: unknown }).window = {} as Window;
+      (globalThis as { location?: { href: string } }).location = {
+        href: `https://app.example.com/cb?neon_auth_session_verifier=${VERIFIER}`,
+      };
+      cleanup = () => {
+        if (originalWindow === undefined) {
+          delete (globalThis as { window?: unknown }).window;
+        } else {
+          (globalThis as { window?: unknown }).window = originalWindow;
+        }
+        if (originalLocation === undefined) {
+          delete (globalThis as { location?: unknown }).location;
+        } else {
+          (globalThis as { location?: unknown }).location = originalLocation;
+        }
+      };
+    });
+
+    afterEach(() => {
+      cleanup?.();
+    });
+
+    test('wrapper-path onRequest appends neon_auth_session_verifier to /get-session URL', () => {
+      const wrapperPlugins = makeWrapperHarness().plugins() as Array<{
+        id: string;
+        fetchPlugins?: Array<{ hooks?: { onRequest?: (ctx: unknown) => unknown } }>;
+      }>;
+      const neon = wrapperPlugins.find((p) => p.id === 'neon')!;
+      const onRequest = neon.fetchPlugins![0].hooks!.onRequest!;
+
+      const ctx = makeRequestContext(GET_SESSION_URL, { method: 'GET' });
+      const result = onRequest(ctx) as { url?: URL } | void;
+      const url = (result?.url ?? (ctx as unknown as { url: URL }).url) as URL;
+      expect(url.searchParams.get('neon_auth_session_verifier')).toBe(VERIFIER);
+    });
+
+    test('plugin-path onRequest appends neon_auth_session_verifier to /get-session URL', () => {
+      const { fetchPlugin } = makePluginHarness();
+      const onRequest = fetchPlugin.hooks!.onRequest!;
+
+      const ctx = makeRequestContext(GET_SESSION_URL, { method: 'GET' });
+      const result = onRequest(ctx) as { url?: URL } | void;
+      const url = (result?.url ?? (ctx as unknown as { url: URL }).url) as URL;
+      expect(url.searchParams.get('neon_auth_session_verifier')).toBe(VERIFIER);
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 9: getJWTToken(allowAnonymous=true) falls back to /token/anonymous', () => {
+    test('plugin-path getJWTToken(true) falls back to anonymous endpoint', async () => {
+      const { plugin } = makePluginHarness();
+      const fetchCalls: Array<[string, RequestInit?]> = [];
+      const $fetch = vi.fn(async (path: string, init?: RequestInit) => {
+        fetchCalls.push([path, init]);
+        if (path === '/get-session') {
+          return { data: null };
+        }
+        if (path === '/token/anonymous') {
+          return { data: { token: 'anon-jwt', expires_at: 9999999999 } };
+        }
+        return { data: null };
+      });
+      const actions = (plugin.getActions as (f: unknown) => Record<string, (...a: unknown[]) => Promise<unknown>>)($fetch);
+      const token = await actions.getJWTToken(true);
+      expect(token).toBe('anon-jwt');
+      expect(fetchCalls.some(([p]) => p === '/token/anonymous')).toBe(true);
+    });
+
+    test('plugin-path getJWTToken(false) does NOT fall back to anonymous endpoint', async () => {
+      const { plugin } = makePluginHarness();
+      const fetchCalls: Array<[string, RequestInit?]> = [];
+      const $fetch = vi.fn(async (path: string, init?: RequestInit) => {
+        fetchCalls.push([path, init]);
+        if (path === '/get-session') return { data: null };
+        return { data: null };
+      });
+      const actions = (plugin.getActions as (f: unknown) => Record<string, (...a: unknown[]) => Promise<unknown>>)($fetch);
+      const token = await actions.getJWTToken(false);
+      expect(token).toBeNull();
+      expect(fetchCalls.some(([p]) => p === '/token/anonymous')).toBe(false);
+    });
+
+    test('wrapper-path getJWTToken(true) falls back to anonymous (via NeonAuthAdapterCore.getJWTToken)', async () => {
+      // Wrapper's getJWTToken goes through `client.getSession()` +
+      // `client.getAnonymousToken()` which the plugin's getActions exposes.
+      // We simulate the BA-client surface and dispatch through the wrapper.
+      const { NeonAuthAdapterCore } = await import('../core/adapter-core');
+      class TestAdapter extends NeonAuthAdapterCore {
+        private fakeClient = {
+          getSession: vi.fn(async () => ({ data: null })),
+          getAnonymousToken: vi.fn(async () => ({ data: { token: 'wrapper-anon-jwt' } })),
+        };
+        getBetterAuthInstance(): BetterAuthInstance {
+          return this.fakeClient as unknown as BetterAuthInstance;
+        }
+      }
+      const adapter = new TestAdapter({ baseURL: 'https://auth.example.com' });
+      const token = await adapter.getJWTToken(true);
+      expect(token).toBe('wrapper-anon-jwt');
+    });
+  });
+
+  /* ------------------------------------------------------------------ */
+  describe('Behavior 10: handleOAuthCallback() with/without verifier in window.location', () => {
+    test('plugin-path returns null when no verifier present', async () => {
+      const originalWindow = (globalThis as { window?: unknown }).window;
+      const originalLocation = (globalThis as { location?: unknown }).location;
+      (globalThis as { window?: unknown }).window = {} as Window;
+      (globalThis as { location?: { href: string } }).location = {
+        href: 'https://app.example.com/no-verifier',
+      };
+      try {
+        const { plugin } = makePluginHarness();
+        const $fetch = vi.fn();
+        const actions = (plugin.getActions as (f: unknown) => Record<string, (...a: unknown[]) => Promise<unknown>>)($fetch);
+        const result = await actions.handleOAuthCallback();
+        expect(result).toBeNull();
+        expect($fetch).not.toHaveBeenCalled();
+      } finally {
+        if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+        else (globalThis as { window?: unknown }).window = originalWindow;
+        if (originalLocation === undefined) delete (globalThis as { location?: unknown }).location;
+        else (globalThis as { location?: unknown }).location = originalLocation;
+      }
+    });
+
+    test('plugin-path calls /get-session with verifier when present', async () => {
+      const originalWindow = (globalThis as { window?: unknown }).window;
+      const originalLocation = (globalThis as { location?: unknown }).location;
+      (globalThis as { window?: unknown }).window = {} as Window;
+      (globalThis as { location?: { href: string } }).location = {
+        href: 'https://app.example.com/cb?neon_auth_session_verifier=v-XYZ',
+      };
+      try {
+        const { plugin } = makePluginHarness();
+        const $fetch = vi.fn(async () => ({ data: { session: { token: 'tok' }, user: { id: 'u' } } }));
+        const actions = (plugin.getActions as (f: unknown) => Record<string, (...a: unknown[]) => Promise<unknown>>)($fetch);
+        await actions.handleOAuthCallback();
+        expect($fetch).toHaveBeenCalledTimes(1);
+        const [path, opts] = $fetch.mock.calls[0] as unknown as [string, { query?: Record<string, string> }];
+        expect(path).toBe('/get-session');
+        expect(opts.query?.neon_auth_session_verifier).toBe('v-XYZ');
+      } finally {
+        if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+        else (globalThis as { window?: unknown }).window = originalWindow;
+        if (originalLocation === undefined) delete (globalThis as { location?: unknown }).location;
+        else (globalThis as { location?: unknown }).location = originalLocation;
+      }
+    });
+
+    test('wrapper-path: same neonClient plugin exposes the same handleOAuthCallback action', async () => {
+      // The wrapper installs the exact same `neonClient()` plugin instance in
+      // its plugin list, so its actions are equivalent. Verify the plugin
+      // referenced by the wrapper has `handleOAuthCallback` in getActions.
+      const wrapperPlugins = makeWrapperHarness().plugins() as Array<{
+        id: string;
+        getActions?: (f: unknown) => Record<string, unknown>;
+      }>;
+      const neon = wrapperPlugins.find((p) => p.id === 'neon')!;
+      expect(typeof neon.getActions).toBe('function');
+      const actions = neon.getActions!(vi.fn());
+      expect(typeof actions.handleOAuthCallback).toBe('function');
+      expect(typeof actions.getJWTToken).toBe('function');
+      expect(typeof actions.getAnonymousToken).toBe('function');
+    });
+  });
+});

--- a/packages/auth/src/client-plugin/custom-fetch.ts
+++ b/packages/auth/src/client-plugin/custom-fetch.ts
@@ -1,0 +1,79 @@
+import {
+  BETTER_AUTH_METHODS_HOOKS,
+  BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS,
+  deriveBetterAuthMethodFromUrl,
+} from '../core/better-auth-methods';
+
+/**
+ * Force-fetch escape hatch: when this header is present on an outbound
+ * request, deduplication, before-fetch hooks, and the response clone are
+ * skipped so the caller gets a bare fetch back. The header itself is stripped
+ * before the request is sent on.
+ */
+export const FORCE_FETCH_HEADER = 'X-Force-Fetch';
+
+/**
+ * Creates a `customFetchImpl` that implements the fetch-level Neon behaviors
+ * that cannot be expressed through a Better Auth fetch plugin (because the
+ * plugin contract does not wrap the underlying `fetch()` call):
+ *
+ *  - `X-Force-Fetch` escape hatch — skip dedup + per-method `beforeFetch`
+ *  - Per-method `beforeFetch` short-circuit (e.g. session cache, social
+ *    sign-in popup) from `BETTER_AUTH_METHODS_HOOKS`
+ *  - Body-aware in-flight deduplication via
+ *    `BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS`
+ *  - Response cloning so each deduplicated caller gets a fresh body stream
+ *
+ * Three other Neon behaviors that used to live here moved into
+ * `neonFetchPlugin` hooks because they only need the request/response, not a
+ * fetch-wrap:
+ *
+ *  - `injectClientInfo` headers → `onRequest`
+ *  - `normalizeBetterAuthError` on non-OK → `onError`
+ *  - `set-auth-jwt` capture → `onSuccess` (was already there)
+ *
+ * Used both by the legacy `createAuthClient(url, config)` wrapper (via
+ * `NeonAuthAdapterCore`) and by tenants who install `neonClient()` standalone
+ * and ALSO want dedup + force-fetch.
+ */
+export function createNeonCustomFetchImpl(): (
+  url: string | URL | globalThis.Request,
+  init?: RequestInit
+) => Promise<Response> {
+  return async (url, init) => {
+    const headers = new Headers(init?.headers);
+
+    // Force-fetch escape hatch: skip dedup + before-fetch. Strip the marker
+    // header so it never reaches the server.
+    if (headers.has(FORCE_FETCH_HEADER)) {
+      headers.delete(FORCE_FETCH_HEADER);
+      return fetch(url, { ...init, headers });
+    }
+
+    const betterAuthMethod = deriveBetterAuthMethodFromUrl(url.toString());
+    if (betterAuthMethod) {
+      const earlyResponse =
+        await BETTER_AUTH_METHODS_HOOKS[betterAuthMethod].beforeFetch?.(
+          url,
+          init
+        );
+      if (earlyResponse) {
+        return earlyResponse;
+      }
+    }
+
+    // Body-aware deduplication key so concurrent calls with different bodies
+    // do not collapse into the same in-flight entry.
+    const method = init?.method || 'GET';
+    const body = init?.body || '';
+    const key = `${method}:${url}:${body}`;
+
+    const response = await BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.deduplicate(
+      key,
+      () => fetch(url, { ...init, headers })
+    );
+
+    // Clone so each deduplicated caller gets its own readable body stream.
+    return response.clone();
+  };
+}

--- a/packages/auth/src/client-plugin/fetch-hooks.ts
+++ b/packages/auth/src/client-plugin/fetch-hooks.ts
@@ -1,0 +1,188 @@
+import type {
+  BetterFetchPlugin,
+  ErrorContext,
+  RequestContext,
+  ResponseContext,
+  SuccessContext,
+} from '@better-fetch/fetch';
+import {
+  BETTER_AUTH_METHODS_HOOKS,
+  deriveBetterAuthMethodFromUrl,
+} from '../core/better-auth-methods';
+import { normalizeBetterAuthError } from '../core/better-auth-helpers';
+import { injectClientInfo } from '../utils/client-info';
+
+const NEON_AUTH_SESSION_VERIFIER_PARAM_NAME = 'neon_auth_session_verifier';
+const GET_SESSION_PATH = '/get-session';
+
+const readVerifierFromWindow = (): string | null => {
+  if (typeof globalThis.window === 'undefined') {
+    return null;
+  }
+  try {
+    return new URL(globalThis.location.href).searchParams.get(
+      NEON_AUTH_SESSION_VERIFIER_PARAM_NAME
+    );
+  } catch {
+    return null;
+  }
+};
+
+const extractPathname = (raw: string): string => {
+  try {
+    return new URL(raw, 'http://placeholder.invalid').pathname;
+  } catch {
+    return raw;
+  }
+};
+
+const isGetSessionUrl = (url: URL | string): boolean => {
+  const pathname = typeof url === 'string' ? extractPathname(url) : url.pathname;
+  return pathname.endsWith(GET_SESSION_PATH);
+};
+
+/**
+ * Mutate `ctx.headers` in place so the Neon `X-Neon-Client-Info` header is on
+ * every outbound request. better-fetch always passes a real `Headers` instance
+ * by reference, so mutation is sufficient (no need to return a new ctx).
+ *
+ * `injectClientInfo` returns a fresh `Headers` rather than mutating, so we
+ * copy the missing entries back onto the original instance.
+ */
+const applyClientInfo = (ctx: RequestContext): void => {
+  const injected = injectClientInfo(ctx.headers);
+  injected.forEach((value, name) => {
+    if (!ctx.headers.has(name)) {
+      ctx.headers.set(name, value);
+    }
+  });
+};
+
+/**
+ * Single onRequest hook used by both the standalone plugin and the wrapper.
+ *
+ * Combines:
+ *  - `injectClientInfo` — Neon identifying headers on every outbound request
+ *  - per-method `BETTER_AUTH_METHODS_HOOKS[method].onRequest` (side-effects
+ *    like clearing the in-flight cache on sign-out, and the get-session
+ *    verifier rewrite)
+ *  - OAuth verifier query-param forwarding into outbound `/get-session`
+ *    requests so the server can finalize the session
+ *
+ * Returns a (potentially mutated) RequestContext or void.
+ */
+export const onRequestHook = (
+  ctx: RequestContext
+): RequestContext | void => {
+  // Inject client-info headers on every outbound. Mutates ctx.headers in
+  // place; better-fetch always supplies a real Headers instance.
+  applyClientInfo(ctx);
+
+  const urlString = ctx.url.toString();
+  const method = deriveBetterAuthMethodFromUrl(urlString);
+
+  let next: RequestContext | void = undefined;
+  if (method) {
+    const result = BETTER_AUTH_METHODS_HOOKS[method].onRequest(ctx);
+    if (result) {
+      next = result;
+      ctx = result;
+    }
+  }
+
+  // OAuth verifier forwarding. The per-method get-session hook already does
+  // this, but we also run it for standalone-plugin consumers who land on a
+  // path that does not match deriveBetterAuthMethodFromUrl (e.g. custom
+  // session-fetch endpoints that still end in /get-session).
+  const verifier = readVerifierFromWindow();
+  if (verifier && isGetSessionUrl(ctx.url)) {
+    const url = typeof ctx.url === 'string' ? new URL(ctx.url) : ctx.url;
+    if (!url.searchParams.has(NEON_AUTH_SESSION_VERIFIER_PARAM_NAME)) {
+      url.searchParams.set(
+        NEON_AUTH_SESSION_VERIFIER_PARAM_NAME,
+        verifier
+      );
+      next = { ...ctx, url };
+    }
+  }
+
+  return next;
+};
+
+/**
+ * Single onSuccess hook used by both the standalone plugin and the wrapper.
+ *
+ *  - Captures the `set-auth-jwt` response header and injects the JWT into
+ *    `ctx.data.session.token` BEFORE Better Auth processes the response,
+ *    so the BA session-cache update sees the JWT and downstream
+ *    `useSession.subscribe()` consumers cache the session with the JWT
+ *    included.
+ *  - Dispatches per-method `BETTER_AUTH_METHODS_HOOKS[method].onSuccess`
+ *    (session cache write, anonymous-token cache, cross-tab broadcast).
+ */
+export const onSuccessHook = async (
+  ctx: SuccessContext
+): Promise<void> => {
+  const jwt = ctx.response.headers.get('set-auth-jwt');
+  if (jwt) {
+    const data = ctx.data as { session?: { token?: string } } | undefined;
+    if (data?.session) {
+      data.session.token = jwt;
+    }
+  }
+
+  const url = ctx.request.url.toString();
+  const method = deriveBetterAuthMethodFromUrl(url);
+  if (method) {
+    await BETTER_AUTH_METHODS_HOOKS[method].onSuccess(ctx.data);
+  }
+};
+
+/**
+ * No-op onResponse used purely as a type-safety anchor; reserved for future
+ * response transformations.
+ */
+export const onResponseHook = (_ctx: ResponseContext): void => {
+  return;
+};
+
+/**
+ * Normalize non-OK responses to a typed `AuthApiError` / `AuthError`. Throws
+ * out of better-fetch's hook loop, so callers using `fetchOptions.throw: true`
+ * — or those who chain into the action layer — see a typed Auth error.
+ *
+ * Callers using `throw: false` will get this error inside their try/await
+ * (it propagates out of better-fetch's onError loop), preserving the same
+ * surface the legacy `customFetchImpl` produced.
+ */
+export const onErrorHook = (ctx: ErrorContext): void => {
+  const { response, error } = ctx;
+  const body = (error ?? {}) as {
+    message?: string;
+    code?: string;
+    [k: string]: unknown;
+  };
+  throw normalizeBetterAuthError({
+    status: response.status,
+    statusText: response.statusText,
+    message:
+      body.message || `HTTP ${response.status} ${response.statusText}`,
+    code: body.code,
+    body,
+  });
+};
+
+/**
+ * The single BetterFetchPlugin every Neon Auth client (wrapper or
+ * stand-alone) installs. Wraps the hooks above behind a stable id.
+ */
+export const neonFetchPlugin: BetterFetchPlugin = {
+  id: 'neon-fetch',
+  name: 'neon-fetch',
+  hooks: {
+    onRequest: onRequestHook,
+    onSuccess: onSuccessHook,
+    onResponse: onResponseHook,
+    onError: onErrorHook,
+  },
+};

--- a/packages/auth/src/client-plugin/index.ts
+++ b/packages/auth/src/client-plugin/index.ts
@@ -1,0 +1,206 @@
+import type { BetterAuthClientPlugin } from 'better-auth/client';
+import type { BetterFetch } from '@better-fetch/fetch';
+import { initBroadcastChannel } from '../core/better-auth-methods';
+import { anonymousTokenResponseSchema } from '../plugins/anonymous-token';
+import { neonFetchPlugin } from './fetch-hooks';
+
+/**
+ * Neon Auth Better Auth client plugin.
+ *
+ * Drop into any stock `better-auth/client` or `better-auth/react`
+ * `createAuthClient` plugin list and the resulting client will have every
+ * Neon-specific behavior the `@neondatabase/auth` wrapper provides today:
+ *
+ *  - cross-tab session sync (via `initBroadcastChannel`)
+ *  - per-method `BETTER_AUTH_METHODS_HOOKS` onRequest / onSuccess routing
+ *    (session-cache write, signOut clears in-flight cache + cross-tab
+ *    broadcast, anonymous-token cache, JWT capture from `set-auth-jwt`)
+ *  - OAuth verifier query-param forwarding into outbound `/get-session`
+ *  - actions on the auth client root:
+ *      - `getAnonymousToken()`   GET `/token/anonymous`
+ *      - `getJWTToken()`         GET `/token` (with cached-session fast path
+ *        + optional anonymous fallback)
+ *      - `handleOAuthCallback()` explicit `/get-session?neon_auth_session_verifier=…`
+ *
+ * Three Neon behaviors that need the request/response only — not a fetch
+ * wrap — live directly on `neonFetchPlugin` hooks and therefore work with
+ * just `plugins: [neonClient()]`:
+ *
+ *  - `injectClientInfo` headers on every outbound (`onRequest`)
+ *  - `normalizeBetterAuthError` of non-OK responses to a typed
+ *    `AuthApiError` / `AuthError` (`onError`)
+ *  - `set-auth-jwt` capture into the cached session token (`onSuccess`)
+ *
+ * Two Neon behaviors require wrapping the underlying `fetch` and therefore
+ * need the companion `customFetchImpl`:
+ *
+ *  - body-aware in-flight deduplication
+ *  - `X-Force-Fetch` escape hatch
+ *
+ * Three tiers of consumer boilerplate:
+ *
+ * ```ts
+ * // Tier 1 — every Neon behavior except dedup + force-fetch
+ * import { neonClient } from '@neondatabase/auth/client-plugin';
+ * const client = createAuthClient({
+ *   baseURL: 'https://auth.neon.tech',
+ *   plugins: [neonClient()],
+ * });
+ *
+ * // Tier 2 — Tier 1 plus the legacy `{ data, error }` envelope shape
+ * const client = createAuthClient({
+ *   baseURL: 'https://auth.neon.tech',
+ *   plugins: [neonClient()],
+ *   fetchOptions: { throw: false },
+ * });
+ *
+ * // Tier 3 — Tier 2 plus body-aware dedup + X-Force-Fetch
+ * import { neonClient, createNeonCustomFetchImpl }
+ *   from '@neondatabase/auth/client-plugin';
+ * const client = createAuthClient({
+ *   baseURL: 'https://auth.neon.tech',
+ *   plugins: [neonClient()],
+ *   fetchOptions: {
+ *     throw: false,
+ *     customFetchImpl: createNeonCustomFetchImpl(),
+ *   },
+ * });
+ * ```
+ */
+
+const NEON_AUTH_SESSION_VERIFIER_PARAM_NAME = 'neon_auth_session_verifier';
+const ANONYMOUS_TOKEN_ENDPOINT = '/token/anonymous';
+const GET_SESSION_ENDPOINT = '/get-session';
+
+const readVerifierFromWindow = (): string | null => {
+  if (typeof globalThis.window === 'undefined') {
+    return null;
+  }
+  try {
+    return new URL(globalThis.location.href).searchParams.get(
+      NEON_AUTH_SESSION_VERIFIER_PARAM_NAME
+    );
+  } catch {
+    return null;
+  }
+};
+
+export interface NeonAnonymousTokenResponse {
+  token: string;
+  expires_at: number;
+}
+
+export interface NeonJWTTokenResponse {
+  token: string;
+}
+
+interface BetterAuthSessionLike {
+  session?: { token?: string } | null;
+}
+
+export const neonClient = () => {
+  // Cross-tab session sync. Idempotent: subsequent calls re-subscribe but the
+  // first invocation also handles OAuth-popup completion (postMessage +
+  // window.close), so running this at plugin construction is correct for
+  // both the wrapper and standalone consumers.
+  initBroadcastChannel();
+
+  return {
+    id: 'neon',
+    // Anonymous-token endpoint is GET; inherit pathMethods from the legacy
+    // anonymousTokenClient so server-plugin path inference still maps it.
+    pathMethods: {
+      [ANONYMOUS_TOKEN_ENDPOINT]: 'GET',
+    },
+    fetchPlugins: [neonFetchPlugin],
+    getActions: ($fetch: BetterFetch) => ({
+      /**
+       * GET `/token/anonymous` — short-lived RLS token for unauthenticated
+       * users. Response is validated against `anonymousTokenResponseSchema`.
+       */
+      getAnonymousToken: async () => {
+        return $fetch<NeonAnonymousTokenResponse>(ANONYMOUS_TOKEN_ENDPOINT, {
+          method: 'GET',
+        });
+      },
+
+      /**
+       * Returns a JWT for the current session.
+       *
+       *  - First tries the BA-cached session (populated by the `set-auth-jwt`
+       *    capture in `neonFetchPlugin`) so this is a synchronous read in
+       *    the happy path.
+       *  - Falls back to GET `/token`.
+       *  - When `allowAnonymous` is true and no session exists, falls back
+       *    to `getAnonymousToken()`.
+       *
+       * Returns `null` when no token is available.
+       */
+      getJWTToken: async (allowAnonymous = false): Promise<string | null> => {
+        const sessionResponse = await $fetch<BetterAuthSessionLike>(
+          GET_SESSION_ENDPOINT,
+          {
+            method: 'GET',
+          }
+        );
+        const session = (sessionResponse as { data?: BetterAuthSessionLike })
+          .data;
+        const cachedToken = session?.session?.token;
+        if (cachedToken) {
+          return cachedToken;
+        }
+
+        if (allowAnonymous) {
+          const anon = await $fetch<NeonAnonymousTokenResponse>(
+            ANONYMOUS_TOKEN_ENDPOINT,
+            { method: 'GET' }
+          );
+          const parsed = anonymousTokenResponseSchema.safeParse(
+            (anon as { data?: unknown }).data
+          );
+          return parsed.success ? parsed.data.token : null;
+        }
+
+        return null;
+      },
+
+      /**
+       * If the current page URL contains a `neon_auth_session_verifier`,
+       * call `/get-session?neon_auth_session_verifier=…` to finalize the
+       * OAuth / magic-link redirect. Returns `null` on the server or when
+       * no verifier is present.
+       */
+      handleOAuthCallback: async () => {
+        const verifier = readVerifierFromWindow();
+        if (!verifier) {
+          return null;
+        }
+        return $fetch(GET_SESSION_ENDPOINT, {
+          method: 'GET',
+          query: {
+            [NEON_AUTH_SESSION_VERIFIER_PARAM_NAME]: verifier,
+          },
+        });
+      },
+    }),
+  } satisfies BetterAuthClientPlugin;
+};
+
+export type NeonClientPlugin = ReturnType<typeof neonClient>;
+
+export {
+  createNeonCustomFetchImpl,
+  FORCE_FETCH_HEADER,
+} from './custom-fetch';
+
+/**
+ * Re-export the typed error classes thrown by `neonFetchPlugin.hooks.onError`
+ * so plugin-only consumers can narrow with `instanceof` without depending on
+ * `@neondatabase/auth/server` or the wrapper sub-path.
+ */
+export {
+  AuthError,
+  AuthApiError,
+  isAuthError,
+  isAuthApiError,
+} from '../adapters/supabase/auth-interface';

--- a/packages/auth/src/core/adapter-core.ts
+++ b/packages/auth/src/core/adapter-core.ts
@@ -8,23 +8,19 @@ import {
   organizationClient,
   phoneNumberClient,
 } from 'better-auth/client/plugins';
+import { neonClient } from '../client-plugin';
 import {
-  BETTER_AUTH_METHODS_HOOKS,
-  BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS,
-  deriveBetterAuthMethodFromUrl,
-  initBroadcastChannel,
-} from './better-auth-methods';
-import { anonymousTokenClient } from '../plugins/anonymous-token';
-import { injectClientInfo } from '../utils/client-info';
+  createNeonCustomFetchImpl,
+  
+} from '../client-plugin/custom-fetch';
 import type { BetterAuthInstance } from '../types';
-import { normalizeBetterAuthError } from './better-auth-helpers';
 
 export interface NeonAuthAdapterCoreAuthOptions extends Omit<
   BetterAuthClientOptions,
   'plugins'
 > {}
 
-export const FORCE_FETCH_HEADER = 'X-Force-Fetch';
+
 
 const supportedBetterAuthClientPlugins = [
   jwtClient(),
@@ -33,7 +29,12 @@ const supportedBetterAuthClientPlugins = [
   emailOTPClient(),
   magicLinkClient(),
   phoneNumberClient(),
-  anonymousTokenClient(),
+  // `neonClient()` is the single source of truth for every Neon-specific
+  // client-side behavior: it installs the per-method onRequest/onSuccess
+  // fetch hooks (session-cache + cross-tab sync + JWT capture), exposes the
+  // `getAnonymousToken` / `getJWTToken` / `handleOAuthCallback` actions, and
+  // calls `initBroadcastChannel()` at construction.
+  neonClient(),
 ] satisfies BetterAuthClientOptions['plugins'];
 
 export type SupportedBetterAuthClientPlugins =
@@ -50,133 +51,32 @@ export abstract class NeonAuthAdapterCore {
   /**
    * Better Auth adapter implementing the NeonAuthClient interface.
    * See CLAUDE.md for architecture details and API mappings.
+   *
+   * All Neon-specific behaviors (per-method hooks, cross-tab sync, JWT
+   * capture, anonymous token, verifier forwarding, force-fetch escape
+   * hatch, in-flight dedup, error normalization, client-info injection)
+   * are installed via the shared `neonClient()` plugin and
+   * `createNeonCustomFetchImpl()`, so a tenant who wires up stock
+   * `better-auth/client` + `neonClient()` gets the same behavior as this
+   * wrapper.
    */
 
   //#region Constructor
   constructor(betterAuthClientOptions: NeonAuthAdapterCoreAuthOptions) {
-    // Preserve user's onSuccess callback if they provided one
-    const userOnSuccess = betterAuthClientOptions.fetchOptions?.onSuccess;
-    const userOnRequest = betterAuthClientOptions.fetchOptions?.onRequest;
-
+    const userFetchOptions = betterAuthClientOptions.fetchOptions ?? {};
     this.betterAuthOptions = {
       ...betterAuthClientOptions,
       plugins: supportedBetterAuthClientPlugins,
       fetchOptions: {
-        ...betterAuthClientOptions.fetchOptions,
+        ...userFetchOptions,
         throw: false,
-        onRequest: (request) => {
-          const url = request.url;
-          const method = deriveBetterAuthMethodFromUrl(url.toString());
-          if (method) {
-            BETTER_AUTH_METHODS_HOOKS[method].onRequest(request);
-          }
-          userOnRequest?.(request);
-        },
-        customFetchImpl: async (url, init) => {
-          const headers = injectClientInfo(init?.headers);
-          // Skip deduplication if X-Force-Fetch header is present
-          if (headers.has(FORCE_FETCH_HEADER)) {
-            headers.delete(FORCE_FETCH_HEADER);
-            const response = await fetch(url, { ...init, headers });
-
-            // Check for HTTP errors. Route through normalizeBetterAuthError
-            // so consumers always get a typed AuthApiError with `.status` + `.code`.
-            if (!response.ok) {
-              const body = await response
-                .clone()
-                .json()
-                .catch(() => ({}));
-              throw normalizeBetterAuthError({
-                status: response.status,
-                statusText: response.statusText,
-                message:
-                  body.message ||
-                  `HTTP ${response.status} ${response.statusText}`,
-                code: body.code,
-                body,
-              });
-            }
-
-            return response;
-          }
-
-          const betterAuthMethod = deriveBetterAuthMethodFromUrl(
-            url.toString()
-          );
-          if (betterAuthMethod) {
-            const response = await BETTER_AUTH_METHODS_HOOKS[
-              betterAuthMethod
-            ].beforeFetch?.(url, init);
-            if (response) {
-              return response;
-            }
-          }
-
-          // Create body-aware deduplication key
-          const method = init?.method || 'GET';
-          const body = init?.body || '';
-          const key = `${method}:${url}:${body}`;
-
-          const response =
-            await BETTER_AUTH_METHODS_IN_FLIGHT_REQUESTS.deduplicate(key, () =>
-              fetch(url, { ...init, headers })
-            );
-
-          // Check for HTTP errors before returning. Route through
-          // normalizeBetterAuthError so consumers always get a typed
-          // AuthApiError with `.status` + `.code`.
-          if (!response.ok) {
-            const errorBody = await response
-              .clone()
-              .json()
-              .catch(() => ({}));
-            throw normalizeBetterAuthError({
-              status: response.status,
-              statusText: response.statusText,
-              message:
-                errorBody.message ||
-                `HTTP ${response.status} ${response.statusText}`,
-              code: errorBody.code,
-              body: errorBody,
-            });
-          }
-
-          // Clone the response so each caller gets a fresh body stream
-          // (Response bodies can only be read once, but deduplication shares the same Response)
-          return response.clone();
-        },
-        onSuccess: async (ctx) => {
-          // Capture JWT from any request that includes it
-          const jwt = ctx.response.headers.get('set-auth-jwt');
-          if (jwt) {
-            // Inject JWT into response data BEFORE Better Auth processes it.
-            // Better Auth will then update its internal state, triggering useSession.subscribe()
-            // which will cache the session with JWT included (single cache-setting point).
-            if (ctx.data?.session) {
-              ctx.data.session.token = jwt;
-            } else {
-              console.warn(
-                '[onSuccess] JWT found but no session data to inject into!'
-              );
-            }
-          }
-
-          const url = ctx.request.url.toString();
-          const responseData = ctx.data;
-
-          // Detect sign-in/sign-up
-          const method = deriveBetterAuthMethodFromUrl(url);
-          if (method) {
-            BETTER_AUTH_METHODS_HOOKS[method].onSuccess(responseData);
-          }
-
-          // Call user's onSuccess callback if they provided one
-          await userOnSuccess?.(ctx);
-        },
+        // Preserve any caller-supplied customFetchImpl by falling through to
+        // ours only when they did not provide one. (In practice nobody does
+        // — the wrapper is the only caller — but better safe than surprised.)
+        customFetchImpl:
+          userFetchOptions.customFetchImpl ?? createNeonCustomFetchImpl(),
       },
     };
-
-    initBroadcastChannel();
   }
 
   abstract getBetterAuthInstance(): BetterAuthInstance;
@@ -207,3 +107,5 @@ export abstract class NeonAuthAdapterCore {
     return null;
   }
 }
+
+export {FORCE_FETCH_HEADER} from '../client-plugin/custom-fetch';

--- a/packages/auth/src/core/better-auth-methods.ts
+++ b/packages/auth/src/core/better-auth-methods.ts
@@ -410,6 +410,8 @@ export function deriveBetterAuthMethodFromUrl(
   return undefined;
 }
 
+let broadcastChannelSubscribed = false;
+
 export function initBroadcastChannel() {
   // Handle OAuth popup completion - send verifier to parent and close
   if (isBrowser() && globalThis.opener && globalThis.opener !== globalThis) {
@@ -425,6 +427,11 @@ export function initBroadcastChannel() {
       return;
     }
   }
+
+  if (broadcastChannelSubscribed) {
+    return;
+  }
+  broadcastChannelSubscribed = true;
 
   getGlobalBroadcastChannel().subscribe((message) => {
     if (message.clientId === CURRENT_TAB_CLIENT_ID) {

--- a/packages/auth/tsdown.config.ts
+++ b/packages/auth/tsdown.config.ts
@@ -20,6 +20,8 @@ export default defineConfig(
 
       'src/next/index.ts',
       'src/next/server/index.ts',
+
+      'src/client-plugin/index.ts',
     ],
     skipNodeModulesBundle: true,
     // Explicitly externalize workspace deps that skipNodeModulesBundle misses


### PR DESCRIPTION
## What

Adds `@neondatabase/auth/client-plugin` — a stock Better Auth client plugin (`neonClient()`) that lets consumers drop into any `better-auth/client` or `better-auth/react` `createAuthClient` and get every Neon-specific client-side behavior the existing `@neondatabase/auth` wrapper provides. The wrapper continues to work unchanged; it now installs `neonClient()` under the hood, so both surfaces share one implementation.

## Why each decision

### Plugin alongside the wrapper, not replacement
Existing `createAuthClient(url, config)` callers keep working. Two paths to the same code:
- Wrapper users: keep their current factory + curated plugin set + envelope shape with zero changes.
- Plugin users: bring their own `createAuthClient` from `better-auth/react`, pick their own BA client plugins, add `neonClient()` for Neon features.

Lower risk, broader adoption surface.

### One shared implementation
`adapter-core.ts` no longer inlines Neon-specific behaviors. It just adds `neonClient()` to its plugin list and installs `customFetchImpl: createNeonCustomFetchImpl()`. If a behavior fires in the wrapper, it fires in the plugin path — same call sites, same code. Drift impossible.

### Three-tier consumer ergonomics
Plugin-only consumers can opt in incrementally:
1. `plugins: [neonClient()]` — gets `injectClientInfo` headers, `normalizeBetterAuthError`, `set-auth-jwt` capture, OAuth verifier forwarding, per-method hooks, cross-tab broadcast, and the `getJWTToken` / `getAnonymousToken` / `handleOAuthCallback` actions.
2. + `fetchOptions: { throw: false }` — return `{ data, error }` envelopes instead of throwing.
3. + `customFetchImpl: createNeonCustomFetchImpl()` — adds body-aware in-flight dedup + `X-Force-Fetch` escape hatch.

This three-tier split exists because BA's plugin contract physically can't wrap the underlying `fetch` call (it can only run around it), so dedup must live in a `customFetchImpl`. Header injection and error normalization moved out of `customFetchImpl` and into hook callbacks — Tier 1 covers ~90% of behavior with zero boilerplate.

### Behavior parity verified
- All 158 pre-existing wrapper tests still pass — no behavior change for wrapper users.
- 30 new compat tests in `src/__compat__/transport-parity.test.ts` exercise each behavior side-by-side: wrapper path + plugin+customFetch path + Tier-1 plugin-only path. All identical.
- 6 wrapper tests repurposed to run against the plugin path — all pass.
- Total: 195/195 tests, `tsc --noEmit` clean, `tsdown` build clean.

### `AuthError` / `AuthApiError` re-export
`@neondatabase/auth/client-plugin` re-exports the typed error classes. Plugin-only consumers can `instanceof`-check errors without pulling in the wrapper.

### What's intentionally NOT in this PR
- **Server-side surface** (`createNeonAuth`, `auth.handler()`, `auth.middleware()`, `auth.api.*`) — these stay wrapper-only. A minimal `@neondatabase/auth/next` adapter is a follow-up.
- **SupabaseAuthAdapter** parity — 28 Supabase-compat methods (`signInWithPassword`, `onAuthStateChange`, etc.) remain wrapper-only. Plugin targets BA backends only.
- **Example apps** — neither new (orgs-plugin-example, ba-kitchensink) nor migrated existing ones land here. They live on a sibling Phase 2 branch.
- **BA version bump** — pin stays at 1.4.18. Bumping to 1.6.x is a separate change.

## Test plan

- [x] `pnpm test:ci` — 195 / 195 pass
- [x] `pnpm run build` — clean tsdown output, all entrypoints emit
- [x] `tsc --noEmit` — clean
- [x] Surface diff vs wrapper: 69 / 69 runtime auth-client methods match
- [x] Compat test harness covers in-flight dedup, X-Force-Fetch, injectClientInfo, set-auth-jwt capture, normalizeBetterAuthError, per-method onRequest hooks, BroadcastChannel cross-tab sync (manual browser verification recommended for the storage-event round-trip), OAuth verifier forwarding, getJWTToken anonymous fallback, handleOAuthCallback, pathMethods routing.
- [ ] End-to-end demo against managed Neon Auth — deferred to a Phase 1.5 follow-up that ships the `@neondatabase/auth/next` server adapter.

## Follow-ups
- `@neondatabase/auth/next` minimal Next.js proxy (~80 lines) to handle first-party cookies and OAuth callback finalization on the tenant origin. Required before example apps can be migrated to the plugin pattern end-to-end.
- Bump `better-auth` peer dependency range to `^1.6` once the BA 1.6 surface is reviewed.
- Migrate `examples/*` to plugin-only path (lives on the Phase 2 branch).
