### PR TITLE
fix(auth): skip Set-Cookie write-back in Next.js RSC render phase

### DIFF
--- a/packages/auth/src/next/server/adapter.test.ts
+++ b/packages/auth/src/next/server/adapter.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { SignJWT } from 'jose';
+import { createAuthServer } from '@/server/client-factory';
+import { createNextRequestContext } from './adapter';
+import {
+  NEON_AUTH_SESSION_COOKIE_NAME,
+  NEON_AUTH_SESSION_DATA_COOKIE_NAME,
+} from '@/server/constants';
+import type { RequireSessionData } from '@/server/types';
+import type { BetterAuthSession, BetterAuthUser } from '@/core/better-auth-types';
+
+const TEST_SECRET = 'test-secret-at-least-32-characters-long!';
+const TEST_BASE_URL = 'https://auth.example.com';
+
+class ReadonlyRequestCookiesError extends Error {
+  constructor() {
+    super(
+      'Cookies can only be modified in a Server Action or Route Handler.'
+    );
+    this.name = 'ReadonlyRequestCookiesError';
+  }
+}
+
+const sessionPayload: RequireSessionData = {
+  session: {
+    id: 'session-123',
+    userId: 'user-123',
+    token: 'opaque-token',
+    expiresAt: new Date(Date.now() + 3_600_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ipAddress: '127.0.0.1',
+    userAgent: 'test-agent',
+  } as BetterAuthSession,
+  user: {
+    id: 'user-123',
+    email: 'test@example.com',
+    emailVerified: true,
+    name: 'Test User',
+    image: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as BetterAuthUser,
+};
+
+async function signSessionData(): Promise<string> {
+  const encodedSecret = new TextEncoder().encode(TEST_SECRET);
+  return new SignJWT(sessionPayload)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt()
+    .setExpirationTime(Math.floor(Date.now() / 1000) + 300)
+    .setSubject(sessionPayload.user.id)
+    .sign(encodedSecret);
+}
+
+type CookieStore = {
+  get: (name: string) => { value: string } | undefined;
+  set: ReturnType<typeof vi.fn>;
+};
+
+function createCookieStore(initial: Record<string, string>, mutable: boolean): CookieStore {
+  const jar = new Map(Object.entries(initial));
+  const setImpl = mutable
+    ? vi.fn((name: string, value: string) => {
+        jar.set(name, value);
+      })
+    : vi.fn(() => {
+        throw new ReadonlyRequestCookiesError();
+      });
+
+  return {
+    get: (name: string) => {
+      const value = jar.get(name);
+      return value === undefined ? undefined : { value };
+    },
+    set: setImpl,
+  };
+}
+
+function cookieHeaderFromJar(jar: Record<string, string>): string {
+  return Object.entries(jar)
+    .map(([name, value]) => `${name}=${value}`)
+    .join('; ');
+}
+
+const workUnitStore = { type: 'request' as const, phase: 'render' as 'render' | 'action' };
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+  headers: vi.fn(),
+}));
+
+vi.mock(
+  'next/dist/server/app-render/work-unit-async-storage.external',
+  () => ({
+    workUnitAsyncStorage: {
+      getStore: () => workUnitStore,
+    },
+  })
+);
+
+describe('createNextRequestContext + getSession cookie mutation contexts', () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let cookieStore: CookieStore;
+
+  beforeEach(async () => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    workUnitStore.phase = 'render';
+
+    const { cookies, headers } = await import('next/headers');
+    cookieStore = createCookieStore({}, false);
+    vi.mocked(cookies).mockResolvedValue(cookieStore as never);
+    vi.mocked(headers).mockReturnValue(
+      new Headers({
+        cookie: '',
+        origin: 'https://app.example.com',
+      }) as never
+    );
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  function makeServer() {
+    return createAuthServer({
+      baseUrl: TEST_BASE_URL,
+      context: createNextRequestContext,
+      cookieSecret: TEST_SECRET,
+    });
+  }
+
+  test('A: RSC render phase with valid session_data cache succeeds without cookie writes', async () => {
+    const sessionData = await signSessionData();
+    const jar = {
+      [NEON_AUTH_SESSION_COOKIE_NAME]: 'session-token-value',
+      [NEON_AUTH_SESSION_DATA_COOKIE_NAME]: sessionData,
+    };
+    cookieStore = createCookieStore(jar, false);
+    const { cookies, headers } = await import('next/headers');
+    vi.mocked(cookies).mockResolvedValue(cookieStore as never);
+    vi.mocked(headers).mockReturnValue(
+      new Headers({
+        cookie: cookieHeaderFromJar(jar),
+        origin: 'https://app.example.com',
+      }) as never
+    );
+
+    const server = makeServer();
+    const result = await server.getSession();
+
+    expect(result.error).toBeNull();
+    expect(result.data?.user?.email).toBe('test@example.com');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(cookieStore.set).not.toHaveBeenCalled();
+  });
+
+  test('B: RSC render phase with expired session_data returns session without illegal cookie writes', async () => {
+    const jar = {
+      [NEON_AUTH_SESSION_COOKIE_NAME]: 'session-token-value',
+    };
+    cookieStore = createCookieStore(jar, false);
+    const { cookies, headers } = await import('next/headers');
+    vi.mocked(cookies).mockResolvedValue(cookieStore as never);
+    vi.mocked(headers).mockReturnValue(
+      new Headers({
+        cookie: cookieHeaderFromJar(jar),
+        origin: 'https://app.example.com',
+      }) as never
+    );
+
+    fetchMock.mockResolvedValueOnce(
+      Response.json(sessionPayload, {
+        status: 200,
+        headers: {
+          'Set-Cookie': `${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=refreshed; Path=/; HttpOnly; Secure; SameSite=Lax`,
+        },
+      })
+    );
+
+    const server = makeServer();
+    const result = await server.getSession();
+
+    expect(result.error).toBeNull();
+    expect(result.data?.user?.email).toBe('test@example.com');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(cookieStore.set).not.toHaveBeenCalled();
+  });
+
+  test('C: route handler / server action phase still persists refreshed cookies', async () => {
+    workUnitStore.phase = 'action';
+
+    const jar = {
+      [NEON_AUTH_SESSION_COOKIE_NAME]: 'session-token-value',
+    };
+    cookieStore = createCookieStore(jar, true);
+    const { cookies, headers } = await import('next/headers');
+    vi.mocked(cookies).mockResolvedValue(cookieStore as never);
+    vi.mocked(headers).mockReturnValue(
+      new Headers({
+        cookie: cookieHeaderFromJar(jar),
+        origin: 'https://app.example.com',
+      }) as never
+    );
+
+    fetchMock.mockResolvedValueOnce(
+      Response.json(sessionPayload, {
+        status: 200,
+        headers: {
+          'Set-Cookie': `${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=refreshed; Path=/; HttpOnly; Secure; SameSite=Lax`,
+        },
+      })
+    );
+
+    const server = makeServer();
+    const result = await server.getSession();
+
+    expect(result.error).toBeNull();
+    expect(result.data?.user?.email).toBe('test@example.com');
+    expect(cookieStore.set).toHaveBeenCalled();
+  });
+
+  test('RSC slow path with multiple upstream Set-Cookie headers skips all writes', async () => {
+    const jar = {
+      [NEON_AUTH_SESSION_COOKIE_NAME]: 'session-token-value',
+    };
+    cookieStore = createCookieStore(jar, false);
+    const { cookies, headers } = await import('next/headers');
+    vi.mocked(cookies).mockResolvedValue(cookieStore as never);
+    vi.mocked(headers).mockReturnValue(
+      new Headers({
+        cookie: cookieHeaderFromJar(jar),
+        origin: 'https://app.example.com',
+      }) as never
+    );
+
+    const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
+    responseHeaders.append(
+      'Set-Cookie',
+      `${NEON_AUTH_SESSION_COOKIE_NAME}=rotated; Path=/; HttpOnly; Secure; SameSite=Lax`
+    );
+    responseHeaders.append(
+      'Set-Cookie',
+      `${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=refreshed; Path=/; HttpOnly; Secure; SameSite=Lax`
+    );
+
+    fetchMock.mockResolvedValueOnce(
+      Response.json(sessionPayload, {
+        status: 200,
+        headers: responseHeaders,
+      })
+    );
+
+    const server = makeServer();
+    const result = await server.getSession();
+
+    expect(result.error).toBeNull();
+    expect(cookieStore.set).not.toHaveBeenCalled();
+  });
+
+  test('RSC with no session cookies returns unauthenticated without cookie writes', async () => {
+    cookieStore = createCookieStore({}, false);
+    const { cookies, headers } = await import('next/headers');
+    vi.mocked(cookies).mockResolvedValue(cookieStore as never);
+    vi.mocked(headers).mockReturnValue(
+      new Headers({
+        cookie: '',
+        origin: 'https://app.example.com',
+      }) as never
+    );
+
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ session: null, user: null }, { status: 200 })
+    );
+
+    const server = makeServer();
+    const result = await server.getSession();
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ session: null, user: null });
+    expect(cookieStore.set).not.toHaveBeenCalled();
+  });
+
+  test('disableCookieCache bypasses local cache and still avoids illegal writes in RSC', async () => {
+    const sessionData = await signSessionData();
+    const jar = {
+      [NEON_AUTH_SESSION_COOKIE_NAME]: 'session-token-value',
+      [NEON_AUTH_SESSION_DATA_COOKIE_NAME]: sessionData,
+    };
+    cookieStore = createCookieStore(jar, false);
+    const { cookies, headers } = await import('next/headers');
+    vi.mocked(cookies).mockResolvedValue(cookieStore as never);
+    vi.mocked(headers).mockReturnValue(
+      new Headers({
+        cookie: cookieHeaderFromJar(jar),
+        origin: 'https://app.example.com',
+      }) as never
+    );
+
+    fetchMock.mockResolvedValueOnce(
+      Response.json(sessionPayload, {
+        status: 200,
+        headers: {
+          'Set-Cookie': `${NEON_AUTH_SESSION_DATA_COOKIE_NAME}=refreshed; Path=/; HttpOnly; Secure; SameSite=Lax`,
+        },
+      })
+    );
+
+    const server = makeServer();
+    const result = await server.getSession({
+      query: { disableCookieCache: 'true' },
+    });
+
+    expect(result.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(cookieStore.set).not.toHaveBeenCalled();
+  });
+});

