### PR TITLE
fix(auth): use declared upstream method in auth proxy, not the incoming request’s

### DIFF
--- a/packages/auth/src/server/proxy/request.test.ts
+++ b/packages/auth/src/server/proxy/request.test.ts
@@ -32,3 +32,57 @@ describe('handleAuthRequest cookie forwarding', () => {
     expect(upstreamHeaders.get('cookie')).toBe(`${legacyCookie}; ${canonicalCookie}`);
   });
 });
+
+describe('handleAuthRequest upstream method (issue #204)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('proxies a POST to the get-session path upstream as GET', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const request = new Request('https://app.example.com/api/auth/get-session', {
+      method: 'POST',
+      body: JSON.stringify({ mutation: true }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await handleAuthRequest('https://auth.example.com', request, 'get-session');
+
+    const requestInit = fetchSpy.mock.calls[0]?.[1];
+    expect(requestInit?.method).toBe('GET');
+    expect(requestInit?.body).toBeUndefined();
+  });
+
+  test('keeps the incoming method for POST-declared endpoints', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const request = new Request('https://app.example.com/api/auth/sign-in/email', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'a@b.co' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await handleAuthRequest('https://auth.example.com', request, 'sign-in/email');
+
+    const requestInit = fetchSpy.mock.calls[0]?.[1];
+    expect(requestInit?.method).toBe('POST');
+    expect(requestInit?.body).not.toBeUndefined();
+  });
+
+  test('falls back to the incoming method for unknown paths', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const request = new Request('https://app.example.com/api/auth/some-extension', {
+      method: 'DELETE',
+    });
+
+    await handleAuthRequest('https://auth.example.com', request, 'some-extension');
+
+    const requestInit = fetchSpy.mock.calls[0]?.[1];
+    expect(requestInit?.method).toBe('DELETE');
+  });
+});

--- a/packages/auth/src/server/proxy/request.ts
+++ b/packages/auth/src/server/proxy/request.ts
@@ -1,3 +1,5 @@
+import { API_ENDPOINTS } from '@/server/endpoints';
+import type { EndpointConfig, EndpointTree } from '@/server/endpoints';
 import { extractNeonAuthCookies } from "@/server/utils/cookies";
 import type { ResolvedNeonAuthLogging } from '@/server/logger';
 import { classifyFetchFailure } from '@/server/network-error';
@@ -27,6 +29,27 @@ function safeAuthHost(baseUrl: string): string | undefined {
  * @param log - Optional resolved logging sink
  * @returns Response from upstream server or error response
  */
+// Reverse lookup from API_ENDPOINTS: upstream path -> declared method.
+// Auth endpoints have fixed methods (e.g. get-session is GET-only upstream),
+// so the incoming request's method must not be forwarded blindly - a POST to a
+// protected route would otherwise hit get-session as POST and 404, signing the
+// user out (see issue #204).
+const METHOD_BY_PATH: Record<string, EndpointConfig['method']> = (() => {
+	const map: Record<string, EndpointConfig['method']> = {};
+	const walk = (tree: EndpointTree) => {
+		for (const value of Object.values(tree)) {
+			if (typeof (value as EndpointConfig).path === 'string') {
+				const config = value as EndpointConfig;
+				map[config.path] = config.method;
+			} else {
+				walk(value as EndpointTree);
+			}
+		}
+	};
+	walk(API_ENDPOINTS as EndpointTree);
+	return map;
+})();
+
 export const handleAuthRequest = async (
 	baseUrl: string,
 	request: Request,
@@ -34,12 +57,15 @@ export const handleAuthRequest = async (
 	log?: ResolvedNeonAuthLogging,
 ) => {
 	const headers = prepareRequestHeaders(request);
-	const body = await parseRequestBody(request);
+	const upstreamMethod = METHOD_BY_PATH[path] ?? request.method;
+	// GET/HEAD upstream calls cannot carry a body; only parse one when the
+	// upstream method allows it.
+	const body = upstreamMethod === 'GET' ? undefined : await parseRequestBody(request);
 
 	try {
 		const upstreamURL = getUpstreamURL(baseUrl, path, { originalUrl: new URL(request.url) });
 		const response = await fetch(upstreamURL.toString(), {
-			method: request.method,
+			method: upstreamMethod,
 			headers: headers,
 			body: body,
 		});


### PR DESCRIPTION
Fixes #204

## Problem

`handleAuthRequest` (`packages/auth/src/server/proxy/request.ts`) forwarded the incoming request's method verbatim. A POST to a protected route hit the GET-only `get-session` endpoint as POST; Better Auth 404'd, the middleware read that as no session, and every mutation failed for signed-in users.

## Fix

Reverse-lookup the DECLARED upstream method from the repo's own `API_ENDPOINTS` registry (`endpoints.ts`) instead of trusting the incoming method, drop the body on GET upstream calls, and fall back to the incoming method for unknown paths. Covers all five GET-only endpoints (`get-session`, `get-access-token`, `list-sessions`, `list-accounts`, `account-info`) - the same latent bug existed on each.

## Verification

- Regression tests: POST-to-get-session now goes upstream as GET; POST endpoints keep their method; unknown paths fall back.
- `vitest run src/server/proxy/`: 37/37 green; the new regression test fails against unpatched main (red-green verified).

> Built by breken, your AI support engineer - breken.ai - this one's on us.
