### PR TITLE
ci(e2e): bump delete-branch-action to fix chronic E2E redness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -184,7 +184,7 @@ jobs:
       # Clean up: Delete Neon branch (runs even if tests fail)
       - name: Delete Neon branch
         if: always()
-        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3.2.1
+        uses: neondatabase/delete-branch-action@aed9ab1ec86e380312c7b0a9e29942e41349adf6 # main (neonctl pinned to 2.22.0)
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch: test-${{ matrix.app }}-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
The `Delete Neon branch` teardown has failed on essentially every run for over a month. delete-branch-action@v3.2.1 installs the floating `neonctl@v2`, which now resolves to a version that pulls an unpublished `@neon/config` (npm ETARGET), failing the step — and the job — after the Playwright tests have already passed.

Bump the action pin to its main HEAD (PR #33, supply-chain-hardening), which installs the pinned `neonctl@2.22.0 --ignore-scripts`; its deps resolve cleanly (no `@neon/config`). No other change — the matrix stays parallel and teardown is not masked.

Co-authored-by: Isaac