--- a/packages/auth/src/next/server/adapter.ts
+++ b/packages/auth/src/next/server/adapter.ts
@@ -1,4 +1,6 @@
 import { cookies, headers } from 'next/headers';
+import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external';
+import { areCookiesMutableInCurrentPhase } from 'next/dist/server/web/spec-extension/adapters/request-cookies';
 import type { RequestContext } from '../../server';
 import { extractNeonAuthCookies } from '../../server/utils/cookies';
 
@@ -17,6 +19,14 @@ export async function createNextRequestContext(): Promise<RequestContext> {
 
     setCookie(name, value, options) {
       cookieStore.set(name, value, options);
+    },
+
+    canSetCookies() {
+      const store = workUnitAsyncStorage.getStore();
+      if (!store || store.type !== 'request') {
+        return false;
+      }
+      return areCookiesMutableInCurrentPhase(store);
     },
 
     getHeader(name) {

--- a/packages/auth/src/server/client-factory.test.ts
+++ b/packages/auth/src/server/client-factory.test.ts
@@ -391,4 +391,65 @@ describe('createAuthServer cookie forwarding (Secure forcing)', () => {
     const options = setCookieSpy.mock.calls[0][2];
     expect(options).toMatchObject({ secure: true, sameSite: 'none' });
   });
+
+  test('skips setCookie when RequestContext.canSetCookies returns false', async () => {
+    const setCookieSpy = vi.fn();
+    const context: RequestContext = {
+      getCookies: () => '',
+      setCookie: setCookieSpy,
+      canSetCookies: () => false,
+      getHeader: () => null,
+      getOrigin: () => 'https://app.example.com',
+      getFramework: () => 'test',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      upstreamWithSetCookie(
+        '__Secure-neon-auth.example_cookie=abc; Path=/; HttpOnly; SameSite=Lax'
+      )
+    );
+
+    const server = createAuthServer({
+      baseUrl: TEST_BASE_URL,
+      context: () => context,
+      cookieSecret: TEST_SECRET,
+    });
+
+    const result = await (server as unknown as {
+      getSession: () => Promise<{ data: unknown; error: null }>;
+    }).getSession();
+
+    expect(result.error).toBeNull();
+    expect(setCookieSpy).not.toHaveBeenCalled();
+  });
+
+  test('still calls setCookie when RequestContext.canSetCookies returns true', async () => {
+    const setCookieSpy = vi.fn();
+    const context: RequestContext = {
+      getCookies: () => '',
+      setCookie: setCookieSpy,
+      canSetCookies: () => true,
+      getHeader: () => null,
+      getOrigin: () => 'https://app.example.com',
+      getFramework: () => 'test',
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      upstreamWithSetCookie(
+        '__Secure-neon-auth.example_cookie=abc; Path=/; HttpOnly; SameSite=Lax'
+      )
+    );
+
+    const server = createAuthServer({
+      baseUrl: TEST_BASE_URL,
+      context: () => context,
+      cookieSecret: TEST_SECRET,
+    });
+
+    await (server as unknown as {
+      getSession: () => Promise<unknown>;
+    }).getSession();
+
+    expect(setCookieSpy).toHaveBeenCalled();
+  });
 });

