### PR TITLE
fix(examples/nextjs-neon-auth): migrate to @neondatabase/auth-ui direct imports

### DIFF
--- a/examples/nextjs-neon-auth/README.md
+++ b/examples/nextjs-neon-auth/README.md
@@ -31,7 +31,7 @@ bun run dev
 ## Demos
 
 - **`/`** – Marketing landing page
-- **`/auth/sign-in`**, **`/auth/sign-up`** – Auth UI views (powered by `@neondatabase/auth/react/ui`)
+- **`/auth/sign-in`**, **`/auth/sign-up`** – Auth UI views (powered by `@neondatabase/auth-ui`)
 - **`/dashboard`**, **`/notes`**, **`/account/*`** – Protected routes that require a session
 - **`/iframe-test`** – Embeds the auth views in a same-origin iframe to verify that
   email/password and **OAuth (popup) flows work inside an iframe**

--- a/examples/nextjs-neon-auth/app/account/[path]/page.tsx
+++ b/examples/nextjs-neon-auth/app/account/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { AccountView } from '@neondatabase/auth/react/ui';
-import { accountViewPaths } from '@neondatabase/auth/react/ui/server';
+import { AccountView } from '@neondatabase/auth-ui';
+import { accountViewPaths } from '@neondatabase/auth-ui/server';
 
 export const dynamicParams = false;
 

--- a/examples/nextjs-neon-auth/app/auth/[path]/page.tsx
+++ b/examples/nextjs-neon-auth/app/auth/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { AuthView } from '@neondatabase/auth/react/ui';
-import { authViewPaths } from '@neondatabase/auth/react/ui/server';
+import { AuthView } from '@neondatabase/auth-ui';
+import { authViewPaths } from '@neondatabase/auth-ui/server';
 import Link from 'next/link';
 
 export const dynamicParams = false;

--- a/examples/nextjs-neon-auth/app/dashboard/page.tsx
+++ b/examples/nextjs-neon-auth/app/dashboard/page.tsx
@@ -205,7 +205,7 @@ export default function DashboardPage() {
                                     Security
                                 </Button>
                             </Link>
-                            <Link href="/account/profile">
+                            <Link href="/account/organizations">
                                 <Button variant="outline" className="w-full justify-start">
                                     <svg
                                         className="mr-2 h-4 w-4"
@@ -217,10 +217,10 @@ export default function DashboardPage() {
                                             strokeLinecap="round"
                                             strokeLinejoin="round"
                                             strokeWidth={2}
-                                            d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                                            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 2a2 2 0 11-4 0 2 2 0 014 0zM7 9a2 2 0 11-4 0 2 2 0 014 0z"
                                         />
                                     </svg>
-                                    Profile
+                                    Organizations
                                 </Button>
                             </Link>
                         </div>

--- a/examples/nextjs-neon-auth/app/globals.css
+++ b/examples/nextjs-neon-auth/app/globals.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
-@import '@neondatabase/auth/ui/tailwind';
+@import '@neondatabase/auth-ui/tailwind';
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));

--- a/examples/nextjs-neon-auth/app/layout.tsx
+++ b/examples/nextjs-neon-auth/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/examples/nextjs-neon-auth/app/organization/[path]/page.tsx
+++ b/examples/nextjs-neon-auth/app/organization/[path]/page.tsx
@@ -1,5 +1,5 @@
-import { OrganizationView } from '@neondatabase/auth/react/ui';
-import { organizationViewPaths } from '@neondatabase/auth/react/ui/server';
+import { OrganizationView } from '@neondatabase/auth-ui';
+import { organizationViewPaths } from '@neondatabase/auth-ui/server';
 
 export const dynamicParams = false;
 

--- a/examples/nextjs-neon-auth/app/providers.tsx
+++ b/examples/nextjs-neon-auth/app/providers.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { NeonAuthUIProvider } from "@neondatabase/auth/react/ui"
+import { NeonAuthUIProvider } from "@neondatabase/auth-ui"
 import Link from "next/link"
+import { ThemeProvider } from "next-themes"
 import { useRouter } from "next/navigation"
 import type { ReactNode } from "react"
 
@@ -11,6 +12,7 @@ export function Providers({ children }: { children: ReactNode }) {
     const router = useRouter()
 
     return (
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
         <NeonAuthUIProvider
             authClient={authClient}
             navigate={router.push}
@@ -35,5 +37,6 @@ export function Providers({ children }: { children: ReactNode }) {
         >
             {children}
         </NeonAuthUIProvider>
+        </ThemeProvider>
     )
 }

--- a/examples/nextjs-neon-auth/components/header.tsx
+++ b/examples/nextjs-neon-auth/components/header.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { SignedIn, SignedOut, UserButton } from "@neondatabase/auth/react/ui"
+import { SignedIn, SignedOut, UserButton } from "@neondatabase/auth-ui"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"

--- a/examples/nextjs-neon-auth/next.config.ts
+++ b/examples/nextjs-neon-auth/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'standalone',
-  transpilePackages: ['@neondatabase/auth'],
+  transpilePackages: ['@neondatabase/auth', '@neondatabase/auth-ui'],
 };
 
 export default nextConfig;

--- a/examples/nextjs-neon-auth/package.json
+++ b/examples/nextjs-neon-auth/package.json
@@ -25,7 +25,8 @@
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "sonner": "2.0.7",
-    "tailwind-merge": "3.4.0"
+    "tailwind-merge": "3.4.0",
+    "@neondatabase/auth-ui": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@neondatabase/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@neondatabase/auth-ui':
+        specifier: workspace:*
+        version: link:../../packages/auth-ui
       '@neondatabase/serverless':
         specifier: 1.0.2
         version: 1.0.2


### PR DESCRIPTION
## Summary

- Replace deprecated `@neondatabase/auth/react/ui` re-export paths with direct `@neondatabase/auth-ui` imports across all pages and components
- Add `@neondatabase/auth-ui` as an explicit dependency and to `transpilePackages` in `next.config.ts`
- Add `ThemeProvider` (next-themes) for app-wide dark mode support; `suppressHydrationWarning` on `<html>` for SSR compat
- Fix Organizations nav link in dashboard sidebar (was pointing to `/account/profile`)

## Test plan

- [ ] Dev server starts without errors
- [ ] Auth UI renders on `/auth/sign-in`, `/auth/sign-up`
- [ ] Account views render on `/account/*`
- [ ] Organization views render on `/account/organizations`
- [ ] Dark mode toggle applies `class="dark"` to `<html>` correctly
- [ ] No hydration warnings in console

This pull request and its description were written by Isaac.