### PR TITLE
feat(neon-js): support external auth providers in createClient

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,6 +404,23 @@ const client = new NeonPostgrestClient({
 const { data: items } = await client.from('items').select();
 ```
 
+### Using createClient (External Auth Provider)
+
+When authentication is handled by your own identity provider (Clerk, Auth0, …) rather than Neon Auth, omit the `auth` block and pass `dataApi.getToken`. No Neon Auth client is created; the returned client is a plain `NeonPostgrestClient` (no `.auth` property), and your token is attached to every Data API request.
+
+```typescript
+import { createClient } from '@neondatabase/neon-js';
+
+const neon = createClient<Database>({
+  dataApi: {
+    url: 'https://data-api.example.com/rest/v1',
+    getToken: async () => await yourAuthProvider.getToken(), // returns a JWT or null
+  },
+});
+
+const { data: items } = await neon.from('items').select();
+```
+
 ### Using NeonClient (With Auth) - Adapter Pattern
 
 The `createClient()` factory accepts any auth adapter, allowing you to choose the API style:

--- a/packages/neon-js/CHANGELOG.md
+++ b/packages/neon-js/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`createClient` external auth provider support**: `createClient` now accepts a
+  Data-API-only form for apps that authenticate with their own identity provider
+  (Clerk, Auth0, …). Omit the `auth` block and pass `dataApi.getToken`; the token
+  is attached to every Data API request and no Neon Auth client is created. This
+  form returns a `NeonPostgrestClient` (no `.auth` property). New exported types:
+  `CreateClientExternalConfig`, `CreateClientExternalDataApiConfig`, and
+  `NeonDataApiTokenProvider`; `NeonPostgrestClient` is now re-exported from the
+  package entry.
+
+  ```typescript
+  const neon = createClient({
+    dataApi: {
+      url: import.meta.env.VITE_NEON_DATA_API_URL,
+      getToken: async () => await yourAuthProvider.getToken(),
+    },
+  });
+  ```
+
 - **Client Telemetry**: Automatically injects `X-Neon-Client-Info` header with SDK name, version, runtime environment (Node.js, Deno, Bun, Edge, Browser), and framework detection (Next.js, Remix, React, Vue, Angular).
 
 ### Deprecated

--- a/packages/neon-js/README.md
+++ b/packages/neon-js/README.md
@@ -196,6 +196,28 @@ const client = createClient<Database>({
 const { data: publicItems } = await client.from('public_items').select();
 ```
 
+### External Auth Provider
+
+If your app authenticates with its own identity provider (Clerk, Auth0, and others) instead of Neon Auth, omit the `auth` block and pass a `getToken` function on `dataApi`. It is called lazily on every request and its JWT is attached to each Data API call — Neon validates it against the JWKS URL you configured for the provider.
+
+```typescript
+import { createClient } from '@neondatabase/neon-js';
+
+const neon = createClient<Database>({
+  dataApi: {
+    url: import.meta.env.VITE_NEON_DATA_API_URL,
+    // Return a valid JWT from your provider, e.g. Clerk's getToken()
+    // or Auth0's getAccessTokenSilently().
+    getToken: async () => await yourAuthProvider.getToken(),
+  },
+});
+
+// Every request carries your provider's token, so RLS policies apply
+const { data: items } = await neon.from('items').select();
+```
+
+This form returns a `NeonPostgrestClient` — the same query API as above, without the `.auth` namespace (auth is handled by your provider). No `@neondatabase/postgrest-js` import is needed.
+
 ## Authentication
 
 ### Sign Up

--- a/packages/neon-js/src/__tests__/client-factory.test.ts
+++ b/packages/neon-js/src/__tests__/client-factory.test.ts
@@ -131,3 +131,73 @@ describe('createClient — object form (backward compat)', () => {
     );
   });
 });