--- a/packages/auth/src/server/client-factory.ts
+++ b/packages/auth/src/server/client-factory.ts
@@ -2,6 +2,7 @@ import type { NeonAuthServer } from './types';
 import type { SessionCookieSameSite } from './config';
 import {
   NEON_AUTH_SERVER_PROXY_HEADER,
+  type RequestContext,
   type RequestContextFactory,
 } from './request-context';
 import {
@@ -137,6 +138,15 @@ export function createAuthServer(
 
   const effectiveSameSite = sameSite ?? 'lax';
 
+  async function shouldPersistResponseCookies(
+    ctx: RequestContext
+  ): Promise<boolean> {
+    if (!ctx.canSetCookies) {
+      return true;
+    }
+    return await ctx.canSetCookies();
+  }
+
   const fetchWithAuth = async (
     path: string,
     method: 'GET' | 'POST',
@@ -236,63 +246,74 @@ export function createAuthServer(
       });
     }
 
-    // Handle response cookies 
     const setCookieHeaders = response.headers.getSetCookie();
+    const canPersistCookies = await shouldPersistResponseCookies(ctx);
     if (setCookieHeaders.length > 0) {
-      for (const setCookieHeader of setCookieHeaders) {
-        const parsedCookies = parseSetCookies(setCookieHeader);
-        for (const cookie of parsedCookies) {
-          // Mirror sanitization from prepareResponseHeaders (response.ts):
-          // strip Partitioned and apply configured SameSite (default `lax`).
-          // Always override domain: use local config if set, otherwise strip any
-          // upstream Domain attribute to avoid leaking the auth server's domain.
-          // Always force Secure to match the minting path
-          // (`session/minting.ts` hardcodes `secure: true`) and the documented
-          // "Secure is always applied" contract. With `SameSite=None`, a
-          // missing `Secure` makes the browser drop the cookie entirely.
-          // See #161 review feedback (Andras FIX 1, security).
-          const cookieOptions = {
-            ...cookie,
-            domain: domain,
-            partitioned: undefined,
-            sameSite: effectiveSameSite,
-            secure: true,
-          };
-          await ctx.setCookie(cookie.name, cookie.value, cookieOptions);
-        }
-      }
-
-      // Mint session data cookie if session_token was set
-      try {
-        const sessionDataCookie = await mintSessionDataFromResponse(
-          response.headers,
-          baseUrl,
-          {
-            secret: cookieSecret,
-            sessionDataTtl,
-            domain,
-            sameSite,
-          },
-          log
-        );
-
-        if (sessionDataCookie) {
-          // Parse the Set-Cookie string to extract cookie details
-          const [parsedSessionData] = parseSetCookies(sessionDataCookie);
-          if (parsedSessionData) {
-            await ctx.setCookie(
-              parsedSessionData.name,
-              parsedSessionData.value,
-              parsedSessionData
-            );
+      if (canPersistCookies) {
+        for (const setCookieHeader of setCookieHeaders) {
+          const parsedCookies = parseSetCookies(setCookieHeader);
+          for (const cookie of parsedCookies) {
+            // Mirror sanitization from prepareResponseHeaders (response.ts):
+            // strip Partitioned and apply configured SameSite (default `lax`).
+            // Always override domain: use local config if set, otherwise strip any
+            // upstream Domain attribute to avoid leaking the auth server's domain.
+            // Always force Secure to match the minting path
+            // (`session/minting.ts` hardcodes `secure: true`) and the documented
+            // "Secure is always applied" contract. With `SameSite=None`, a
+            // missing `Secure` makes the browser drop the cookie entirely.
+            // See #161 review feedback (Andras FIX 1, security).
+            const cookieOptions = {
+              ...cookie,
+              domain: domain,
+              partitioned: undefined,
+              sameSite: effectiveSameSite,
+              secure: true,
+            };
+            await ctx.setCookie(cookie.name, cookie.value, cookieOptions);
           }
         }
-      } catch (error) {
-        log?.warn('[neon-auth] Failed to mint session data cookie', {
-          component: 'server-api',
-          detail: error instanceof Error ? error.message : String(error),
-          err: error,
-        });
+
+        // Mint session data cookie if session_token was set
+        try {
+          const sessionDataCookie = await mintSessionDataFromResponse(
+            response.headers,
+            baseUrl,
+            {
+              secret: cookieSecret,
+              sessionDataTtl,
+              domain,
+              sameSite,
+            },
+            log
+          );
+
+          if (sessionDataCookie) {
+            // Parse the Set-Cookie string to extract cookie details
+            const [parsedSessionData] = parseSetCookies(sessionDataCookie);
+            if (parsedSessionData) {
+              await ctx.setCookie(
+                parsedSessionData.name,
+                parsedSessionData.value,
+                parsedSessionData
+              );
+            }
+          }
+        } catch (error) {
+          log?.warn('[neon-auth] Failed to mint session data cookie', {
+            component: 'server-api',
+            detail: error instanceof Error ? error.message : String(error),
+            err: error,
+          });
+        }
+      } else {
+        log?.debug(
+          '[neon-auth] Skipping upstream Set-Cookie write-back in read-only context',
+          {
+            component: 'server-api',
+            path: url.pathname,
+            cookieCount: setCookieHeaders.length,
+          }
+        );
       }
     }
 

--- a/packages/auth/src/server/public-surface-types.test.ts
+++ b/packages/auth/src/server/public-surface-types.test.ts
@@ -117,12 +117,19 @@ describe('NeonAuthServerConfig shape', () => {
 });
 
 describe('RequestContext shape', () => {
-  it('exposes the five framework-bridging methods adapters must implement', () => {
+  it('exposes the framework-bridging methods adapters must implement', () => {
     expectTypeOf<RequestContext['getCookies']>().toBeFunction();
     expectTypeOf<RequestContext['setCookie']>().toBeFunction();
     expectTypeOf<RequestContext['getHeader']>().toBeFunction();
     expectTypeOf<RequestContext['getOrigin']>().toBeFunction();
     expectTypeOf<RequestContext['getFramework']>().toBeFunction();
+  });
+
+  it('allows optional canSetCookies for read-only render contexts', () => {
+    type CanSetCookies = RequestContext['canSetCookies'];
+    expectTypeOf<CanSetCookies>().toEqualTypeOf<
+      (() => boolean | Promise<boolean>) | undefined
+    >();
   });
 
   it('setCookie requires (name, value, options) — options is not optional', () => {

--- a/packages/auth/src/server/request-context.ts
+++ b/packages/auth/src/server/request-context.ts
@@ -87,6 +87,21 @@ export interface RequestContext {
   ): Promise<void> | void;
 
   /**
+   * Whether the current execution context allows persisting upstream
+   * `Set-Cookie` headers via {@link setCookie}.
+   *
+   * When this returns `false`, the toolkit still returns upstream response
+   * data (e.g. a refreshed session payload from `getSession()`) but skips
+   * cookie write-back. Adapters for frameworks that forbid cookie mutation
+   * during certain phases (e.g. Next.js React Server Component render)
+   * should implement this explicitly.
+   *
+   * When omitted, the toolkit assumes cookie writes are always permitted
+   * (backward-compatible default for adapters that can mutate on every call).
+   */
+  canSetCookies?(): Promise<boolean> | boolean;
+
+  /**
    * Read a single request header by name. Names are case-insensitive per
    * the HTTP spec; implementations MUST normalize lookups (or rely on
    * a framework API that already does).


### PR DESCRIPTION
## Summary
- Fixes #196: `auth.getSession()` slow path no longer calls `cookies().set()` during React Server Component render.
- Adds optional `RequestContext.canSetCookies` so the server toolkit can return refreshed session data while skipping cookie write-back in read-only contexts.
- Next.js adapter implements `canSetCookies` via `areCookiesMutableInCurrentPhase` (writes still allowed in Route Handlers and Server Actions).

## Root cause
When `session_data` is missing or expired, `getSession()` fetches upstream `get-session`, receives `Set-Cookie`, and `fetchWithAuth` unconditionally forwarded them through `ctx.setCookie()` → `cookies().set()`. Next.js forbids that during RSC render.

## Test plan
- [x] `cd packages/auth && node --run test:ci` (249 tests, including new `adapter.test.ts`)
- [x] RED reproduced on `upstream/main` before fix (test B throws `ReadonlyRequestCookiesError`)
- [x] `node --run lint` in `packages/auth`
- [x] RSC fast path (valid cache): no cookie writes
- [x] RSC slow path (expired/missing cache): session returned, no illegal writes
- [x] Route Handler / Server Action phase: cookie writes preserved
