### PR TITLE
fix(auth): force GET method and undefined body for get-session path in handleAuthRequest (#200)

### DIFF
--- a/packages/auth/src/server/proxy/request.test.ts
+++ b/packages/auth/src/server/proxy/request.test.ts
@@ -31,4 +31,23 @@ describe('handleAuthRequest cookie forwarding', () => {
     const upstreamHeaders = new Headers(requestInit?.headers);
     expect(upstreamHeaders.get('cookie')).toBe(`${legacyCookie}; ${canonicalCookie}`);
   });
+
+  test('forces GET method for get-session path even when caller request method is POST', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const request = new Request('https://app.example.com/api/mutate', {
+      method: 'POST',
+      body: JSON.stringify({ data: 'test' }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    await handleAuthRequest('https://auth.example.com', request, 'get-session');
+
+    const requestInit = fetchSpy.mock.calls[0]?.[1];
+    expect(requestInit?.method).toBe('GET');
+    expect(requestInit?.body).toBeUndefined();
+  });
 });

--- a/packages/auth/src/server/proxy/request.ts
+++ b/packages/auth/src/server/proxy/request.ts
@@ -34,12 +34,14 @@ export const handleAuthRequest = async (
 	log?: ResolvedNeonAuthLogging,
 ) => {
 	const headers = prepareRequestHeaders(request);
-	const body = await parseRequestBody(request);
+	const isGetSession = path === 'get-session';
+	const method = isGetSession ? 'GET' : request.method;
+	const body = isGetSession ? undefined : await parseRequestBody(request);
 
 	try {
 		const upstreamURL = getUpstreamURL(baseUrl, path, { originalUrl: new URL(request.url) });
 		const response = await fetch(upstreamURL.toString(), {
-			method: request.method,
+			method,
 			headers: headers,
 			body: body,
 		});


### PR DESCRIPTION
Fixes #200.

In @neondatabase/auth, when handleAuthRequest proxied requests to the auth server's get-session path, it forwarded request.method verbatim. When state-mutating requests (such as POST, PUT, PATCH, DELETE API calls or Server Actions) were issued on middleware-gated routes by a signed-in user, handleAuthRequest attempted a POST /get-session request to the upstream auth server, which responded with 405 Method Not Allowed. The middleware interpreted the 405 as an absent session and redirected signed-in users to sign-in.

This PR updates handleAuthRequest in packages/auth/src/server/proxy/request.ts to explicitly use GET method and undefined body when path === 'get-session'.