+
+describe('createClient — external auth provider form', () => {
+  beforeEach(() => {
+    createInternalNeonAuthMock.mockClear();
+  });
+
+  it('does not create a Neon Auth client when auth is omitted', () => {
+    createClient({
+      dataApi: {
+        url: 'https://data-api.example.com/rest/v1',
+        getToken: async () => 'external-token',
+      },
+    });
+
+    expect(createInternalNeonAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a plain client with no `auth` property', () => {
+    const client = createClient({
+      dataApi: {
+        url: 'https://data-api.example.com/rest/v1',
+        getToken: async () => 'external-token',
+      },
+    });
+
+    expect((client as unknown as { url: string }).url).toBe(
+      'https://data-api.example.com/rest/v1'
+    );
+    expect((client as unknown as { auth?: unknown }).auth).toBeUndefined();
+  });
+
+  it("attaches the caller's token to Data API requests", async () => {
+    const baseFetch = vi.fn(async () => new Response('[]'));
+    const getToken = vi.fn(async () => 'external-token');
+
+    const client = createClient({
+      dataApi: {
+        url: 'https://data-api.example.com/rest/v1',
+        getToken,
+        options: { global: { fetch: baseFetch as unknown as typeof fetch } },
+      },
+    });
+
+    await client.from('todos').select('*');
+
+    expect(getToken).toHaveBeenCalled();
+    const init = baseFetch.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get('Authorization')).toBe('Bearer external-token');
+  });
+
+  it('surfaces AuthRequiredError when getToken yields null', async () => {
+    const baseFetch = vi.fn(async () => new Response('[]'));
+
+    const client = createClient({
+      dataApi: {
+        url: 'https://data-api.example.com/rest/v1',
+        getToken: async () => null,
+        options: { global: { fetch: baseFetch as unknown as typeof fetch } },
+      },
+    });
+
+    // The upstream PostgrestClient catches the fetch-layer throw and returns it
+    // as `{ error }` rather than rejecting.
+    const { error } = await client.from('todos').select('*');
+
+    expect(error?.message).toMatch(/Authentication required/);
+    expect(baseFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/neon-js/src/__tests__/type-tests.test-d.ts
+++ b/packages/neon-js/src/__tests__/type-tests.test-d.ts
@@ -260,3 +260,23 @@ describe('String form with Database type parameter', () => {
     expectTypeOf(typed.auth.signInWithPassword).toBeFunction();
   });
 });
+
+// =============================================================================
+// Test 10: External auth provider form — queries work, no `.auth` property
+// =============================================================================
+describe('External auth provider form type inference', () => {
+  const client = createClient({
+    dataApi: {
+      url: 'https://data-api.example.com/rest/v1',
+      getToken: async () => 'token',
+    },
+  });
+
+  it('should expose Data API query methods', () => {
+    expectTypeOf(client.from).toBeFunction();
+  });
+
+  it('should not expose an `auth` property', () => {
+    expectTypeOf(client).not.toHaveProperty('auth');
+  });
+});

--- a/packages/neon-js/src/client/client-factory.ts
+++ b/packages/neon-js/src/client/client-factory.ts
@@ -8,7 +8,11 @@ import {
   type SupabaseAuthAdapterInstance,
 } from '@neondatabase/auth/vanilla/adapters';
 import { type BetterAuthReactAdapterInstance } from '@neondatabase/auth/react/adapters';
-import { fetchWithToken } from '@neondatabase/postgrest-js';
+import {
+  fetchWithToken,
+  NeonPostgrestClient,
+  type NeonPostgrestClientConstructorOptions,
+} from '@neondatabase/postgrest-js';
 import {
   NeonClient,
   type DefaultSchemaName,
@@ -52,6 +56,43 @@ export type CreateClientConfig<SchemaName, T extends NeonAuthAdapter> = {
   auth: CreateClientAuthConfig<T>;
   /** Data API configuration */
   dataApi: CreateClientDataApiConfig<SchemaName, T>;
+};
+
+/**
+ * Returns a valid JWT for the current user, or `null` if there is no session.
+ *
+ * Called lazily on every Data API request. Wire this to your own identity
+ * provider — e.g. Clerk's `getToken()` or Auth0's `getAccessTokenSilently()`.
+ * Neon validates the returned token against the JWKS URL configured for the
+ * provider.
+ */
+export type NeonDataApiTokenProvider = () => Promise<string | null>;
+
+/**
+ * Data API configuration for the external-auth-provider form of createClient.
+ *
+ * Same as {@link CreateClientDataApiConfig} but carries a `getToken` function
+ * instead of relying on a Neon Auth service.
+ */
+export type CreateClientExternalDataApiConfig<SchemaName> =
+  CreateClientDataApiConfig<SchemaName, NeonAuthAdapter> & {
+    /** Token provider consulted on every Data API request. */
+    getToken: NeonDataApiTokenProvider;
+  };
+
+/**
+ * Configuration for the external-auth-provider form of createClient.
+ *
+ * Use this when authentication is handled by your own identity provider
+ * (Clerk, Auth0, …) rather than Neon Auth: omit the `auth` block entirely and
+ * supply `dataApi.getToken`. No Neon Auth client is created, and the returned
+ * client is a plain {@link NeonPostgrestClient} (no `.auth` property).
+ */
+export type CreateClientExternalConfig<SchemaName> = {
+  /** External providers do not use a Neon Auth service. */
+  auth?: never;
+  /** Data API configuration, including your token provider. */
+  dataApi: CreateClientExternalDataApiConfig<SchemaName>;
 };
 
 /**
@@ -104,6 +145,20 @@ export type CreateClientConfig<SchemaName, T extends NeonAuthAdapter> = {
  *   'https://ep-xxx.c-2.us-east-2.aws.neon.build/dbname'
  * );
  * ```
+ *
+ * @example
+ * ```typescript
+ * // External auth provider (Clerk, Auth0, …): omit `auth` and supply a
+ * // `getToken` function. The returned client has no `.auth` property.
+ * const client = createClient({
+ *   dataApi: {
+ *     url: 'https://data-api.example.com/rest/v1',
+ *     getToken: async () => await yourAuthProvider.getToken(),
+ *   },
+ * });
+ *
+ * const { data: items } = await client.from('items').select();
+ * ```
  */
 
 /**
@@ -114,6 +169,13 @@ type CreateClientResult<
   Database,
   TAdapter extends NeonAuthAdapter,
 > = NeonClient<Database, DefaultSchemaName<Database>, TAdapter>;
+
+// Overload: External auth provider (no Neon Auth) — returns a plain
+// NeonPostgrestClient with no `.auth` property. Listed first so its `auth?:
+// never` shape is matched before the auth-required object overloads.
+export function createClient<Database = any>(
+  config: CreateClientExternalConfig<DefaultSchemaName<Database>>
+): NeonPostgrestClient<Database, DefaultSchemaName<Database>>;
 
 // Overload: No adapter specified (defaults to BetterAuthVanillaAdapter)
 export function createClient<Database = any>(config: {
@@ -190,13 +252,27 @@ export function createClient<
   SchemaName extends string & keyof Database = DefaultSchemaName<Database>,
   TAuthAdapter extends NeonAuthAdapter = BetterAuthVanillaAdapterInstance,
 >(
-  arg1: string | CreateClientConfig<SchemaName, TAuthAdapter>,
+  arg1:
+    | string
+    | CreateClientConfig<SchemaName, TAuthAdapter>
+    | CreateClientExternalConfig<SchemaName>,
   arg2?: CreateClientStringOptions<SchemaName, TAuthAdapter>
-): NeonClient<Database, SchemaName, TAuthAdapter> {
+):
+  | NeonClient<Database, SchemaName, TAuthAdapter>
+  | NeonPostgrestClient<Database, SchemaName> {
+  // External-auth-provider form: no `auth` block, a `getToken` on `dataApi`.
+  // Build a plain NeonPostgrestClient and let the caller's token flow through
+  // unchanged — no Neon Auth client is created.
+  if (typeof arg1 !== 'string' && !arg1.auth) {
+    return buildExternalClient<Database, SchemaName>(
+      (arg1 as CreateClientExternalConfig<SchemaName>).dataApi
+    );
+  }
+
   const config: CreateClientConfig<SchemaName, TAuthAdapter> =
     typeof arg1 === 'string'
       ? buildConfigFromBaseUrl<SchemaName, TAuthAdapter>(arg1, arg2)
-      : arg1;
+      : (arg1 as CreateClientConfig<SchemaName, TAuthAdapter>);
 
   const { auth: authConfig, dataApi: dataApiConfig } = config;
 
@@ -244,6 +320,44 @@ export function createClient<
   });
 
   return client;
+}
+
+/**
+ * Builds the external-auth-provider client: a plain NeonPostgrestClient whose
+ * every request carries the caller's token via `fetchWithToken(getToken)`.
+ *
+ * Mirrors the fetch/header wiring of the auth path, but the token comes from
+ * the caller's `getToken` rather than a Neon Auth session.
+ */
+function buildExternalClient<
+  Database,
+  SchemaName extends string & keyof Database,
+>(
+  dataApiConfig: CreateClientExternalDataApiConfig<SchemaName>
+): NeonPostgrestClient<Database, SchemaName> {
+  const clientInfoHeader = buildNeonJsClientInfo();
+
+  const tokenFetch = fetchWithToken(
+    dataApiConfig.getToken,
+    dataApiConfig.options?.global?.fetch
+  );
+
+  const options: NeonPostgrestClientConstructorOptions<SchemaName>['options'] = {
+    ...dataApiConfig.options,
+    global: {
+      ...dataApiConfig.options?.global,
+      fetch: tokenFetch,
+      headers: {
+        ...dataApiConfig.options?.global?.headers,
+        [X_NEON_CLIENT_INFO_HEADER]: clientInfoHeader,
+      },
+    },
+  };
+
+  return new NeonPostgrestClient<Database, SchemaName>({
+    dataApiUrl: dataApiConfig.url,
+    options,
+  });
 }
 
 /**

--- a/packages/neon-js/src/index.ts
+++ b/packages/neon-js/src/index.ts
@@ -1,6 +1,11 @@
 // Main client factory
 export { createClient } from './client/client-factory';
-export type { CreateClientStringOptions } from './client/client-factory';
+export type {
+  CreateClientStringOptions,
+  CreateClientExternalConfig,
+  CreateClientExternalDataApiConfig,
+  NeonDataApiTokenProvider,
+} from './client/client-factory';
 
 // URL derivation (mostly used by wrappers; end users don't need this)
 export {
@@ -10,6 +15,9 @@ export {
 
 // Re-export utilities from postgrest-js for convenience
 export { fetchWithToken, AuthRequiredError } from '@neondatabase/postgrest-js';
+
+// The external-auth-provider form of createClient returns this type
+export { NeonPostgrestClient } from '@neondatabase/postgrest-js';
 
 // Re-export auth utilities (no React dependency)
 export {


### PR DESCRIPTION
Add a Data-API-only form of `createClient` for apps that authenticate with their own identity provider (Clerk, Auth0, …) instead of Neon Auth. Omit the `auth` block and pass `dataApi.getToken`; the token is attached to every Data API request via `fetchWithToken` and no Neon Auth client is created. This form returns a `NeonPostgrestClient` (no `.auth` property).

Previously every `createClient` overload required an `auth` block and the implementation unconditionally built a Neon Auth client, re-wrapping the caller's fetch with a Neon Auth token — so a bring-your-own-token flow was impossible without dropping down to `@neondatabase/postgrest-js` directly.

New exported types: CreateClientExternalConfig,
CreateClientExternalDataApiConfig, NeonDataApiTokenProvider. NeonPostgrestClient is now re-exported from the package entry.

Adds unit + type tests and updates the CHANGELOG, package README, and CLAUDE.md/AGENTS.md usage docs.